### PR TITLE
Ensure that name fields are not lost when opening/closing avatar picker

### DIFF
--- a/ui/src/lib/components/profiles/CreateProfile.svelte
+++ b/ui/src/lib/components/profiles/CreateProfile.svelte
@@ -152,12 +152,14 @@
 				<List inset={isWideScreen.value || theme === 'ios'} strongIos>
 					<ListInput
 						type="text"
+						value={name ?? ''}
 						onInput={e => (name = e.target.value)}
 						placeholder={m.nameMandatory()}
 						data-testid="create-profile-name"
 					></ListInput>
 					<ListInput
 						type="text"
+						value={surname ?? ''}
 						onInput={e => (surname = e.target.value)}
 						placeholder={m.surnameOptional()}
 						data-testid="create-profile-surname"


### PR DESCRIPTION
The fields were not controlled, and they were getting unmounted when the picker opened, now fixed.

As a larger consideration, coming from react, I would typically make a component like this more of a pure component, without talking to the state directly. Then, have the calling page do the handle the result of this save and writing it to the state. 

Fix for https://github.com/dash-chat/dash-chat/issues/120