### PR TITLE
Don't autostart second agent

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,6 @@
 		"ui/.svelte-kit": true,
 		"ui/build": true,
 		"*.log": true
-	}
+	},
+	"tailwindCSS.lint.suggestCanonicalClasses": "ignore"
 }

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -3,7 +3,8 @@ procs:
     shell: pnpm tauri dev
   agent2:
     shell: pnpm tauri dev
-  mailbox-server: 
+    autostart: false
+  mailbox-server:
     shell: cargo run -p mailbox-server -- --db-path "$PWD/.dbs/dev/mailbox-server/mailbox.db" --addr 0.0.0.0:3000 --push-notifications-url http://localhost:3001
   push-notifications-server:
     shell: just push server


### PR DESCRIPTION
I find that when running mprocs, the majority of the time I don't want to test with two agents. I think it's a slight quality-of-life improvement to have the second agent not auto-start. It's simple to start it with a single keypress.

Obviously in this case I could just use 'pnpm tauri dev' instead, but then I get a lot of recurring warnings about the mailbox server not being started. Additionally, I like using mprocs because I can also start android and stuff from there.

Also in this PR, a slight tweak to VSCode specific settings to disable a linting warning that we're not currently auto-fixing. It is just annoying to see the error if we aren't planning to fix it. 