### PR TITLE
fix(android): pin NDK r26 and isolate Linux Android CC env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ result*
 **/*/google-services.json
 service-account-key.json
 
+# Android studio
+src-tauri/gen/android/.idea/
+
 # Development environment database files
 *.redb
 .dbs

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,13 @@
       perSystem = { inputs', self', lib, system, ... }:
         let
           overlays = [ (import inputs.rust-overlay) ];
-          pkgs = import inputs.nixpkgs { inherit system overlays; };
+          pkgs = import inputs.nixpkgs {
+            inherit system overlays;
+            config = {
+              allowUnfree = true;
+              android_sdk.accept_license = true;
+            };
+          };
 
           tauriLibraries = with pkgs; [
             webkitgtk_4_1
@@ -87,12 +93,86 @@
           devShells.androidDev = let
             rust = pkgs.rust-bin.fromRustupToolchainFile
               ./rust-toolchain.android.toml;
+            androidCompositionR26 = pkgs.androidenv.composeAndroidPackages {
+              includeNDK = true;
+              ndkVersion = "26.3.11579264";
+            };
+            androidSdkR26 = androidCompositionR26.androidsdk;
+            # On Linux, C_INCLUDE_PATH from nix host packages leaks into Android
+            # CC subprocesses, causing ring 'uintptr_t and size_t differ' errors.
+            # We can't fix this via shellHook (nix re-applies derivation vars afterward),
+            # so we wrap each NDK compiler to unset the host headers at invocation time.
+            linuxNdkPrebuilt = "${androidSdkR26}/libexec/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64";
+            mkAndroidCC = bin: pkgs.writeShellScript "${bin}-android-isolated" ''
+              unset CPATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH OBJC_INCLUDE_PATH
+              exec "${linuxNdkPrebuilt}/bin/${bin}" "$@"
+            '';
           in pkgs.mkShell {
-            packages = [ rust ] ++ packages;
+            packages = [ rust androidSdkR26 ] ++ packages;
             inputsFrom = [
               devShells.default
               inputs'.tauri-plugin-holochain.devShells.holochainTauriAndroidDev
             ];
+            shellHook = ''
+              # Pin NDK to r26 for Linux compatibility with ring during Android builds.
+              export ANDROID_NDK_HOME="${androidSdkR26}/libexec/android-sdk/ndk-bundle"
+              export ANDROID_NDK_LATEST_HOME="$ANDROID_NDK_HOME"
+              export ANDROID_NDK="$ANDROID_NDK_HOME"
+              export ANDROID_NDK_ROOT="$ANDROID_NDK_HOME"
+              export NDK_HOME="$ANDROID_NDK_HOME"
+
+              # Used by tauri plugin build scripts when targeting Android.
+              export WRY_ANDROID_LIBRARY="''${WRY_ANDROID_LIBRARY:-tauri_app_lib}"
+
+              for d in "$ANDROID_NDK_HOME"/toolchains/llvm/prebuilt/*; do
+                export NDK_PREBUILT_DIR="$d"
+                break
+              done
+
+              export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$NDK_PREBUILT_DIR/bin/aarch64-linux-android24-clang"
+
+              export AR="$NDK_PREBUILT_DIR/bin/llvm-ar"
+              export RANLIB="$NDK_PREBUILT_DIR/bin/llvm-ranlib"
+              export CLANG_PATH="$NDK_PREBUILT_DIR/bin/clang"
+
+              ${lib.optionalString pkgs.stdenv.isLinux ''
+              # On Linux, use wrapper scripts to clear host C include paths at
+              # compiler invocation time (shellHook cannot unset nix derivation vars).
+              export CC_aarch64_linux_android="${mkAndroidCC "aarch64-linux-android24-clang"}"
+              export CC_armv7_linux_androideabi="${mkAndroidCC "armv7a-linux-androideabi24-clang"}"
+              export CC_i686_linux_android="${mkAndroidCC "i686-linux-android24-clang"}"
+              export CC_x86_64_linux_android="${mkAndroidCC "x86_64-linux-android24-clang"}"
+              export CXX_aarch64_linux_android="${mkAndroidCC "aarch64-linux-android24-clang++"}"
+              export CXX_armv7_linux_androideabi="${mkAndroidCC "armv7a-linux-androideabi24-clang++"}"
+              export CXX_i686_linux_android="${mkAndroidCC "i686-linux-android24-clang++"}"
+              export CXX_x86_64_linux_android="${mkAndroidCC "x86_64-linux-android24-clang++"}"
+              ''}
+              ${lib.optionalString (!pkgs.stdenv.isLinux) ''
+              export CC_aarch64_linux_android="$NDK_PREBUILT_DIR/bin/aarch64-linux-android24-clang"
+              export CC_armv7_linux_androideabi="$NDK_PREBUILT_DIR/bin/armv7a-linux-androideabi24-clang"
+              export CC_i686_linux_android="$NDK_PREBUILT_DIR/bin/i686-linux-android24-clang"
+              export CC_x86_64_linux_android="$NDK_PREBUILT_DIR/bin/x86_64-linux-android24-clang"
+              export CXX_aarch64_linux_android="$NDK_PREBUILT_DIR/bin/aarch64-linux-android24-clang++"
+              export CXX_armv7_linux_androideabi="$NDK_PREBUILT_DIR/bin/armv7a-linux-androideabi24-clang++"
+              export CXX_i686_linux_android="$NDK_PREBUILT_DIR/bin/i686-linux-android24-clang++"
+              export CXX_x86_64_linux_android="$NDK_PREBUILT_DIR/bin/x86_64-linux-android24-clang++"
+              ''}
+
+              export CFLAGS_aarch64_linux_android="--target=aarch64-linux-android24 --sysroot=$NDK_PREBUILT_DIR/sysroot"
+              export CFLAGS_armv7_linux_androideabi="--target=armv7-linux-androideabi24 --sysroot=$NDK_PREBUILT_DIR/sysroot"
+              export CFLAGS_i686_linux_android="--target=i686-linux-android24 --sysroot=$NDK_PREBUILT_DIR/sysroot"
+              export CFLAGS_x86_64_linux_android="--target=x86_64-linux-android24 --sysroot=$NDK_PREBUILT_DIR/sysroot"
+
+              export CXXFLAGS_aarch64_linux_android="--target=aarch64-linux-android24"
+              export CXXFLAGS_armv7_linux_androideabi="--target=armv7-linux-androideabi24"
+              export CXXFLAGS_i686_linux_android="--target=i686-linux-android24"
+              export CXXFLAGS_x86_64_linux_android="--target=x86_64-linux-android24"
+
+              export BINDGEN_EXTRA_CLANG_ARGS_aarch64_linux_android="--sysroot=$NDK_PREBUILT_DIR/sysroot -I$NDK_PREBUILT_DIR/sysroot/usr/include/aarch64-linux-android"
+              export BINDGEN_EXTRA_CLANG_ARGS_armv7_linux_androideabi="--sysroot=$NDK_PREBUILT_DIR/sysroot -I$NDK_PREBUILT_DIR/sysroot/usr/include/arm-linux-androideabi"
+              export BINDGEN_EXTRA_CLANG_ARGS_i686_linux_android="--sysroot=$NDK_PREBUILT_DIR/sysroot -I$NDK_PREBUILT_DIR/sysroot/usr/include/i686-linux-android"
+              export BINDGEN_EXTRA_CLANG_ARGS_x86_64_linux_android="--sysroot=$NDK_PREBUILT_DIR/sysroot -I$NDK_PREBUILT_DIR/sysroot/usr/include/x86_64-linux-android"
+            '';
           };
 
           devShells.iosDev = let

--- a/flake.nix
+++ b/flake.nix
@@ -120,10 +120,13 @@
             # CC subprocesses, causing ring 'uintptr_t and size_t differ' errors.
             # We can't fix this via shellHook (nix re-applies derivation vars afterward),
             # so we wrap each NDK compiler to unset the host headers at invocation time.
-            linuxNdkPrebuilt = "${androidSdkR26}/libexec/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64";
             mkAndroidCC = bin: pkgs.writeShellScript "${bin}-android-isolated" ''
+              if [ -z "''${NDK_PREBUILT_DIR:-}" ]; then
+                echo "NDK_PREBUILT_DIR is not set" >&2
+                exit 1
+              fi
               unset CPATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH OBJC_INCLUDE_PATH
-              exec "${linuxNdkPrebuilt}/bin/${bin}" "$@"
+              exec "$NDK_PREBUILT_DIR/bin/${bin}" "$@"
             '';
           in pkgs.mkShell {
             packages = [ rust androidSdkR26 ] ++ packages;

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,25 @@
           pkgs = import inputs.nixpkgs {
             inherit system overlays;
             config = {
-              allowUnfree = true;
+              allowUnfreePredicate = pkg:
+                let
+                  name = lib.getName pkg;
+                  androidUnfreeNames = [
+                    "androidsdk"
+                    "platform-tools"
+                    "build-tools"
+                    "cmdline-tools"
+                    "tools"
+                    "platforms"
+                    "sources"
+                    "system-images"
+                    "emulator"
+                    "ndk"
+                    "cmake"
+                    "patcher"
+                  ];
+                in lib.hasPrefix "android-sdk-" name
+                || builtins.elem name androidUnfreeNames;
               android_sdk.accept_license = true;
             };
           };


### PR DESCRIPTION
I'm getting some build errors on develop due a cross-compiling issue in the ring crate. It seems to be linux specific.

Claude assures me that this is the fix, although I admit to not understanding every line here.