### PR TITLE
During setup, make it clearer how the user can complete the "chat colour" step

### DIFF
--- a/ui/src/lib/components/GetStarted.svelte
+++ b/ui/src/lib/components/GetStarted.svelte
@@ -74,7 +74,7 @@
 			id: 'chat-color',
 			label: () => m.chatColor(),
 			icon: mdiPalette,
-			href: '/settings/appearance',
+			href: '/settings/appearance?setup=true',
 			tone: 'warm',
 		},
 		{

--- a/ui/src/lib/components/GetStarted.svelte
+++ b/ui/src/lib/components/GetStarted.svelte
@@ -2,6 +2,7 @@
 	import '@awesome.me/webawesome/dist/components/icon/icon.js';
 	import { m } from '$lib/paraglide/messages.js';
 	import { wrapPathInSvg } from '$lib/utils/icon';
+	import { goto } from '$app/navigation';
 	import {
 		mdiAccountMultiplePlus,
 		mdiAccountPlus,
@@ -121,12 +122,20 @@
 	});
 
 	function dismiss(id: string) {
+		if (dismissed.includes(id)) return;
 		dismissed = [...dismissed, id];
 		try {
 			localStorage.setItem(DISMISSED_KEY, JSON.stringify(dismissed));
 		} catch (e) {
 			console.error('Failed to persist dismissed cards:', e);
 		}
+	}
+
+	function onCardClick(id: string, href: string) {
+		if (id === 'chat-color') {
+			dismiss(id);
+		}
+		goto(href);
 	}
 </script>
 
@@ -144,6 +153,10 @@
 					>
 						<a
 							href={card.href}
+							onclick={e => {
+								e.preventDefault();
+								onCardClick(card.id, card.href);
+							}}
 							class="flex flex-col items-center px-5 pb-5 pt-7"
 						>
 							<wa-icon src={wrapPathInSvg(card.icon)} style="font-size: 28px">

--- a/ui/src/routes/settings/appearance/+page.svelte
+++ b/ui/src/routes/settings/appearance/+page.svelte
@@ -5,11 +5,13 @@
 	import { m } from '$lib/paraglide/messages.js';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
 	import { useReactivePromise } from '$lib/stores/use-signal';
+	import { isIos } from '$lib/utils/environment';
 	import { type SettingsStore, type ColorScheme } from 'dash-chat-stores';
 	import { showToast } from '$lib/utils/toasts';
 	import {
 		Button,
 		BlockTitle,
+		Link,
 		List,
 		ListItem,
 		Navbar,
@@ -40,6 +42,14 @@
 					onClick={() => goto('/settings')}
 					data-testid="appearance-back"
 				/>
+			{/if}
+		{/snippet}
+
+		{#snippet right()}
+			{#if setup && isIos}
+				<Link onClick={() => goto('/')} data-testid="appearance-done-link">
+					{m.done()}
+				</Link>
 			{/if}
 		{/snippet}
 	</Navbar>
@@ -92,12 +102,12 @@
 			</div>
 		</div>
 
-		{#if setup}
+		{#if setup && !isIos}
 			<Button
 				onClick={() => goto('/')}
 				class="fixed-action-btn"
 				rounded
-				data-testid="appearance-done"
+				data-testid="appearance-done-btn"
 			>
 				{m.done()}
 			</Button>

--- a/ui/src/routes/settings/appearance/+page.svelte
+++ b/ui/src/routes/settings/appearance/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import { getContext } from 'svelte';
 	import { m } from '$lib/paraglide/messages.js';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
@@ -7,6 +8,7 @@
 	import { type SettingsStore, type ColorScheme } from 'dash-chat-stores';
 	import { showToast } from '$lib/utils/toasts';
 	import {
+		Button,
 		BlockTitle,
 		List,
 		ListItem,
@@ -19,6 +21,7 @@
 	const theme = $derived(useTheme());
 	const settingsStore: SettingsStore = getContext('settings-store');
 	const colorScheme = useReactivePromise(settingsStore.colorScheme);
+	const setup = $derived(page.url.searchParams.get('setup') === 'true');
 
 	async function select(scheme: ColorScheme) {
 		try {
@@ -88,5 +91,16 @@
 				</List>
 			</div>
 		</div>
+
+		{#if setup}
+			<Button
+				onClick={() => goto('/')}
+				class="fixed-action-btn"
+				rounded
+				data-testid="appearance-done"
+			>
+				{m.done()}
+			</Button>
+		{/if}
 	{/await}
 </Page>


### PR DESCRIPTION
When the user clicks on the setup tile for setting chat colour, the tile is cleared since it's assumed that they only need to see the setting screen to know it's an option, they don't need to actually change it.

The screen has a "done" button when there enter it in this way (not normally), which just takes them back home.