### PR TITLE
Show bottom-right action buttons on macOS desktop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ This is a pnpm workspace with multiple packages:
 - UI built with Konsta UI components (mobile-first design)
 - Internationalization using @inlang/paraglide-js
 - Image compression before upload
-- **iOS theme action buttons**: In the iOS theme, all primary action buttons (Save, Done, Create, Add, Next) must appear as a `<Link>` in the Navbar's `right` snippet — never as a bottom FAB. The bottom FAB (`class="fixed-action-btn"`) is Material-only. Use `{#if theme === 'ios'}` in the navbar right snippet and `{#if theme === 'material'}` around the FAB. Apply disabled styling via `rightClass="ios-right-disabled"` on the Navbar (defined in `app.css`).
+- **iOS theme action buttons**: On actual iOS devices, primary action buttons (Save, Done, Create, Add, Next) appear as a `<Link>` in the Navbar's `right` snippet. On all other platforms (including macOS desktop), they appear as a bottom FAB (`class="fixed-action-btn"`). Use `import { isIos } from '$lib/utils/environment'` and `{#if isIos}` in the navbar right snippet and `{#if !isIos}` around the FAB. Apply disabled styling via `rightClass="ios-right-disabled"` on the Navbar (defined in `app.css`).
 
 ### Desktop Layout
 

--- a/ui/src/lib/components/layout/SelectColor.svelte
+++ b/ui/src/lib/components/layout/SelectColor.svelte
@@ -16,6 +16,7 @@
 		Button,
 		useTheme,
 	} from 'konsta/svelte';
