### PR TITLE
Add some comments to prevent confusion about log height

### DIFF
--- a/crates/dashchat-node/src/stores/op_store.rs
+++ b/crates/dashchat-node/src/stores/op_store.rs
@@ -79,6 +79,7 @@ where
         }
     }
 
+    /// Get the "height" of each log, which is actually the highest sequence number of the log.
     pub async fn get_log_heights(
         &self,
         topic: &TopicId,
@@ -369,6 +370,7 @@ where
         self.store.latest_operation(public_key, topic).await
     }
 
+    /// Get the "height" of each log, which is actually the highest sequence number of the log.
     async fn get_log_heights(&self, topic: &TopicId) -> Result<Vec<(PublicKey, u64)>, Self::Error> {
         self.store.get_log_heights(topic).await
     }

--- a/crates/mailbox-client/src/store.rs
+++ b/crates/mailbox-client/src/store.rs
@@ -9,6 +9,12 @@ pub trait MailboxStore<Item: MailboxItem>: Clone + Send + Sync + 'static {
         from: u64,
     ) -> Result<Option<Vec<Item>>, anyhow::Error>;
 
+    /// Get the last sequence number of each author's log.
+    ///
+    /// NOTE: "height" here is potentially misleading.
+    /// It's not the length of the log!
+    /// For instance, if the log has 2 items, the "height" is 1.
+    /// This is how p2panda measures height, and so do we.
     async fn get_log_heights(
         &self,
         topic: &Item::Topic,


### PR DESCRIPTION
I was working with a new MailboxStore that I wrote, and had to spend a ridiculously long time debugging a problem, which was due to my own misinterpretation of "log height". You would think the height of a log with 3 items would be 3, but it's actually 2! I added comments to guide any other travelers away from misery.