### PR TITLE
Fix desktop font sizes and list item density

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -302,15 +302,30 @@ emoji-picker {
 
 /*
  * Desktop density — override Tailwind theme variables to match Signal Desktop.
- * --spacing shrinks all spacing/padding/height utilities proportionally.
- * Font-size overrides target Konsta-internal arbitrary-value classes.
+ * --spacing controls all spacing/padding/height utilities proportionally.
+ * Navbar gets tighter --spacing for a compact 40px header.
  */
 .desktop {
-	--spacing: 0.15625rem; /* 2.5px — matches Signal Desktop density */
+	--spacing: 0.1875rem; /* 3px — general desktop density */
 	--text-xs: 0.6875rem; /* 11px */
 	--text-sm: 0.8125rem; /* 13px */
 	--text-base: 0.875rem; /* 14px */
 	font-size: 14px;
+}
+
+/* Compact navbar — tighter spacing for ~40px height like Signal Desktop */
+.desktop .k-navbar {
+	--spacing: 0.15625rem; /* 2.5px — h-16 → 40px, max-h-12 → 30px */
+}
+
+/* Tighter padding on navbar action links */
+.desktop .k-navbar .k-link {
+	padding-inline: 0.3125rem; /* 5px — Signal-style tight icon buttons */
+}
+
+/* Navbar icons smaller than body icons */
+.desktop .k-navbar wa-icon {
+	font-size: 18px;
 }
 
 /* Konsta Material navbar title (generates text-[22px] — arbitrary, no variable) */

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -287,3 +287,40 @@ emoji-picker {
 	width: auto;
 }
 
+/*
+ * Desktop density overrides — scoped to .desktop (applied when !isMobile).
+ * Konsta UI generates Tailwind utility classes (e.g. text-[22px], text-[16px])
+ * for font sizes, so we use attribute selectors with !important to override them.
+ */
+.desktop {
+	font-size: 14px;
+}
+
+.desktop .k-navbar [class*='text-[22px]'] {
+	font-size: 16px !important;
+}
+
+.desktop .k-list-item [class*='text-[16px]'] {
+	font-size: 14px !important;
+}
+
+.desktop .k-list-item .text-sm {
+	font-size: 13px;
+}
+
+.desktop .k-list-item wa-avatar {
+	--size: 36px;
+}
+
+.desktop wa-icon {
+	font-size: 20px;
+}
+
+.desktop wa-icon[slot='start'],
+.desktop wa-icon[slot='end'] {
+	font-size: 18px;
+}
+
+.desktop .message {
+	font-size: 14px;
+}

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -2,6 +2,9 @@
 /* import Konsta UI theme */
 @import 'konsta/svelte/theme.css';
 
+/* Desktop density variant — matches elements inside .desktop (set on <App> when !isMobile) */
+@custom-variant desktop (&:where(.desktop *));
+
 @theme {
 	--color-brand-primary: #007aff;
 	--color-brand-red: #ff0000;
@@ -288,39 +291,41 @@ emoji-picker {
 }
 
 /*
- * Desktop density overrides — scoped to .desktop (applied when !isMobile).
- * Konsta UI generates Tailwind utility classes (e.g. text-[22px], text-[16px])
- * for font sizes, so we use attribute selectors with !important to override them.
+ * Desktop density — override Tailwind's --spacing variable to shrink all
+ * spacing/padding/height utilities proportionally (75% of mobile).
+ * Font-size overrides target Konsta-internal classes we cannot control.
  */
 .desktop {
+	--spacing: 0.1875rem; /* 3px vs default 4px — tighter desktop density */
 	font-size: 14px;
 }
 
+/* Konsta Material navbar title (generates text-[22px]) */
 .desktop .k-navbar [class*='text-[22px]'] {
 	font-size: 16px !important;
 }
 
+/* Konsta list-item title row (generates text-[16px]) */
 .desktop .k-list-item [class*='text-[16px]'] {
 	font-size: 14px !important;
 }
 
+/* Konsta list-item subtitle / after text */
 .desktop .k-list-item .text-sm {
 	font-size: 13px;
 }
 
+/* Default list-item avatar size */
 .desktop .k-list-item wa-avatar {
 	--size: 36px;
 }
 
+/* Global icon size */
 .desktop wa-icon {
 	font-size: 20px;
 }
 
-.desktop wa-icon[slot='start'],
-.desktop wa-icon[slot='end'] {
-	font-size: 18px;
-}
-
-.desktop .message {
+/* Message input textarea */
+.desktop .message-textarea {
 	font-size: 14px;
 }

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -171,6 +171,10 @@ li.plain span {
 	background-color: var(--k-color-md-dark-surface);
 }
 
+:where(.desktop) .sticky-day-tag {
+	top: calc(40px + 8px);
+}
+
 .small-icon {
 	font-size: 16px;
 }
@@ -199,6 +203,12 @@ li.plain span {
 	width: 56px;
 	height: 56px;
 	border-radius: 16px;
+}
+
+:where(.desktop) .k-button.icon-only {
+	width: 44px;
+	height: 44px;
+	border-radius: 12px;
 }
 
 .search-highlight {
@@ -291,20 +301,21 @@ emoji-picker {
 }
 
 /*
- * Desktop density — override Tailwind's --spacing variable to shrink all
- * spacing/padding/height utilities proportionally (75% of mobile).
- * Font-size overrides target Konsta-internal classes we cannot control.
+ * Desktop density — override Tailwind theme variables to match Signal Desktop.
+ * --spacing shrinks all spacing/padding/height utilities proportionally.
+ * Font-size overrides target Konsta-internal arbitrary-value classes.
  */
 .desktop {
-	--spacing: 0.1875rem; /* 3px vs default 4px — tighter desktop density */
-	--text-sm: 0.8125rem; /* 13px vs default 14px */
-	--text-base: 0.875rem; /* 14px vs default 16px */
+	--spacing: 0.15625rem; /* 2.5px — matches Signal Desktop density */
+	--text-xs: 0.6875rem; /* 11px */
+	--text-sm: 0.8125rem; /* 13px */
+	--text-base: 0.875rem; /* 14px */
 	font-size: 14px;
 }
 
 /* Konsta Material navbar title (generates text-[22px] — arbitrary, no variable) */
 .desktop .k-navbar [class*='text-[22px]'] {
-	font-size: 16px !important;
+	font-size: 15px !important;
 }
 
 /* Konsta list-item title row (generates text-[16px] — arbitrary, no variable) */

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -297,22 +297,19 @@ emoji-picker {
  */
 .desktop {
 	--spacing: 0.1875rem; /* 3px vs default 4px — tighter desktop density */
+	--text-sm: 0.8125rem; /* 13px vs default 14px */
+	--text-base: 0.875rem; /* 14px vs default 16px */
 	font-size: 14px;
 }
 
-/* Konsta Material navbar title (generates text-[22px]) */
+/* Konsta Material navbar title (generates text-[22px] — arbitrary, no variable) */
 .desktop .k-navbar [class*='text-[22px]'] {
 	font-size: 16px !important;
 }
 
-/* Konsta list-item title row (generates text-[16px]) */
+/* Konsta list-item title row (generates text-[16px] — arbitrary, no variable) */
 .desktop .k-list-item [class*='text-[16px]'] {
 	font-size: 14px !important;
-}
-
-/* Konsta list-item subtitle / after text */
-.desktop .k-list-item .text-sm {
-	font-size: 13px;
 }
 
 /* Default list-item avatar size */

--- a/ui/src/lib/components/MessageInput.svelte
+++ b/ui/src/lib/components/MessageInput.svelte
@@ -5,7 +5,7 @@
 	import { mdiSend, mdiEmoticonHappyOutline } from '@mdi/js';
 	import { useTheme } from 'konsta/svelte';
 	import { onMount } from 'svelte';
-	import { isIos, isMobile } from '$lib/utils/environment';
+	import { isIos } from '$lib/utils/environment';
 
 	interface Props {
 		value?: string;
@@ -99,7 +99,6 @@
 			<textarea
 				class="message-textarea"
 				data-testid="message-input-textarea"
-				style={isMobile ? undefined : 'font-size: 14px'}
 				{placeholder}
 				bind:value
 				bind:this={textarea}

--- a/ui/src/lib/components/MessageInput.svelte
+++ b/ui/src/lib/components/MessageInput.svelte
@@ -5,7 +5,7 @@
 	import { mdiSend, mdiEmoticonHappyOutline } from '@mdi/js';
 	import { useTheme } from 'konsta/svelte';
 	import { onMount } from 'svelte';
-	import { isIos } from '$lib/utils/environment';
+	import { isIos, isMobile } from '$lib/utils/environment';
 
 	interface Props {
 		value?: string;
@@ -99,6 +99,7 @@
 			<textarea
 				class="message-textarea"
 				data-testid="message-input-textarea"
+				style={isMobile ? undefined : 'font-size: 14px'}
 				{placeholder}
 				bind:value
 				bind:this={textarea}

--- a/ui/src/lib/components/layout/ChatListPanel.svelte
+++ b/ui/src/lib/components/layout/ChatListPanel.svelte
@@ -10,6 +10,7 @@
 	import { Link, Navbar, useTheme } from 'konsta/svelte';
 	import { m } from '$lib/paraglide/messages';
 	import { pushState } from '$app/navigation';
+	import { isMobile } from '$lib/utils/environment';
 
 	const contactsStore: ContactsStore = getContext('contacts-store');
 	const myProfile = useReactivePromise(contactsStore.myProfile);
@@ -24,7 +25,7 @@
 					<wa-avatar
 						image={myProfile?.avatar}
 						initials={myProfile?.name.slice(0, 2)}
-						style="--size: 42px"
+						style={`--size: ${isMobile ? '42px' : '32px'}`}
 					>
 					</wa-avatar>
 				</Link>

--- a/ui/src/lib/components/layout/ChatListPanel.svelte
+++ b/ui/src/lib/components/layout/ChatListPanel.svelte
@@ -10,8 +10,6 @@
 	import { Link, Navbar, useTheme } from 'konsta/svelte';
 	import { m } from '$lib/paraglide/messages';
 	import { pushState } from '$app/navigation';
-	import { isMobile } from '$lib/utils/environment';
-
 	const contactsStore: ContactsStore = getContext('contacts-store');
 	const myProfile = useReactivePromise(contactsStore.myProfile);
 	const theme = $derived(useTheme());
@@ -25,7 +23,7 @@
 					<wa-avatar
 						image={myProfile?.avatar}
 						initials={myProfile?.name.slice(0, 2)}
-						style={`--size: ${isMobile ? '42px' : '32px'}`}
+						class="[--size:42px] desktop:[--size:32px]"
 					>
 					</wa-avatar>
 				</Link>

--- a/ui/src/lib/components/layout/SettingsPanel.svelte
+++ b/ui/src/lib/components/layout/SettingsPanel.svelte
@@ -18,6 +18,7 @@
 		useTheme,
 	} from 'konsta/svelte';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
+	import { isMobile } from '$lib/utils/environment';
 	import type { Action } from 'svelte/action';
 
 	const stopPropagation: Action = (node) => {
@@ -68,16 +69,16 @@
 				linkProps={{ href: '/settings/profile' }}
 				data-testid="settings-profile-link"
 				title={myProfile ? fullName(myProfile) : undefined}
-				titleFontSizeIos="text-xl"
-				titleFontSizeMaterial="text-xl"
+				titleFontSizeIos={isMobile ? 'text-xl' : 'text-base'}
+				titleFontSizeMaterial={isMobile ? 'text-xl' : 'text-base'}
 			>
 				{#snippet media()}
 					<wa-avatar
 						image={myProfile?.avatar}
 						initials={myProfile?.name.slice(0, 2)}
 						style={isWideScreen.value || theme === 'ios'
-							? '--size: 64px'
-							: '--size: 64px; margin-left: 16px'}
+							? `--size: ${isMobile ? '64px' : '40px'}`
+							: `--size: ${isMobile ? '64px' : '40px'}; margin-left: 16px`}
 					>
 					</wa-avatar>
 				{/snippet}
@@ -107,7 +108,7 @@
 				{#snippet media()}
 					<wa-icon
 						src={wrapPathInSvg(mdiAccountCircleOutline)}
-						style="font-size: 28px"
+						style={`font-size: ${isMobile ? '28px' : '24px'}`}
 					></wa-icon>
 				{/snippet}
 			</ListItem>
@@ -122,7 +123,7 @@
 				{#snippet media()}
 					<wa-icon
 						src={wrapPathInSvg(mdiPaletteOutline)}
-						style="font-size: 28px"
+						style={`font-size: ${isMobile ? '28px' : '24px'}`}
 					></wa-icon>
 				{/snippet}
 			</ListItem>
@@ -140,7 +141,7 @@
 				{#snippet media()}
 					<wa-icon
 						src={wrapPathInSvg(mdiHelpCircleOutline)}
-						style="font-size: 28px"
+						style={`font-size: ${isMobile ? '28px' : '24px'}`}
 					></wa-icon>
 				{/snippet}
 			</ListItem>

--- a/ui/src/lib/components/layout/SettingsPanel.svelte
+++ b/ui/src/lib/components/layout/SettingsPanel.svelte
@@ -18,7 +18,6 @@
 		useTheme,
 	} from 'konsta/svelte';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
-	import { isMobile } from '$lib/utils/environment';
 	import type { Action } from 'svelte/action';
 
 	const stopPropagation: Action = (node) => {
@@ -69,16 +68,15 @@
 				linkProps={{ href: '/settings/profile' }}
 				data-testid="settings-profile-link"
 				title={myProfile ? fullName(myProfile) : undefined}
-				titleFontSizeIos={isMobile ? 'text-xl' : 'text-base'}
-				titleFontSizeMaterial={isMobile ? 'text-xl' : 'text-base'}
+				titleFontSizeIos="text-xl desktop:text-base"
+				titleFontSizeMaterial="text-xl desktop:text-base"
 			>
 				{#snippet media()}
 					<wa-avatar
 						image={myProfile?.avatar}
 						initials={myProfile?.name.slice(0, 2)}
-						style={isWideScreen.value || theme === 'ios'
-							? `--size: ${isMobile ? '64px' : '40px'}`
-							: `--size: ${isMobile ? '64px' : '40px'}; margin-left: 16px`}
+						class="[--size:64px] desktop:![--size:40px]"
+						style={isWideScreen.value || theme === 'ios' ? undefined : 'margin-left: 16px'}
 					>
 					</wa-avatar>
 				{/snippet}
@@ -108,7 +106,7 @@
 				{#snippet media()}
 					<wa-icon
 						src={wrapPathInSvg(mdiAccountCircleOutline)}
-						style={`font-size: ${isMobile ? '28px' : '24px'}`}
+						class="text-[28px] desktop:text-[24px]"
 					></wa-icon>
 				{/snippet}
 			</ListItem>
@@ -123,7 +121,7 @@
 				{#snippet media()}
 					<wa-icon
 						src={wrapPathInSvg(mdiPaletteOutline)}
-						style={`font-size: ${isMobile ? '28px' : '24px'}`}
+						class="text-[28px] desktop:text-[24px]"
 					></wa-icon>
 				{/snippet}
 			</ListItem>
@@ -141,7 +139,7 @@
 				{#snippet media()}
 					<wa-icon
 						src={wrapPathInSvg(mdiHelpCircleOutline)}
-						style={`font-size: ${isMobile ? '28px' : '24px'}`}
+						class="text-[28px] desktop:text-[24px]"
 					></wa-icon>
 				{/snippet}
 			</ListItem>

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -38,7 +38,7 @@
 	import { useSignal } from '$lib/stores/use-signal';
 	import { applyDarkMode } from '$lib/utils/theme';
 	import { showToast } from '$lib/utils/toasts';
-	import { isIos, isMac, isTauriEnv } from '$lib/utils/environment';
+	import { isIos, isMac, isMobile, isTauriEnv } from '$lib/utils/environment';
 
 	import { m } from '$lib/paraglide/messages.js';
 	import { setLocale } from '$lib/paraglide/runtime';
@@ -141,7 +141,7 @@
 {/if}
 
 <KonstaProvider {theme} dark={effectiveDark}>
-	<App safeAreas {theme} class="k-{theme}" dark={effectiveDark}>
+	<App safeAreas {theme} class="k-{theme}{isMobile ? '' : ' desktop'}" dark={effectiveDark}>
 		<SplashscreenPrompt>
 			{#if isWideScreen.value}
 				<DesktopLayout>

--- a/ui/src/routes/direct-chats/[agentId]/+page.svelte
+++ b/ui/src/routes/direct-chats/[agentId]/+page.svelte
@@ -70,6 +70,7 @@
 	import QuickReactionBar from '$lib/components/messages/QuickReactionBar.svelte';
 	import { longpress } from '$lib/actions/longpress';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
+	import { isMobile } from '$lib/utils/environment';
 	let agentId = page.params.agentId!;
 
 	const contactsStore: ContactsStore = getContext('contacts-store');
@@ -552,7 +553,7 @@
 												>
 												</wa-avatar>
 												<div class="flex items-center gap-1">
-													<span class="text-xl font-semibold"
+													<span class={`${isMobile ? 'text-xl' : 'text-lg'} font-semibold`}
 														>{fullName(profile!)}</span
 													>
 													<wa-icon

--- a/ui/src/routes/direct-chats/[agentId]/+page.svelte
+++ b/ui/src/routes/direct-chats/[agentId]/+page.svelte
@@ -70,7 +70,6 @@
 	import QuickReactionBar from '$lib/components/messages/QuickReactionBar.svelte';
 	import { longpress } from '$lib/actions/longpress';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
-	import { isMobile } from '$lib/utils/environment';
 	let agentId = page.params.agentId!;
 
 	const contactsStore: ContactsStore = getContext('contacts-store');
@@ -553,7 +552,7 @@
 												>
 												</wa-avatar>
 												<div class="flex items-center gap-1">
-													<span class={`${isMobile ? 'text-xl' : 'text-lg'} font-semibold`}
+													<span class="text-xl desktop:text-lg font-semibold"
 														>{fullName(profile!)}</span
 													>
 													<wa-icon

--- a/ui/src/routes/direct-chats/[agentId]/chat-settings/+page.svelte
+++ b/ui/src/routes/direct-chats/[agentId]/chat-settings/+page.svelte
@@ -27,7 +27,6 @@
 		useTheme,
 	} from 'konsta/svelte';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
-	import { isMobile } from '$lib/utils/environment';
 	import { page } from '$app/state';
 	let agentId = page.params.agentId!;
 
@@ -70,7 +69,7 @@
 					</wa-avatar>
 
 					<div class="flex cursor-pointer items-center gap-1" onclick={() => (showPeerProfile = true)} role="button" tabindex="0">
-						<span class={`${isMobile ? 'text-xl' : 'text-lg'} font-semibold`} data-testid="chat-settings-peer-name">{fullName(profile!)}</span>
+						<span class="text-xl desktop:text-lg font-semibold" data-testid="chat-settings-peer-name">{fullName(profile!)}</span>
 						<wa-icon
 							class="small-icon quiet"
 							src={wrapPathInSvg(mdiChevronRight)}

--- a/ui/src/routes/direct-chats/[agentId]/chat-settings/+page.svelte
+++ b/ui/src/routes/direct-chats/[agentId]/chat-settings/+page.svelte
@@ -27,6 +27,7 @@
 		useTheme,
 	} from 'konsta/svelte';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
+	import { isMobile } from '$lib/utils/environment';
 	import { page } from '$app/state';
 	let agentId = page.params.agentId!;
 
@@ -69,7 +70,7 @@
 					</wa-avatar>
 
 					<div class="flex cursor-pointer items-center gap-1" onclick={() => (showPeerProfile = true)} role="button" tabindex="0">
-						<span class="text-xl font-semibold" data-testid="chat-settings-peer-name">{fullName(profile!)}</span>
+						<span class={`${isMobile ? 'text-xl' : 'text-lg'} font-semibold`} data-testid="chat-settings-peer-name">{fullName(profile!)}</span>
 						<wa-icon
 							class="small-icon quiet"
 							src={wrapPathInSvg(mdiChevronRight)}

--- a/ui/src/routes/group-chat/[chatId]/info/+page.svelte
+++ b/ui/src/routes/group-chat/[chatId]/info/+page.svelte
@@ -37,7 +37,6 @@
 	import Layout from '../../../+layout.svelte';
 
 	import { isWideScreen } from '$lib/stores/screen.svelte';
-	import { isMobile } from '$lib/utils/environment';
 	import { page } from '$app/state';
 	let chatId = page.params.chatId!;
 
@@ -161,7 +160,7 @@
 							<wa-icon src={wrapPathInSvg(mdiAccountGroup)}> </wa-icon>
 						</wa-avatar>
 
-						<span class={`${isMobile ? 'text-xl' : 'text-lg'} font-semibold`}>{info.name}</span>
+						<span class="text-xl desktop:text-lg font-semibold">{info.name}</span>
 
 						<span class="quiet">{info.description}</span>
 					</div>

--- a/ui/src/routes/group-chat/[chatId]/info/+page.svelte
+++ b/ui/src/routes/group-chat/[chatId]/info/+page.svelte
@@ -37,6 +37,7 @@
 	import Layout from '../../../+layout.svelte';
 
 	import { isWideScreen } from '$lib/stores/screen.svelte';
+	import { isMobile } from '$lib/utils/environment';
 	import { page } from '$app/state';
 	let chatId = page.params.chatId!;
 
@@ -160,7 +161,7 @@
 							<wa-icon src={wrapPathInSvg(mdiAccountGroup)}> </wa-icon>
 						</wa-avatar>
 
-						<span class="text-xl font-semibold">{info.name}</span>
+						<span class={`${isMobile ? 'text-xl' : 'text-lg'} font-semibold`}>{info.name}</span>
 
 						<span class="quiet">{info.description}</span>
 					</div>


### PR DESCRIPTION
## Summary
- Add `.desktop` CSS class on `<App>` when `!isMobile` (user-agent detection) to scope all density overrides — mobile is unaffected
- Override Konsta UI's generated Tailwind utility classes (`text-[22px]`, `text-[16px]`) for navbar titles and list-item text via attribute selectors
- Shrink settings-panel profile avatar (64→40px), name (text-xl→text-base), and icons (28→24px) on desktop
- Reduce chat-list navbar avatar (42→32px), list-item avatars (→36px via CSS), and message textarea font (16→14px) on desktop
- Downsize headings in direct-chat intro, chat-settings, and group-chat info from text-xl to text-lg on desktop

## Test plan
- [ ] Start the app on desktop — verify `.desktop` class is present on the app root
- [ ] Compare chat list, settings sidebar, direct chat, and chat-settings against Signal Desktop screenshots
- [ ] Open the app in a mobile emulator or with a mobile user agent — confirm `.desktop` class is absent and no density changes apply
- [ ] Run E2E tests to verify no regressions

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)