+	import { isIos } from '$lib/utils/environment';
 
 	let {
 		code,
@@ -72,7 +73,7 @@
 		{/snippet}
 
 		{#snippet right()}
-			{#if theme === 'ios'}
+			{#if isIos}
 				<Link onClick={save} data-testid="color-picker-done">
 					{m.done()}
 				</Link>
@@ -156,7 +157,7 @@
 		</div>
 	</div>
 
-	{#if theme === 'material'}
+	{#if !isIos}
 		<Button
 			rounded
 			inline

--- a/ui/src/lib/components/profiles/CreateProfile.svelte
+++ b/ui/src/lib/components/profiles/CreateProfile.svelte
@@ -6,6 +6,7 @@
 	import PhotoPicker from './PhotoPicker.svelte';
 	import { m } from '$lib/paraglide/messages.js';
 	import { showToast } from '$lib/utils/toasts';
+	import { isIos } from '$lib/utils/environment';
 	import {
 		Page,
 		Button,
@@ -79,7 +80,7 @@
 			/>
 		</div>
 
-		{#if !textEditorOpen && theme === 'material'}
+		{#if !textEditorOpen && !isIos}
 			<Button
 				rounded
 				tonal
@@ -100,7 +101,7 @@
 				: ''}
 		>
 			{#snippet right()}
-				{#if theme === 'ios'}
+				{#if isIos}
 					<Link
 						onClick={setProfile}
 						data-testid="create-profile-create-link"
@@ -168,7 +169,7 @@
 			</div>
 		</div>
 
-		{#if theme === 'material'}
+		{#if !isIos}
 			<Button
 				onClick={setProfile}
 				class="fixed-action-btn"

--- a/ui/src/lib/components/profiles/PhotoPicker.svelte
+++ b/ui/src/lib/components/profiles/PhotoPicker.svelte
@@ -4,9 +4,9 @@
 	import { wrapPathInSvg } from '$lib/utils/icon';
 	import { mdiClose, mdiCamera, mdiImage, mdiArrowLeft } from '@mdi/js';
 	import { m } from '$lib/paraglide/messages.js';
-	import { Button, Link, Navbar, Segmented, SegmentedButton, useTheme } from 'konsta/svelte';
+	import { Button, Link, Navbar, Segmented, SegmentedButton } from 'konsta/svelte';
 	import { resizeAndExport } from '$lib/utils/image';
-	import { isMobile } from '$lib/utils/environment';
+	import { isMobile, isIos } from '$lib/utils/environment';
 
 	let {
 		avatar = $bindable(),
@@ -25,8 +25,6 @@
 		saveLabel?: string;
 		saveDisabled?: boolean;
 	} = $props();
-
-	const theme = $derived(useTheme());
 
 	let view = $state<'picker' | 'text'>('picker');
 	$effect(() => {
@@ -163,7 +161,7 @@
 />
 
 {#if view === 'picker'}
-	{#if onClose || (onSave && theme === 'ios')}
+	{#if onClose || (onSave && isIos)}
 		<Navbar transparent rightClass={saveDisabled ? 'ios-right-disabled' : ''}>
 			{#snippet left()}
 				{#if onClose}
@@ -173,7 +171,7 @@
 				{/if}
 			{/snippet}
 			{#snippet right()}
-				{#if theme === 'ios' && onSave}
+				{#if isIos && onSave}
 					<Link onClick={onSave} data-testid="edit-photo-save-link">
 						{saveLabel || m.save()}
 					</Link>
@@ -272,7 +270,7 @@
 			</Link>
 		{/snippet}
 		{#snippet right()}
-			{#if theme === 'ios'}
+			{#if isIos}
 				<Link onClick={generateTextAvatar}>
 					{m.done()}
 				</Link>
@@ -328,7 +326,7 @@
 		</div>
 	{/if}
 
-	{#if theme === 'material'}
+	{#if !isIos}
 		<Button
 			rounded
 			tonal

--- a/ui/src/routes/group-chat/[chatId]/info/add-members/+page.svelte
+++ b/ui/src/routes/group-chat/[chatId]/info/add-members/+page.svelte
@@ -17,11 +17,11 @@
 		Link,
 		Preloader,
 		Checkbox,
-		useTheme,
 	} from 'konsta/svelte';
 	import { useReactivePromise } from '$lib/stores/use-signal';
 	import { wrapPathInSvg } from '$lib/utils/icon';
 	import Avatar from '$lib/components/profiles/Avatar.svelte';
+	import { isIos } from '$lib/utils/environment';
 	import { page } from '$app/state';
 	let chatId = page.params.chatId!;
 
@@ -29,7 +29,6 @@
 	let selectedContacts = $state<PublicKey[]>([]);
 
 	const contacts = useReactivePromise(contactsStore.profilesForAllContacts);
-	const theme = $derived(useTheme());
 
 	async function addMembers() {
 		goto(`/group-chat/${chatId}/info`);
@@ -51,7 +50,7 @@
 			/>
 		{/snippet}
 		{#snippet right()}
-			{#if theme === 'ios'}
+			{#if isIos}
 				<Link onClick={addMembers}>
 					{m.add()}
 				</Link>
@@ -100,7 +99,7 @@
 			</div>
 		</div>
 
-		{#if theme === 'material'}
+		{#if !isIos}
 			<Button
 				onClick={addMembers}
 				class="fixed-action-btn"

--- a/ui/src/routes/group-chat/[chatId]/info/edit/+page.svelte
+++ b/ui/src/routes/group-chat/[chatId]/info/edit/+page.svelte
@@ -19,6 +19,7 @@
 		useTheme,
 	} from 'konsta/svelte';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
+	import { isIos } from '$lib/utils/environment';
 	import { page } from '$app/state';
 	let chatId = page.params.chatId!;
 
@@ -56,7 +57,7 @@
 			/>
 		{/snippet}
 		{#snippet right()}
-			{#if theme === 'ios'}
+			{#if isIos}
 				<Link onClick={save}>
 					{m.save()}
 				</Link>
@@ -91,7 +92,7 @@
 			</div>
 		</div>
 
-		{#if theme === 'material'}
+		{#if !isIos}
 			<Button
 				onClick={save}
 				class="fixed-action-btn"

--- a/ui/src/routes/new-group/+page.svelte
+++ b/ui/src/routes/new-group/+page.svelte
@@ -28,6 +28,7 @@
 		useTheme,
 	} from 'konsta/svelte';
 	import { mdiArrowNext } from '$lib/utils/icon';
+	import { isIos } from '$lib/utils/environment';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
 
 	const contactsStore: ContactsStore = getContext('contacts-store');
@@ -56,7 +57,7 @@
 			{/snippet}
 
 			{#snippet right()}
-				{#if theme === 'ios'}
+				{#if isIos}
 					<Link onClick={() => (currentPage = 'group-info')} data-testid="new-group-next-link">
 						{selectedContacts.length === 0 ? m.omit() : m.next()}
 					</Link>
@@ -107,7 +108,7 @@
 			</div>
 		</div>
 
-		{#if theme === 'material'}
+		{#if !isIos}
 			<Button
 				onClick={() => (currentPage = 'group-info')}
 				data-testid="new-group-next-btn"
@@ -126,7 +127,7 @@
 			{/snippet}
 
 			{#snippet right()}
-				{#if theme === 'ios'}
+				{#if isIos}
 					<Link onClick={createGroupChat} data-testid="new-group-create-link">
 						{m.create()}
 					</Link>
@@ -153,7 +154,7 @@
 			</div>
 		</div>
 
-		{#if theme === 'material'}
+		{#if !isIos}
 			<Button
 				onClick={createGroupChat}
 				data-testid="new-group-create-btn"

--- a/ui/src/routes/settings/profile/edit-about/+page.svelte
+++ b/ui/src/routes/settings/profile/edit-about/+page.svelte
@@ -17,6 +17,7 @@
 		useTheme,
 	} from 'konsta/svelte';
 	import { showToast } from '$lib/utils/toasts';
+	import { isIos } from '$lib/utils/environment';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
 
 	const contactsStore: ContactsStore = getContext('contacts-store');
@@ -107,7 +108,7 @@
 			{/snippet}
 
 			{#snippet right()}
-				{#if theme === 'ios'}
+				{#if isIos}
 					<Link onClick={save} data-testid="edit-about-save-link">
 						{m.save()}
 					</Link>
@@ -153,7 +154,7 @@
 			</List>
 		</div>
 
-		{#if theme === 'material'}
+		{#if !isIos}
 			<Button
 				onClick={save}
 				class="fixed-action-btn"

--- a/ui/src/routes/settings/profile/edit-name/+page.svelte
+++ b/ui/src/routes/settings/profile/edit-name/+page.svelte
@@ -19,6 +19,7 @@
 		useTheme,
 	} from 'konsta/svelte';
 	import { showToast } from '$lib/utils/toasts';
+	import { isIos } from '$lib/utils/environment';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
 
 	const contactsStore: ContactsStore = getContext('contacts-store');
@@ -87,7 +88,7 @@
 			{/snippet}
 
 			{#snippet right()}
-				{#if theme === 'ios'}
+				{#if isIos}
 					<Link onClick={save} data-testid="edit-name-save-link">
 						{m.save()}
 					</Link>
@@ -119,7 +120,7 @@
 			</List>
 		</div>
 
-		{#if theme === 'material'}
+		{#if !isIos}
 			<Button
 				onClick={save}
 				class="fixed-action-btn"

--- a/ui/src/routes/settings/profile/edit-photo/+page.svelte
+++ b/ui/src/routes/settings/profile/edit-photo/+page.svelte
@@ -5,11 +5,10 @@
 	import { goto } from '$app/navigation';
 	import { useReactivePromise } from '$lib/stores/use-signal';
 	import { m } from '$lib/paraglide/messages.js';
-	import { Button, Page, Preloader, useTheme } from 'konsta/svelte';
+	import { Button, Page, Preloader } from 'konsta/svelte';
 	import { showToast } from '$lib/utils/toasts';
+	import { isIos } from '$lib/utils/environment';
 	import PhotoPicker from '$lib/components/profiles/PhotoPicker.svelte';
-
-	const theme = $derived(useTheme());
 
 	const contactsStore: ContactsStore = getContext('contacts-store');
 	let avatar = $state<string | undefined>(undefined);
@@ -80,7 +79,7 @@
 			/>
 		</div>
 
-		{#if !textEditorOpen && theme === 'material'}
+		{#if !textEditorOpen && !isIos}
 			<!-- Save button -->
 			<Button
 				rounded

--- a/ui/src/routes/settings/profile/edit-photo/text/+page.svelte
+++ b/ui/src/routes/settings/profile/edit-photo/text/+page.svelte
@@ -13,10 +13,8 @@
 		NavbarBackLink,
 		Segmented,
 		SegmentedButton,
-		useTheme,
 	} from 'konsta/svelte';
-
-	const theme = $derived(useTheme());
+	import { isIos } from '$lib/utils/environment';
 
 	// Get initial values from URL params or use defaults
 	const initialText = $page.url.searchParams.get('text') || '';
@@ -75,7 +73,7 @@
 			<NavbarBackLink onClick={() => goto('/settings/profile/edit-photo')} />
 		{/snippet}
 		{#snippet right()}
-			{#if theme === 'ios'}
+			{#if isIos}
 				<Link onClick={done}>
 					{m.done()}
 				</Link>
@@ -144,7 +142,7 @@
 		{/if}
 	</div>
 
-	{#if theme === 'material'}
+	{#if !isIos}
 		<Button
 			rounded
 			tonal


### PR DESCRIPTION
## Summary
- On macOS, the Konsta theme is `ios`, which placed Save/Done/Create/Next buttons in the navbar right slot — this feels out of place on desktop
- Switched the button visibility condition from theme-based (`theme === 'ios'` / `theme === 'material'`) to platform-based (`isIos` / `!isIos`)
- macOS desktop now shows the Material-style fixed bottom-right FAB buttons, while actual iOS devices keep the navbar links

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)