### PR TITLE
Narrow desktop sidebar to match Signal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ This is a pnpm workspace with multiple packages:
 ### Desktop Layout
 
 On wide screens (≥768px), the app uses a two-panel layout managed by `DesktopLayout.svelte`:
-- **Sidebar** (left, 320px): Shows the contextual panel based on the current route — `ChatListPanel` for chat routes, `SettingsPanel` for `/settings/*`, `NewMessagePanel` for `/new-message/*`.
+- **Sidebar** (left, 280px): Shows the contextual panel based on the current route — `ChatListPanel` for chat routes, `SettingsPanel` for `/settings/*`, `NewMessagePanel` for `/new-message/*`.
 - **Content** (right, flex): Shows the page content. For sidebar-only routes (`/` and `/settings`), an `EmptyState` placeholder is rendered instead.
 
 Pages like `/`, `/settings`, and `/new-message` always render their mobile content (wrapped in `<Page>`). On desktop, `DesktopLayout` handles showing the correct sidebar panel and decides whether to render `EmptyState` or the page's children in the content area. Pages never check `isWideScreen` to decide between EmptyState and their content — that logic lives solely in `DesktopLayout`.

--- a/ui/src/lib/components/layout/DesktopLayout.svelte
+++ b/ui/src/lib/components/layout/DesktopLayout.svelte
@@ -76,8 +76,8 @@
 	}
 
 	.desktop-sidebar {
-		width: 320px;
-		min-width: 320px;
+		width: 280px;
+		min-width: 280px;
 		border-right: 1px solid var(--k-hairline-color);
 		overflow-y: auto;
 		overflow-x: hidden;


### PR DESCRIPTION
## Summary
- Reduces desktop sidebar width from 320px to 280px to match Signal Desktop's proportions
- Signal's chat list panel (excluding the 80px nav icons column) is ~240px; at 280px our unified sidebar matches the overall feel
- Updates CLAUDE.md documentation to reflect the new width

Closes #129

## Test plan
- [x] Open app at ≥768px wide — verify sidebar is visibly narrower
- [x] Compare sidebar proportion against Signal Desktop screenshots
- [x] Check chat list, settings panel, and new message panel still render properly in the narrower sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)