### PR TITLE
Add Get Started cards with Signal-matched styling (#133)

### DIFF
--- a/e2e-tests/helpers/setup-agents.ts
+++ b/e2e-tests/helpers/setup-agents.ts
@@ -106,6 +106,16 @@ export async function sendAndReceiveMessage(
 	await waitForMessage(receiver, text);
 }
 
+/** Get IDs of currently visible Get Started cards. */
+export async function getStartedCards(agent: WebdriverIO.Browser): Promise<string[]> {
+	return await agent.execute(() => window.__test.getStartedCards()) as string[];
+}
+
+/** Dismiss a Get Started card by id. */
+export async function dismissGetStartedCard(agent: WebdriverIO.Browser, cardId: string): Promise<void> {
+	await agent.execute((id: string) => window.__test.dismissGetStartedCard(id), cardId);
+}
+
 /** Open a direct chat by contact name. Throws if it fails. */
 export async function openDirectChat(
 	agent: WebdriverIO.Browser,

--- a/e2e-tests/specs/full-flow.spec.ts
+++ b/e2e-tests/specs/full-flow.spec.ts
@@ -8,6 +8,9 @@
 import {
 	waitForBothAgents,
 	createProfile,
+	getStartedCards,
+	dismissGetStartedCard,
+	waitForTestUtils,
 	exchangeContacts,
 	sendMessage,
 	waitForMessage,
@@ -23,6 +26,45 @@ describe('Full messaging flow', () => {
 		const agent2 = browser.getInstance('agent2');
 		await createProfile(agent1, 'Alice', 'Test');
 		await createProfile(agent2, 'Bob', 'Test');
+	});
+
+	it('shows Get Started cards on empty home', async () => {
+		const agent1 = browser.getInstance('agent1');
+
+		await agent1.waitUntil(
+			async () => (await getStartedCards(agent1)).length > 0,
+			{ timeout: 10_000, timeoutMsg: 'No Get Started cards visible' },
+		);
+
+		const cards = await getStartedCards(agent1);
+		expect(cards).toContain('add-contact');
+		expect(cards).toContain('add-photo');
+		expect(cards).toContain('chat-color');
+	});
+
+	it('dismisses a Get Started card and it persists after reload', async () => {
+		const agent1 = browser.getInstance('agent1');
+
+		await dismissGetStartedCard(agent1, 'add-contact');
+
+		await agent1.waitUntil(
+			async () => !(await getStartedCards(agent1)).includes('add-contact'),
+			{ timeout: 5_000, timeoutMsg: 'Add contact card still visible after dismiss' },
+		);
+
+		// Reload and verify dismissal persists
+		await agent1.execute(() => window.location.reload());
+		await waitForTestUtils(agent1);
+		await agent1.waitUntil(
+			async () => agent1.execute(() =>
+				!!document.querySelector('[data-testid="all-chats-list"], [data-testid="all-chats-empty"]'),
+			),
+			{ timeout: 10_000, timeoutMsg: 'Home page not loaded after reload' },
+		);
+
+		const cards = await getStartedCards(agent1);
+		expect(cards).not.toContain('add-contact');
+		expect(cards).toContain('add-photo');
 	});
 
 	it('exchanges contact codes between agents', async () => {

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -42,6 +42,8 @@
 	"aboutTakingABreak": "Taking a break",
 
 	"addContact": "Add contact",
+	"addPhoto": "Add photo",
+	"chatColor": "Chat color",
 	"qrCodeOrLink": "QR code or link",
 	"qrCodeExplanation": "Your QR code is not visible on your profile. Share it only with people you trust.",
 	"contacts": "Contacts",

--- a/ui/src/lib/components/GetStarted.svelte
+++ b/ui/src/lib/components/GetStarted.svelte
@@ -2,18 +2,54 @@
 	import '@awesome.me/webawesome/dist/components/icon/icon.js';
 	import { m } from '$lib/paraglide/messages.js';
 	import { wrapPathInSvg } from '$lib/utils/icon';
-	import { mdiAccountMultiplePlus, mdiAccountPlus, mdiClose } from '@mdi/js';
+	import {
+		mdiAccountMultiplePlus,
+		mdiAccountPlus,
+		mdiCamera,
+		mdiClose,
+		mdiPalette,
+	} from '@mdi/js';
+	import type { ContactsStore } from 'dash-chat-stores';
+	import { getContext } from 'svelte';
+	import { useReactivePromise } from '$lib/stores/use-signal';
+	import { useTheme } from 'konsta/svelte';
+
+	type CardColor = 'warm' | 'sage';
 
 	interface Card {
 		id: string;
 		label: () => string;
 		icon: string;
 		href: string;
-		color: string;
+		tone: CardColor;
 		hidden?: boolean;
 	}
 
+	const theme = $derived(useTheme());
+
+	// Pixel-exact colors extracted from Signal screenshots
+	const colors: Record<string, Record<CardColor, string>> = {
+		ios: { warm: 'bg-[#F6F2E9]', sage: 'bg-[#E9ECE4]' },
+		material: { warm: 'bg-[#F5ECDF]', sage: 'bg-[#DDE4D5]' },
+	};
+	const darkColors: Record<CardColor, string> = {
+		warm: 'dark:bg-amber-900/20',
+		sage: 'dark:bg-[#2A2E20]/20',
+	};
+
 	const DISMISSED_KEY = 'get-started-dismissed';
+
+	let { visible = $bindable(true) }: { visible?: boolean } = $props();
+
+	const contactsStore: ContactsStore = getContext('contacts-store');
+	const myProfile = useReactivePromise(contactsStore.myProfile);
+	let hasAvatar = $state(false);
+	$effect(() => {
+		const p = $myProfile;
+		p.then((profile) => {
+			hasAvatar = !!profile?.avatar;
+		});
+	});
 
 	const allCards: Card[] = [
 		{
@@ -21,17 +57,42 @@
 			label: () => m.addContact(),
 			icon: mdiAccountPlus,
 			href: '/new-message/add-contact',
-			color: 'bg-amber-100 dark:bg-amber-900/30',
+			tone: 'warm',
+		},
+		{
+			id: 'add-photo',
+			label: () => m.addPhoto(),
+			icon: mdiCamera,
+			href: '/settings/profile/edit-photo',
+			tone: 'sage',
+		},
+		{
+			id: 'chat-color',
+			label: () => m.chatColor(),
+			icon: mdiPalette,
+			href: '/settings/appearance',
+			tone: 'warm',
 		},
 		{
 			id: 'new-group',
 			label: () => m.newGroup(),
 			icon: mdiAccountMultiplePlus,
 			href: '/new-group',
-			color: 'bg-green-100 dark:bg-green-900/30',
+			tone: 'sage',
 			hidden: true,
 		},
 	];
+
+	function cardClasses(tone: CardColor): string {
+		const isIos = theme === 'ios';
+		const t = isIos ? 'ios' : 'material';
+		const bg = `${colors[t][tone]} ${darkColors[tone]}`;
+		// iOS Signal cards have a subtle shadow + thin white border; Material has neither
+		const border = isIos
+			? 'shadow-[0_1px_4px_rgba(0,0,0,0.06)] border border-white/50 dark:border-white/10'
+			: '';
+		return `${bg} ${border}`;
+	}
 
 	function getDismissed(): string[] {
 		try {
@@ -43,8 +104,14 @@
 
 	let dismissed = $state(getDismissed());
 
-	let visibleCards = $derived(allCards.filter((c) => !c.hidden && !dismissed.includes(c.id)));
-	let { visible = $bindable(true) }: { visible?: boolean } = $props();
+	let visibleCards = $derived(
+		allCards.filter((c) => {
+			if (c.hidden) return false;
+			if (dismissed.includes(c.id)) return false;
+			if (c.id === 'add-photo' && hasAvatar) return false;
+			return true;
+		}),
+	);
 	$effect(() => {
 		visible = visibleCards.length > 0;
 	});
@@ -61,26 +128,29 @@
 
 {#if visibleCards.length > 0}
 	<div class="px-4 pb-4">
-		<p class="mb-2 text-base font-medium">{m.getStarted()}</p>
-		<div class="flex gap-3 overflow-x-auto">
+		<p class="mb-3 text-lg font-bold">{m.getStarted()}</p>
+		<div class="flex gap-3.5 overflow-x-auto pb-1">
 			{#each visibleCards as card}
-				<a
-					href={card.href}
-					class="relative flex w-44 flex-col items-center rounded-2xl px-6 py-5 {card.color}"
+				<div
+					class="relative w-[165px] shrink-0 rounded-[20px] {cardClasses(card.tone)}"
+					data-testid="get-started-{card.id}"
 				>
-					<button
-						class="absolute right-2 top-2 p-1 opacity-40"
-						onclick={(e) => {
-							e.preventDefault();
-							dismiss(card.id);
-						}}
+					<a
+						href={card.href}
+						class="flex flex-col items-center px-5 pb-5 pt-7"
 					>
-						<wa-icon src={wrapPathInSvg(mdiClose)} style="font-size: 18px"></wa-icon>
+						<wa-icon src={wrapPathInSvg(card.icon)} style="font-size: 28px">
+						</wa-icon>
+						<span class="mt-2 text-center text-sm font-semibold">{card.label()}</span>
+					</a>
+					<button
+						class="absolute right-2 top-2 z-10 p-1 text-black/40 dark:text-white/40"
+						data-testid="get-started-dismiss-{card.id}"
+						onclick={() => dismiss(card.id)}
+					>
+						<wa-icon src={wrapPathInSvg(mdiClose)} style="font-size: 20px"></wa-icon>
 					</button>
-					<wa-icon src={wrapPathInSvg(card.icon)} style="font-size: 28px; opacity: 0.6">
-					</wa-icon>
-					<span class="mt-2 text-sm">{card.label()}</span>
-				</a>
+				</div>
 			{/each}
 		</div>
 	</div>

--- a/ui/src/lib/components/preview/PreviewToolbar.svelte
+++ b/ui/src/lib/components/preview/PreviewToolbar.svelte
@@ -32,6 +32,12 @@
 		localStorage.clear();
 		window.location.reload();
 	}
+
+	function removeAllData() {
+		localStorage.clear();
+		localStorage.setItem('__preview_seeded', 'true');
+		window.location.reload();
+	}
 </script>
 
 <div class="preview-float">
@@ -54,6 +60,9 @@
 			</button>
 			<button class="preview-btn preview-btn-reset" onclick={resetData}>
 				Reset
+			</button>
+			<button class="preview-btn preview-btn-danger" onclick={removeAllData}>
+				Wipe
 			</button>
 		</div>
 	{/if}
@@ -119,5 +128,12 @@
 	}
 	.preview-btn-reset:hover {
 		background: #6a3030;
+	}
+	.preview-btn-danger {
+		background: #6a2020;
+		border-color: #8a3030;
+	}
+	.preview-btn-danger:hover {
+		background: #8a3030;
 	}
 </style>

--- a/ui/tests/pages/get-started.ts
+++ b/ui/tests/pages/get-started.ts
@@ -1,0 +1,16 @@
+import { S } from '../selectors';
+import { click } from '../helpers';
+
+export const selectors = S.getStarted;
+
+const cardIds = ['add-contact', 'add-photo', 'chat-color', 'new-group'] as const;
+
+/** Return IDs of currently visible Get Started cards. */
+export function visibleCards(): string[] {
+	return cardIds.filter((id) => document.querySelector(`[data-testid="get-started-${id}"]`));
+}
+
+/** Dismiss a Get Started card by its id (e.g. 'add-contact'). */
+export function dismissCard(cardId: string): void {
+	click(S.getStarted.dismiss(cardId));
+}

--- a/ui/tests/selectors.ts
+++ b/ui/tests/selectors.ts
@@ -8,6 +8,13 @@ export const S = {
 		chatList: tid('all-chats-list'),
 		emptyState: tid('all-chats-empty'),
 	},
+	getStarted: {
+		addContact: tid('get-started-add-contact'),
+		addPhoto: tid('get-started-add-photo'),
+		chatColor: tid('get-started-chat-color'),
+		newGroup: tid('get-started-new-group'),
+		dismiss: (id: string) => tid(`get-started-dismiss-${id}`),
+	},
 	createProfile: {
 		nameInput: tid('create-profile-name'),
 		surnameInput: tid('create-profile-surname'),

--- a/ui/tests/setup-utils.ts
+++ b/ui/tests/setup-utils.ts
@@ -16,6 +16,7 @@ import { createProfile } from './flows/profile-creation';
 import { navigateToAddContact, getContactCode, addContact } from './flows/contact-exchange';
 import { sendMessage, waitForMessage } from './flows/send-message';
 import { openDirectChat } from './flows/open-chat';
+import { visibleCards as getStartedCards, dismissCard as dismissGetStartedCard } from './pages/get-started';
 import { checkOverflow, checkDarkMode, checkRTL, checkPage } from './review/checks';
 import {
 	visitAllPages,
@@ -43,6 +44,8 @@ export const testUtils = {
 	sendMessage,
 	waitForMessage,
 	openDirectChat,
+	getStartedCards,
+	dismissGetStartedCard,
 	simulateUpdate,
 	checkOverflow,
 	checkDarkMode,


### PR DESCRIPTION
## Summary

Closes #133

- Add "Add photo", "Chat color", and hidden "New group" cards to the Get Started section at the bottom of the empty chat list
- Cards use pixel-exact colors extracted from Signal screenshots with theme-specific tones — iOS uses lighter warm/sage (#F6F2E9/#E9ECE4), Material uses more saturated (#F5ECDF/#DDE4D5)
- "Add photo" card auto-hides when user sets an avatar; cards can be individually dismissed (persisted via localStorage)
- Add E2E test covering card visibility and dismiss persistence across reload
- Add "Wipe" preview toolbar button for testing fresh app state

## Test plan

- [x] Verify all 3 cards appear on empty home screen (no contacts, no chats)
- [x] Verify Material theme shows warmer/greener card colors vs iOS lighter tones
- [x] Dismiss a card and reload — verify it stays dismissed
- [x] Set a profile photo and verify "Add photo" card disappears
- [x] Tap "Chat Color" card — verify navigation to /settings/appearance
- [x] Run E2E tests: `cd e2e-tests && SKIP_BUILD=1 pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)