### PR TITLE
Work around plugin requestPermissions() bug

### DIFF
--- a/scripts/android.just
+++ b/scripts/android.just
@@ -4,8 +4,13 @@ set working-directory := '..'
 dev:
     nix develop git+file:.#androidDev --command pnpm tauri android dev
 
-# build and install the android app via adb
+# install the android app via adb
 install:
+    nix develop git+file:.#androidDev --command bash -c "adb install src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk"
+
+
+# build and install the android app via adb
+build-and-install:
     nix develop git+file:.#androidDev --command bash -c "pnpm tauri android build --apk && adb install src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk"
 
 # build the android app

--- a/ui/src/lib/utils/qrcode.ts
+++ b/ui/src/lib/utils/qrcode.ts
@@ -5,12 +5,60 @@ export async function scanQrCode(): Promise<string> {
 	if (!isTauriEnv()) {
 		throw new Error('QR code scanning requires the Tauri desktop/mobile app');
 	}
-	const { Format, requestPermissions, scan } = await import(
+	const { Format, checkPermissions, requestPermissions, scan } = await import(
 		'@tauri-apps/plugin-barcode-scanner'
 	);
-	await requestPermissions();
+
+	await ensureCameraPermission(checkPermissions, requestPermissions);
+
 	const result = await scan({ windowed: true, formats: [Format.QRCode] });
 	return result.content;
+}
+
+/**
+ * The Tauri barcode scanner plugin's `requestPermissions()` sometimes hangs
+ * on Android: the permission dialog shows and the user grants it, but the
+ * plugin's internal callback never fires, so the JS promise never resolves.
+ *
+ * Workaround: check first with `checkPermissions()` (which always resolves).
+ * If not granted, race `requestPermissions()` against a polling loop that
+ * calls `checkPermissions()` until the permission is granted.
+ */
+async function ensureCameraPermission(
+	checkPermissions: () => Promise<string>,
+	requestPermissions: () => Promise<string>,
+): Promise<void> {
+	const state = await checkPermissions();
+	if (state === 'granted') return;
+
+	// Start the permission request (may hang due to plugin bug)
+	const requestPromise = requestPermissions().catch(() => {});
+
+	// Poll checkPermissions as a fallback — the OS grants the permission
+	// even if the plugin callback never fires.
+	const granted = await Promise.race([
+		requestPromise.then(() => true),
+		pollUntilGranted(checkPermissions),
+	]);
+
+	if (!granted) {
+		throw new Error('Camera permission not granted');
+	}
+}
+
+async function pollUntilGranted(
+	checkPermissions: () => Promise<string>,
+): Promise<boolean> {
+	const maxWaitMs = 30_000;
+	const intervalMs = 500;
+	const start = Date.now();
+
+	while (Date.now() - start < maxWaitMs) {
+		await new Promise((r) => setTimeout(r, intervalMs));
+		const state = await checkPermissions();
+		if (state === 'granted') return true;
+	}
+	return false;
 }
 
 export function scanQrFromImage(file: File): Promise<string> {

--- a/ui/src/lib/utils/qrcode.ts
+++ b/ui/src/lib/utils/qrcode.ts
@@ -37,7 +37,7 @@ async function ensureCameraPermission(
 	// Poll checkPermissions as a fallback — the OS grants the permission
 	// even if the plugin callback never fires.
 	const granted = await Promise.race([
-		requestPromise.then(() => true),
+		requestPromise.then(state => state === 'granted'),
 		pollUntilGranted(checkPermissions),
 	]);
 

--- a/ui/src/lib/utils/qrcode.ts
+++ b/ui/src/lib/utils/qrcode.ts
@@ -1,15 +1,17 @@
 import { isTauriEnv } from '$lib/utils/environment';
+import {
+	Format,
+	checkPermissions,
+	requestPermissions,
+	scan,
+} from '@tauri-apps/plugin-barcode-scanner';
 import jsQR from 'jsqr';
 
 export async function scanQrCode(): Promise<string> {
 	if (!isTauriEnv()) {
 		throw new Error('QR code scanning requires the Tauri desktop/mobile app');
 	}
-	const { Format, checkPermissions, requestPermissions, scan } = await import(
-		'@tauri-apps/plugin-barcode-scanner'
-	);
-
-	await ensureCameraPermission(checkPermissions, requestPermissions);
+	await ensureCameraPermission();
 
 	const result = await scan({ windowed: true, formats: [Format.QRCode] });
 	return result.content;
@@ -24,10 +26,7 @@ export async function scanQrCode(): Promise<string> {
  * If not granted, race `requestPermissions()` against a polling loop that
  * calls `checkPermissions()` until the permission is granted.
  */
-async function ensureCameraPermission(
-	checkPermissions: () => Promise<string>,
-	requestPermissions: () => Promise<string>,
-): Promise<void> {
+async function ensureCameraPermission(): Promise<void> {
 	const state = await checkPermissions();
 	if (state === 'granted') return;
 
@@ -38,7 +37,7 @@ async function ensureCameraPermission(
 	// even if the plugin callback never fires.
 	const granted = await Promise.race([
 		requestPromise.then(state => state === 'granted'),
-		pollUntilGranted(checkPermissions),
+		pollUntilGranted(),
 	]);
 
 	if (!granted) {
@@ -46,9 +45,7 @@ async function ensureCameraPermission(
 	}
 }
 
-async function pollUntilGranted(
-	checkPermissions: () => Promise<string>,
-): Promise<boolean> {
+async function pollUntilGranted(): Promise<boolean> {
 	const maxWaitMs = 30_000;
 	const intervalMs = 500;
 	const start = Date.now();

--- a/ui/src/lib/utils/qrcode.ts
+++ b/ui/src/lib/utils/qrcode.ts
@@ -54,7 +54,7 @@ async function pollUntilGranted(
 	const start = Date.now();
 
 	while (Date.now() - start < maxWaitMs) {
-		await new Promise((r) => setTimeout(r, intervalMs));
+		await new Promise(r => setTimeout(r, intervalMs));
 		const state = await checkPermissions();
 		if (state === 'granted') return true;
 	}

--- a/ui/src/lib/utils/qrcode.ts
+++ b/ui/src/lib/utils/qrcode.ts
@@ -31,7 +31,7 @@ async function ensureCameraPermission(): Promise<void> {
 	if (state === 'granted') return;
 
 	// Start the permission request (may hang due to plugin bug)
-	const requestPromise = requestPermissions().catch(() => {});
+	const requestPromise = requestPermissions().catch(() => 'denied' as string);
 
 	// Poll checkPermissions as a fallback — the OS grants the permission
 	// even if the plugin callback never fires.


### PR DESCRIPTION
https://github.com/dash-chat/dash-chat/pull/220 didn't fix the bug (it's still good to have it merged since we want the additional 3MB downloaded at app download time instead of the first time a QR code is scanned).

This PR works around a bug in the plugin that made it so that the `await requestPermissions()` never returned.