### PR TITLE
Fix timestamp handling

### DIFF
--- a/packages/stores/src/contacts/contacts-store.ts
+++ b/packages/stores/src/contacts/contacts-store.ts
@@ -76,7 +76,7 @@ export class ContactsStore {
 					op.body?.payload?.type === 'AddContact' &&
 					op.body.payload.payload.agent_id === agentId
 				) {
-					return op.header.timestamp * 1000;
+					return op.header.timestamp;
 				}
 			}
 		}
@@ -98,9 +98,9 @@ export class ContactsStore {
 				// Keep the latest rejection timestamp
 				if (
 					!existingTimestamp ||
-					op.header.timestamp * 1000 > existingTimestamp
+					op.header.timestamp > existingTimestamp
 				) {
-					rejected[agentId] = op.header.timestamp * 1000;
+					rejected[agentId] = op.header.timestamp;
 				}
 			}
 		}
@@ -136,14 +136,14 @@ export class ContactsStore {
 					const rejectionTimestamp = rejectedMap[agentId];
 					if (
 						rejectionTimestamp &&
-						operation.header.timestamp * 1000 < rejectionTimestamp
+						operation.header.timestamp < rejectionTimestamp
 					)
 						continue;
 
 					contactRequests.push({
 						...operation.body.payload.payload,
 						topicId,
-						timestamp: operation.header.timestamp * 1000,
+						timestamp: operation.header.timestamp,
 					});
 				}
 			}
@@ -170,7 +170,7 @@ export class ContactsStore {
 					if (operation.body?.type !== 'Inbox') continue;
 					if (operation.body.payload.payload.code.agent_id !== agentId)
 						continue;
-					const ts = operation.header.timestamp * 1000;
+					const ts = operation.header.timestamp;
 					if (!latest || ts > latest.timestamp) {
 						latest = {
 							timestamp: ts,

--- a/packages/stores/src/direct-chats/direct-chat-store.ts
+++ b/packages/stores/src/direct-chats/direct-chat-store.ts
@@ -62,7 +62,7 @@ export class DirectChatStore implements ReadMessagesStore {
 							hash: operation.hash,
 							content: body.payload.payload,
 							author,
-							timestamp: operation.header.timestamp * 1000,
+							timestamp: operation.header.timestamp,
 							reactions: {},
 						};
 					}

--- a/packages/stores/src/p2panda/logs-store.ts
+++ b/packages/stores/src/p2panda/logs-store.ts
@@ -22,7 +22,12 @@ export class LogsStore<PAYLOAD> {
 			const fetchAuthors = async () => {
 				const authors = await this.logsClient.getAuthorsForTopic(topicId);
 				const current = state.value;
-				if (current && current.length === authors.length && authors.every(a => current.includes(a))) return;
+				if (
+					current &&
+					current.length === authors.length &&
+					authors.every(a => current.includes(a))
+				)
+					return;
 				state.value = authors;
 			};
 			fetchAuthors();
@@ -63,7 +68,12 @@ export class LogsStore<PAYLOAD> {
 					if (author !== operation.header.public_key) return;
 
 					// We already have this operation
-					if (state.value?.find(op => op.header.seq_num === operation.header.seq_num)) return;
+					if (
+						state.value?.find(
+							op => op.header.seq_num === operation.header.seq_num,
+						)
+					)
+						return;
 
 					state.value = [...(state.value || []), operation];
 				},
@@ -82,7 +92,8 @@ export class LogsStore<PAYLOAD> {
 			authorsForTopic.map(author => this.logs(topicId, author)),
 		);
 
-		const logsForAllAuthors: Record<PublicKey, SimplifiedOperation<PAYLOAD>[]> = {};
+		const logsForAllAuthors: Record<PublicKey, SimplifiedOperation<PAYLOAD>[]> =
+			{};
 		for (let i = 0; i < authorsForTopic.length; i++) {
 			logsForAllAuthors[authorsForTopic[i]] = logs[i];
 		}

--- a/packages/stores/src/p2panda/simplified-types.ts
+++ b/packages/stores/src/p2panda/simplified-types.ts
@@ -10,7 +10,7 @@ export interface SimplifiedHeader {
 	/// Author of this operation.
 	public_key: PublicKey;
 
-	/// Time in microseconds since the Unix epoch.
+	/// Milliseconds since the Unix epoch (suitable for `new Date(ms)`).
 	timestamp: number;
 
 	/// Number of operations this author has published to this log, begins with 0 and is always

--- a/src-tauri/src/commands/logs.rs
+++ b/src-tauri/src/commands/logs.rs
@@ -1,7 +1,20 @@
 use dashchat_node::{topic::TopicId, DeviceId, Header, Node, Payload, Topic};
-use p2panda_core::{cbor::decode_cbor, Body, Hash, PublicKey};
-use serde::{Deserialize, Serialize};
+use p2panda_core::{cbor::decode_cbor, Body, Hash, PublicKey, Timestamp};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tauri::State;
+
+/// Serialize a `Timestamp` (microseconds) as milliseconds since the UNIX epoch
+/// so JS can pass it straight to `new Date(ms)`.
+fn serialize_timestamp_as_millis<S: Serializer>(ts: &Timestamp, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_u64(ts.as_micros() / 1_000)
+}
+
+fn deserialize_timestamp_from_millis<'de, D: Deserializer<'de>>(
+    d: D,
+) -> Result<Timestamp, D::Error> {
+    let millis = u64::deserialize(d)?;
+    Ok(Timestamp::new(millis * 1_000))
+}
 
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct SimplifiedOperation {
@@ -22,8 +35,12 @@ pub struct SimplifiedHeader {
     /// Author of this operation.
     public_key: PublicKey,
 
-    /// Time in microseconds since the Unix epoch.
-    timestamp: u64,
+    /// Milliseconds since the UNIX epoch when the operation was created.
+    #[serde(
+        serialize_with = "serialize_timestamp_as_millis",
+        deserialize_with = "deserialize_timestamp_from_millis"
+    )]
+    timestamp: Timestamp,
 
     /// Number of operations this author has published to this log, begins with 0 and is always
     /// incremented by 1 with each new operation by the same author.
@@ -46,7 +63,7 @@ impl From<Header> for SimplifiedHeader {
         let previous = header.extensions.dependencies();
         SimplifiedHeader {
             public_key: header.public_key,
-            timestamp: header.timestamp.as_micros(),
+            timestamp: header.timestamp,
             seq_num: header.seq_num,
             backlink: header.backlink,
             previous,


### PR DESCRIPTION
[This line](https://github.com/dash-chat/dash-chat/pull/190/changes#diff-79540ad51bb322a08c8841bd05bf80efdedd77e9b25aea3d0b7ecda290c63f89R49) broke timestamp handling in the UI. The UI expected seconds, but the backend was sending microseconds.

CI didn't catch it because the base branch for that PR was not `develop` or `main` at the time the latest commit in the `groups-sqlite` was made. That made it so that the E2E workflow didn't trigger, but other checks did and github presented the usual "All checks passed" green message, and this bug was merged unnoticed into `develop`. This explains the errors we've seeing in CI these past couple of days.

I'll be adding branch rules that prevent this from happening again, and adds necessary checks from CI before merging PRs into develop.

As far as this PR is concerned, it addresses root cause at the right level by serializing the timestamp type into milliseconds, which is what the UI expects.