### PR TITLE
Fix: always use wide layout on desktop platforms

### DIFF
--- a/ui/src/lib/stores/screen.svelte.ts
+++ b/ui/src/lib/stores/screen.svelte.ts
@@ -1,13 +1,17 @@
+import { isMobile } from '$lib/utils/environment';
+
 const mediaQuery =
 	typeof window !== 'undefined'
 		? window.matchMedia('(min-width: 768px) and (min-height: 500px)')
 		: undefined;
 
-let wide = $state(mediaQuery?.matches ?? false);
+let wide = $state(isMobile ? (mediaQuery?.matches ?? false) : true);
 
-mediaQuery?.addEventListener('change', (e) => {
-	wide = e.matches;
-});
+if (isMobile) {
+	mediaQuery?.addEventListener('change', (e) => {
+		wide = e.matches;
+	});
+}
 
 if (typeof window !== 'undefined') {
 	window.addEventListener('set-wide-screen', ((e: CustomEvent<boolean>) => {


### PR DESCRIPTION
## Summary
- On desktop platforms (Linux/macOS/Windows), always use the wide two-panel layout regardless of window size
- On mobile platforms (Android/iOS), preserve the media query check so tablets get the wide layout while phones get the mobile layout
- The `set-wide-screen` custom event (used by the preview toolbar) still works on all platforms

Closes #130

## Test plan
- [ ] Desktop: resize window below 768px — should keep the two-panel desktop layout
- [ ] Android phone: should show mobile layout
- [ ] Android tablet: should show wide layout when screen width ≥ 768px
- [ ] iOS phone: should show mobile layout
- [ ] iOS tablet: should show wide layout when screen width ≥ 768px
- [ ] Preview toolbar toggle still switches between layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)