### PR TITLE
Local notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -190,7 +190,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1845,6 +1845,7 @@ dependencies = [
  "anyhow",
  "app_dirs2",
  "async-trait",
+ "chrono",
  "dashchat-node",
  "dashchat-utils",
  "env_logger",
@@ -1882,6 +1883,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sonix-i18n",
+ "sqlx",
  "sysinfo",
  "tauri",
  "tauri-build",
@@ -1903,6 +1905,7 @@ dependencies = [
  "tauri-plugin-system-bars-styles",
  "tauri-plugin-updater",
  "tauri-plugin-virtual-keyboard-padding",
+ "tempfile",
  "time",
  "tokio",
  "url2",
@@ -2285,7 +2288,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2672,7 +2675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3917,7 +3920,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4023,12 +4026,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.5.3",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -5319,7 +5322,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5703,7 +5706,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -5745,7 +5748,7 @@ checksum = "ee91b05f4f3353290936ba1f3233518868fb4e2da99cb4c90d1f8cebb064e527"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -5788,7 +5791,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6592,7 +6595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8138,7 +8141,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8243,7 +8246,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8464,7 +8467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8889,22 +8892,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9838,7 +9831,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-notification"
 version = "2.3.3"
-source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#092cdc38115157dba4673ff534d536868b7e5f17"
+source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#5a86891aa12086cc0ec77a3257f552d61a084c89"
 dependencies = [
  "log",
  "notify-rust",
@@ -9859,7 +9852,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-notification-macros"
 version = "0.1.0"
-source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#092cdc38115157dba4673ff534d536868b7e5f17"
+source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#5a86891aa12086cc0ec77a3257f552d61a084c89"
 dependencies = [
  "jni 0.21.1",
  "libc",
@@ -9873,7 +9866,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-notification-models"
 version = "0.1.0"
-source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#092cdc38115157dba4673ff534d536868b7e5f17"
+source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#5a86891aa12086cc0ec77a3257f552d61a084c89"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -10127,7 +10120,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10704,7 +10697,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10785,7 +10778,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11491,7 +11484,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -74,6 +74,8 @@ app_dirs2 = "2.5.5"
 uuid = "1"
 serde = "1"
 serde_json = "1"
+sqlx = { version = "0.8.6", features = ["sqlite", "runtime-tokio"] }
+chrono = "0.4.42"
 sonix-i18n = "0.1.1"
 futures = "0.3"
 
@@ -116,3 +118,4 @@ e2e-tests = []
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+tempfile = "3"

--- a/src-tauri/src/filesystem.rs
+++ b/src-tauri/src/filesystem.rs
@@ -52,6 +52,7 @@ pub fn init_data_dir() {
 }
 
 const SETTINGS_FILE_NAME: &str = "settings.json";
+const NOTIFIED_OPERATIONS_DB_FILE_NAME: &str = "notified_operations.db";
 #[cfg(desktop)]
 const LOCAL_MAILBOX_DB_FILE_NAME: &str = "local-mailbox.redb";
 #[cfg(desktop)]
@@ -116,6 +117,13 @@ impl FileSystem {
 
     pub fn settings_path(&self) -> PathBuf {
         self.app_data_dir.join(SETTINGS_FILE_NAME)
+    }
+
+    /// SQLite database file backing the `NotifiedOperationsStore` — the
+    /// cross-process record of operations we've already surfaced a system
+    /// notification for.
+    pub fn notified_operations_db_path(&self) -> PathBuf {
+        self.app_data_dir.join(NOTIFIED_OPERATIONS_DB_FILE_NAME)
     }
 
     #[cfg(desktop)]

--- a/src-tauri/src/notifications/mod.rs
+++ b/src-tauri/src/notifications/mod.rs
@@ -1,2 +1,331 @@
+mod notified_operations_store;
 #[cfg(mobile)]
 pub mod push_notifications;
+
+pub(crate) use notified_operations_store::NotifiedOperationsStore;
+
+use anyhow::Context;
+use dashchat_node::{topic::TopicId, DeviceId, Header, Node, Payload, Topic};
+use tauri::{AppHandle, Manager};
+use tauri_plugin_notification::{NotificationData, NotificationExt, PermissionState};
+
+/// Returns `true` iff the user has both enabled notifications in app settings
+/// and granted OS-level permission. On desktop the permission state is always
+/// `Granted` so this collapses to the settings check.
+pub(crate) fn are_notifications_enabled(handle: &AppHandle) -> bool {
+    crate::settings::load_settings(handle).notifications_enabled
+        && matches!(
+            handle.notification().permission_state(),
+            Ok(PermissionState::Granted)
+        )
+}
+
+/// Show a system notification for an operation that arrived through the
+/// sync pipeline (local mailbox server, p2p sync). Mirrors the push-path
+/// behavior: same `NotificationData` shape, stable op-hash id,
+/// foreground-suppression handled by the plugin.
+pub(crate) async fn show_sync_notification(
+    app_handle: &AppHandle,
+    notification: &dashchat_node::Notification,
+) {
+    if !are_notifications_enabled(app_handle) {
+        return;
+    }
+
+    let store = app_handle.state::<NotifiedOperationsStore>();
+    match store
+        .record_notified_operation(notification.header.hash())
+        .await
+    {
+        Ok(false) => {
+            log::debug!("Skipping sync notification: op already notified");
+            return;
+        }
+        Ok(true) => {}
+        Err(err) => {
+            log::error!("Failed to record notified operation: {err:?} — proceeding anyway");
+        }
+    }
+
+    let node = app_handle.state::<Node>();
+    let topic_id = notification.header.extensions.topic;
+    let data = build_notification_data(
+        &node,
+        topic_id,
+        &notification.header,
+        Some(&notification.payload),
+    )
+    .await;
+
+    let Some(data) = data else { return };
+
+    if let Err(err) = show_notification_from_data(app_handle, data) {
+        log::error!("Failed to show sync-path notification: {err:?}");
+    }
+}
+
+fn show_notification_from_data(handle: &AppHandle, data: NotificationData) -> anyhow::Result<()> {
+    let mut builder = handle.notification().builder().id(data.id);
+    if let Some(title) = data.title {
+        builder = builder.title(title);
+    }
+    if let Some(body) = data.body {
+        builder = builder.body(body);
+    }
+    if let Some(icon) = data.icon {
+        builder = builder.icon(icon);
+    }
+    if let Some(group) = data.group {
+        builder = builder.group(group);
+    }
+    if let Some(route) = data.route {
+        builder = builder.route(route);
+    }
+    if data.messaging_style {
+        builder = builder.messaging_style();
+    }
+    builder.show()?;
+    Ok(())
+}
+
+/// Build the system notification for a freshly-processed p2panda operation.
+///
+/// Shared between the FCM/APNs entry point (`receive_push_notification`) and the
+/// foreground sync loop (`spawn_notification_loop` in `setup.rs`). Returns `None`
+/// when the op should not produce a user-facing notification (own message, payload
+/// variant we don't surface, etc.).
+pub async fn build_notification_data(
+    node: &Node,
+    topic_id: TopicId,
+    header: &Header,
+    payload: Option<&Payload>,
+) -> Option<NotificationData> {
+    let sender_device_id = DeviceId::from(header.public_key);
+    if sender_device_id == node.device_id() {
+        return None;
+    }
+
+    let id = match stable_notification_id(header.hash().as_bytes()) {
+        Ok(id) => id,
+        Err(err) => {
+            log::error!("Failed to derive stable notification id: {err:?}");
+            return None;
+        }
+    };
+
+    let Some(payload) = payload else {
+        return Some(auth_control_op_notification(node, sender_device_id, id).await);
+    };
+
+    match payload {
+        Payload::Chat(dashchat_node::ChatPayload::Message(content)) => {
+            Some(chat_message_notification(node, topic_id, sender_device_id, content, id).await)
+        }
+        Payload::Inbox(dashchat_node::InboxPayload::ContactRequest { code, profile }) => {
+            Some(NotificationData {
+                id,
+                title: Some(sonix_i18n::t!("newContactRequest")),
+                body: Some(profile.name.clone()),
+                icon: Some("ic_stat_icon".to_string()),
+                group: Some(hex::encode(&*topic_id)),
+                route: Some(format!("/direct-chats/{}", code.agent_id.to_hex())),
+                ..Default::default()
+            })
+        }
+        _ => None,
+    }
+}
+
+async fn chat_message_notification(
+    node: &Node,
+    topic_id: TopicId,
+    sender_device_id: DeviceId,
+    content: &dashchat_node::ChatMessageContent,
+    id: i32,
+) -> NotificationData {
+    let sender_agent_id = match node.lookup_contact(sender_device_id).await {
+        Ok(agent_id) => agent_id,
+        Err(err) => {
+            log::error!("Failed to lookup contact for sender {sender_device_id:?}: {err:?}");
+            None
+        }
+    };
+
+    let sender_name = if let Some(agent_id) = sender_agent_id {
+        node.local_store
+            .get_profile(agent_id)
+            .await
+            .ok()
+            .flatten()
+            .map(|profile| profile.name)
+    } else {
+        None
+    };
+
+    let title = sender_name.unwrap_or_else(|| sonix_i18n::t!("newMessage"));
+
+    let direct_chat_agent_id = sender_agent_id
+        .filter(|&agent_id| *Topic::direct_chat([node.agent_id(), agent_id]) == topic_id);
+    let chat_route = match direct_chat_agent_id {
+        Some(agent_id) => format!("/direct-chats/{}", agent_id.to_hex()),
+        None => format!("/group-chat/{}", hex::encode(&*topic_id)),
+    };
+    let message_text: &str = content.message();
+    let body_text = match message_text.char_indices().nth(200) {
+        Some((idx, _)) => format!("{}...", &message_text[..idx]),
+        None => message_text.to_string(),
+    };
+
+    #[cfg_attr(not(target_os = "android"), allow(unused_mut))]
+    let mut notification_data = NotificationData {
+        id,
+        title: Some(title),
+        body: Some(body_text),
+        icon: Some("ic_stat_icon".to_string()),
+        group: Some(hex::encode(&*topic_id)),
+        route: Some(chat_route),
+        ..Default::default()
+    };
+
+    // Android-only: collapse direct-chat messages into one MessagingStyle thread.
+    // The id must be stable per conversation so MessagingStyle accumulates the
+    // messages onto the same notification instead of stacking new ones.
+    //
+    // TODO: XOR the truncated topic id with a node-specific secret before
+    // using it as the notification id. As-is, the first 4 bytes of the topic
+    // id are public-derivable, so an adversary could mine a contact whose
+    // topic id shares a 4-byte LE prefix with an existing conversation and
+    // get their messages collapsed into the wrong MessagingStyle thread.
+    #[cfg(target_os = "android")]
+    if direct_chat_agent_id.is_some() {
+        match stable_notification_id(&*topic_id) {
+            Ok(id) => notification_data.id = id,
+            Err(err) => log::error!(
+                "Failed to derive Android MessagingStyle id from topic, falling back to random: {err:?}"
+            ),
+        }
+        notification_data.group = Some("dashchat.chats".to_string());
+        notification_data.messaging_style = true;
+    }
+
+    notification_data
+}
+
+/// Build the user-facing notification for a body-less p2panda auth/control op
+/// (GroupControl: Create/Add/Remove). These carry their data in the header's
+/// auth extension and have no body to decode.
+///
+/// Today this fires for *every* body-less op the NSE sees, and we surface them
+/// all as "contact request accepted" — the most common case (the auth Create
+/// the acceptor authors on a new direct chat space). It will misrepresent
+/// future group `Add`/`Remove` operations.
+///
+/// TODO: once Apple grants the
+/// `com.apple.developer.usernotifications.filtering` entitlement
+/// (https://developer.apple.com/contact/request/notification-service), delete
+/// this helper. The caller should return `None` for body-less ops, the NSE
+/// should call `contentHandler(UNMutableNotificationContent())`, and any cases
+/// that DO warrant a notification (real contact-request acceptance, group
+/// member changes) should be implemented by inspecting the auth extension —
+/// distinguishing Create from Add/Remove — instead of this catch-all.
+async fn auth_control_op_notification(
+    node: &Node,
+    sender_device_id: DeviceId,
+    id: i32,
+) -> NotificationData {
+    let sender_agent_id = node.lookup_contact(sender_device_id).await.ok().flatten();
+    let sender_name = match sender_agent_id {
+        Some(agent_id) => node
+            .local_store
+            .get_profile(agent_id)
+            .await
+            .ok()
+            .flatten()
+            .map(|profile| profile.name),
+        None => None,
+    };
+    let title = match &sender_name {
+        Some(name) => sonix_i18n::t!("contactRequestAccepted", { "name": name }),
+        None => sonix_i18n::t!("contactRequestAcceptedNoName"),
+    };
+    let route = sender_agent_id.map(|aid| format!("/direct-chats/{}", aid.to_hex()));
+    NotificationData {
+        id,
+        title: Some(title),
+        body: None,
+        icon: Some("ic_stat_icon".to_string()),
+        route,
+        ..Default::default()
+    }
+}
+
+#[cfg(mobile)]
+pub fn new_message_generic_notification() -> NotificationData {
+    NotificationData {
+        title: Some(sonix_i18n::t!("youHaveANewMessage")),
+        body: None,
+        icon: Some("ic_stat_icon".to_string()),
+        ..Default::default()
+    }
+}
+
+#[cfg(target_os = "ios")]
+pub fn synced_generic_notification() -> NotificationData {
+    NotificationData {
+        title: Some(sonix_i18n::t!("syncedWithServer")),
+        body: None,
+        icon: Some("ic_stat_icon".to_string()),
+        ..Default::default()
+    }
+}
+
+#[cfg(target_os = "ios")]
+pub fn may_have_new_messages_generic_notification() -> NotificationData {
+    NotificationData {
+        title: Some(sonix_i18n::t!("mayHaveNewMessages")),
+        body: None,
+        icon: Some("ic_stat_icon".to_string()),
+        ..Default::default()
+    }
+}
+
+/// Derive a stable 32-bit notification id from a 32-byte identifier — either
+/// an operation hash (per-op id; replaces on iOS / updates the same notif on
+/// Android) or a topic id (Android MessagingStyle, so successive messages
+/// accumulate into the same conversation thread). The first four bytes are
+/// interpreted as a little-endian i32.
+fn stable_notification_id(id_bytes: &[u8]) -> anyhow::Result<i32> {
+    let bytes: [u8; 4] = id_bytes
+        .get(..4)
+        .context("id_bytes is shorter than 4 bytes")?
+        .try_into()?;
+    Ok(i32::from_le_bytes(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stable_notification_id_uses_first_four_bytes_little_endian() {
+        let bytes = [0x01, 0x02, 0x03, 0x04, 0xff, 0xff, 0xff, 0xff];
+        assert_eq!(
+            stable_notification_id(&bytes).unwrap(),
+            i32::from_le_bytes([0x01, 0x02, 0x03, 0x04])
+        );
+    }
+
+    #[test]
+    fn stable_notification_id_is_stable_across_calls() {
+        let bytes = [0xAB; 32];
+        let a = stable_notification_id(&bytes).unwrap();
+        let b = stable_notification_id(&bytes).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn stable_notification_id_errors_on_short_input() {
+        assert!(stable_notification_id(&[]).is_err());
+        assert!(stable_notification_id(&[0x01, 0x02, 0x03]).is_err());
+    }
+}

--- a/src-tauri/src/notifications/notified_operations_store.rs
+++ b/src-tauri/src/notifications/notified_operations_store.rs
@@ -1,0 +1,162 @@
+use std::path::Path;
+use std::time::Duration;
+
+use sqlx::{
+    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions},
+    SqlitePool,
+};
+
+const MIGRATIONS: &[&str] = &["CREATE TABLE IF NOT EXISTS notified_operations (
+        hash BLOB PRIMARY KEY,
+        notified_at_nanos INTEGER NOT NULL
+    )"];
+
+/// App-level persistent record of operations that have already produced a
+/// user-facing notification. Both the FCM/APNs push path and the local-sync
+/// path consult it so the same op never produces two banners — important on
+/// Android where MessagingStyle would otherwise append the message twice into
+/// the same thread.
+#[derive(Clone)]
+pub struct NotifiedOperationsStore {
+    pool: SqlitePool,
+}
+
+impl NotifiedOperationsStore {
+    pub async fn open(db_path: &Path) -> anyhow::Result<Self> {
+        let opts = SqliteConnectOptions::new()
+            .filename(db_path)
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .busy_timeout(Duration::from_secs(30));
+        let pool = SqlitePoolOptions::new().connect_with(opts).await?;
+        for sql in MIGRATIONS {
+            sqlx::query(sql).execute(&pool).await?;
+        }
+        Ok(Self { pool })
+    }
+
+    /// Records that the operation identified by `hash` has had a notification
+    /// surfaced. Returns `true` iff this call inserted a new row (caller
+    /// should proceed to show); `false` means another path already showed it.
+    pub async fn record_notified_operation(
+        &self,
+        hash: p2panda_core::Hash,
+    ) -> anyhow::Result<bool> {
+        let now_nanos: i64 = chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default();
+        let result = sqlx::query(
+            "INSERT OR IGNORE INTO notified_operations (hash, notified_at_nanos) VALUES (?, ?)",
+        )
+        .bind(hash.as_bytes().to_vec())
+        .bind(now_nanos)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() == 1)
+    }
+
+    #[allow(dead_code)]
+    pub async fn has_notified_operation(&self, hash: p2panda_core::Hash) -> anyhow::Result<bool> {
+        let row: Option<(i64,)> =
+            sqlx::query_as("SELECT notified_at_nanos FROM notified_operations WHERE hash = ?")
+                .bind(hash.as_bytes().to_vec())
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.is_some())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash_from_byte(b: u8) -> p2panda_core::Hash {
+        p2panda_core::Hash::from_bytes([b; 32])
+    }
+
+    async fn temp_store() -> (tempfile::TempDir, NotifiedOperationsStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = NotifiedOperationsStore::open(&dir.path().join("notified_operations.db"))
+            .await
+            .unwrap();
+        (dir, store)
+    }
+
+    #[tokio::test]
+    async fn record_returns_true_then_false_for_same_op() {
+        let (_dir, store) = temp_store().await;
+        let hash = hash_from_byte(0xAB);
+        assert!(store.record_notified_operation(hash).await.unwrap());
+        assert!(!store.record_notified_operation(hash).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn record_distinct_ops_independently() {
+        let (_dir, store) = temp_store().await;
+        let a = hash_from_byte(0x01);
+        let b = hash_from_byte(0x02);
+        assert!(store.record_notified_operation(a).await.unwrap());
+        assert!(store.record_notified_operation(b).await.unwrap());
+        assert!(!store.record_notified_operation(a).await.unwrap());
+        assert!(!store.record_notified_operation(b).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn has_notified_reflects_record_outcome() {
+        let (_dir, store) = temp_store().await;
+        let hash = hash_from_byte(0x5A);
+        assert!(!store.has_notified_operation(hash).await.unwrap());
+        store.record_notified_operation(hash).await.unwrap();
+        assert!(store.has_notified_operation(hash).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn record_survives_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("notified_operations.db");
+        let hash = hash_from_byte(0x77);
+
+        let store = NotifiedOperationsStore::open(&path).await.unwrap();
+        assert!(store.record_notified_operation(hash).await.unwrap());
+        drop(store);
+
+        let store = NotifiedOperationsStore::open(&path).await.unwrap();
+        assert!(!store.record_notified_operation(hash).await.unwrap());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_records_for_same_op_produce_exactly_one_true() {
+        // Models the push-vs-sync race: both paths call record_notified_operation
+        // for the same op at roughly the same time; the contract is that exactly
+        // one of them sees `true` (and gets to show the banner).
+        //
+        // Requires multi-thread flavour: the default current-thread runtime
+        // interleaves spawned tasks cooperatively on one OS thread, which would
+        // pass even with strictly-serial execution. We also loop so any single
+        // iteration that fails to overlap doesn't mask a broken implementation.
+        const RACES: usize = 50;
+
+        let (_dir, store) = temp_store().await;
+
+        for i in 0..RACES {
+            let hash = p2panda_core::Hash::from_bytes([i as u8; 32]);
+            let store_a = store.clone();
+            let store_b = store.clone();
+            let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+            let barrier_a = barrier.clone();
+            let barrier_b = barrier.clone();
+            let a = tokio::spawn(async move {
+                barrier_a.wait().await;
+                store_a.record_notified_operation(hash).await.unwrap()
+            });
+            let b = tokio::spawn(async move {
+                barrier_b.wait().await;
+                store_b.record_notified_operation(hash).await.unwrap()
+            });
+            let a = a.await.unwrap();
+            let b = b.await.unwrap();
+            assert!(
+                a ^ b,
+                "race {i}: expected exactly one of the racing callers to see true, got a={a} b={b}"
+            );
+        }
+    }
+}

--- a/src-tauri/src/notifications/push_notifications/mod.rs
+++ b/src-tauri/src/notifications/push_notifications/mod.rs
@@ -9,6 +9,8 @@ use push_notifications_client::types::{FcmToken, PublicKey, TopicId as PushTopic
 use tauri::{AppHandle, Listener, Manager};
 use tauri_plugin_notification::*;
 
+use crate::notifications::are_notifications_enabled;
+
 mod node_cache;
 mod receive_push_notification;
 
@@ -104,8 +106,6 @@ pub fn setup_push_notifications(
 
     Ok(())
 }
-
-use crate::notifications::are_notifications_enabled;
 
 /// If notifications are currently enabled, get the FCM token and register it with the server
 /// If they're not, unregister the FCM token from the server

--- a/src-tauri/src/notifications/push_notifications/mod.rs
+++ b/src-tauri/src/notifications/push_notifications/mod.rs
@@ -105,13 +105,7 @@ pub fn setup_push_notifications(
     Ok(())
 }
 
-fn are_notifications_enabled(handle: &AppHandle) -> bool {
-    crate::settings::load_settings(handle).notifications_enabled
-        && matches!(
-            handle.notification().permission_state(),
-            Ok(PermissionState::Granted)
-        )
-}
+use crate::notifications::are_notifications_enabled;
 
 /// If notifications are currently enabled, get the FCM token and register it with the server
 /// If they're not, unregister the FCM token from the server

--- a/src-tauri/src/notifications/push_notifications/receive_push_notification.rs
+++ b/src-tauri/src/notifications/push_notifications/receive_push_notification.rs
@@ -1,14 +1,17 @@
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Context};
-use dashchat_node::{AsBody, Payload, Topic};
+use dashchat_node::{AsBody, Payload};
 #[cfg(target_os = "android")]
 use jni::objects::JClass;
 #[cfg(target_os = "android")]
 use jni::JNIEnv;
+#[cfg(target_os = "android")]
+use tauri::Manager;
 use tauri_plugin_notification::*;
 
 use crate::filesystem::FileSystem;
+use crate::notifications;
 
 #[cfg(target_os = "android")]
 use super::android::setup_android_logs;
@@ -29,6 +32,21 @@ pub fn receive_push_notification(
     notification: NotificationData,
     context: ReceivePushNotificationContext,
 ) -> Option<NotificationData> {
+    // When the main app is already alive its sync pipeline will handle this op via `show_sync_notification`.
+    // All we need to do is poke the live node so its mailbox sync picks up the op promptly.
+    //
+    // iOS doesn't hit this branch because the NSE runs in a separate process where `APP_HANDLE` is never set.
+    #[cfg(target_os = "android")]
+    if let Some(node) = crate::APP_HANDLE
+        .get()
+        .and_then(|h| h.try_state::<dashchat_node::Node>())
+    {
+        node.mailboxes
+            .wakeup(crate::mailbox::PRODUCTION_MAILBOX_ID.to_string());
+        log::info!("Push arrived while main app is alive; deferring to sync pipeline");
+        return None;
+    }
+
     crate::utils::install_crypto_provider();
 
     #[cfg(target_os = "android")]
@@ -63,7 +81,7 @@ pub fn receive_push_notification(
                     // TODO: apply for the exception to Apple that allows apps to not need to show a notification
                     // https://developer.apple.com/contact/request/notification-service
                     #[cfg(target_os = "ios")]
-                    return Some(synced_generic_notification());
+                    return Some(notifications::synced_generic_notification());
                 }
                 result
             }
@@ -73,7 +91,7 @@ pub fn receive_push_notification(
                 // raw APNS payload (topic_id as title, author:seq as body).
                 // Show a generic fallback so the user sees something readable.
                 #[cfg(target_os = "ios")]
-                return Some(may_have_new_messages_generic_notification());
+                return Some(notifications::may_have_new_messages_generic_notification());
                 #[cfg(not(target_os = "ios"))]
                 None
             }
@@ -156,175 +174,53 @@ async fn handle_push_notification(
         log::warn!(
             "Operation {op_id} in topic {topic_hex} not found after polling, showing generic notification"
         );
-        return Ok(Some(new_message_generic_notification()));
+        return Ok(Some(notifications::new_message_generic_notification()));
     };
-    let header = operation.header;
-    let body = operation.body;
 
-    // Don't show notifications for our own messages
-    let sender_device_id = dashchat_node::DeviceId::from(header.public_key);
-    if sender_device_id == node.device_id() {
-        return Ok(None);
-    }
-
-    let Some(body) = body else {
-        return Ok(Some(
-            auth_control_op_notification(&node, sender_device_id, op_id, topic_hex).await,
-        ));
-    };
-    let payload = Payload::try_from_body(&body)
-        .map_err(|err| anyhow!("failed to decode payload: {err:?}"))?;
-
-    match payload {
-        Payload::Chat(dashchat_node::ChatPayload::Message(content)) => {
-            // Resolve the sender's agent ID and profile name via the contacts table
-            let sender_agent_id = match node.lookup_contact(sender_device_id).await {
-                Ok(agent_id) => agent_id,
-                Err(err) => {
-                    log::error!(
-                        "Failed to lookup contact for sender {sender_device_id:?}: {err:?}"
-                    );
-                    None
-                }
-            };
-
-            let sender_name = if let Some(agent_id) = sender_agent_id {
-                node.local_store
-                    .get_profile(agent_id)
-                    .await
-                    .ok()
-                    .flatten()
-                    .map(|profile| profile.name)
-            } else {
-                None
-            };
-
-            let title = sender_name.unwrap_or_else(|| sonix_i18n::t!("newMessage"));
-
-            let direct_chat_agent_id = sender_agent_id
-                .filter(|&agent_id| *Topic::direct_chat([node.agent_id(), agent_id]) == topic_id);
-            let chat_route = match direct_chat_agent_id {
-                Some(agent_id) => format!("/direct-chats/{}", agent_id.to_hex()),
-                None => format!("/group-chat/{}", hex::encode(&*topic_id)),
-            };
-            let message_text: &str = content.message();
-            let body_text = match message_text.char_indices().nth(200) {
-                Some((idx, _)) => format!("{}...", &message_text[..idx]),
-                None => message_text.to_string(),
-            };
-
-            #[cfg_attr(not(target_os = "android"), allow(unused_mut))]
-            let mut notification_data = NotificationData {
-                title: Some(title),
-                body: Some(body_text),
-                icon: Some("ic_stat_icon".to_string()),
-                group: Some(hex::encode(&*topic_id)),
-                route: Some(chat_route),
-                ..Default::default()
-            };
-
-            // Android-only: reusing a stable id replaces notifications on iOS.
-            #[cfg(target_os = "android")]
-            if direct_chat_agent_id.is_some() {
-                // TODO: XOR with a node specific secret to avoid mining of topic IDs to cause collisions
-                notification_data.id =
-                    i32::from_le_bytes([topic_id[0], topic_id[1], topic_id[2], topic_id[3]]);
-                notification_data.group = Some("dashchat.chats".to_string());
-                notification_data.messaging_style = true;
+    let notified_operations_store = crate::notifications::NotifiedOperationsStore::open(
+        &filesystem.notified_operations_db_path(),
+    )
+    .await
+    .context("failed to open notified operations store")?;
+    match notified_operations_store
+        .record_notified_operation(operation.header.hash())
+        .await
+    {
+        Ok(false) => {
+            // On iOS the NSE must return some content; the main app's
+            // local notification has the same stable id, so iOS will
+            // collapse them into a single banner and the plugin's
+            // `willPresent` callback suppresses it when the user is on
+            // the notification's route.
+            #[cfg(not(target_os = "ios"))]
+            {
+                log::info!("Skipping push notification for op {op_id}: already notified");
+                return Ok(None);
             }
-
-            Ok(Some(notification_data))
+            #[cfg(target_os = "ios")]
+            log::info!("op {op_id} was already notified by the main app; building the same notification so iOS dedups by id");
         }
-        Payload::Inbox(dashchat_node::InboxPayload::ContactRequest { code, profile }) => {
-            Ok(Some(NotificationData {
-                title: Some(sonix_i18n::t!("newContactRequest")),
-                body: Some(profile.name),
-                icon: Some("ic_stat_icon".to_string()),
-                group: Some(topic_hex.to_string()),
-                route: Some(format!("/direct-chats/{}", code.agent_id.to_hex())),
-                ..Default::default()
-            }))
+        Ok(true) => {}
+        Err(err) => {
+            log::error!("Failed to record notified operation: {err:?} — proceeding anyway");
         }
-        _ => Ok(None),
     }
-}
 
-/// Build the user-facing notification for a body-less p2panda auth/control op
-/// (GroupControl: Create/Add/Remove). These carry their data in the header's
-/// auth extension and have no body to decode.
-///
-/// Today this fires for *every* body-less op the NSE sees, and we surface them
-/// all as "contact request accepted" — the most common case (the auth Create
-/// the acceptor authors on a new direct chat space). It will misrepresent
-/// future group `Add`/`Remove` operations.
-///
-/// TODO: once Apple grants the
-/// `com.apple.developer.usernotifications.filtering` entitlement
-/// (https://developer.apple.com/contact/request/notification-service), delete
-/// this helper. The caller should return `Ok(None)` for body-less ops, the NSE
-/// should call `contentHandler(UNMutableNotificationContent())`, and any cases
-/// that DO warrant a notification (real contact-request acceptance, group
-/// member changes) should be implemented by inspecting the auth extension —
-/// distinguishing Create from Add/Remove — instead of this catch-all.
-async fn auth_control_op_notification(
-    node: &dashchat_node::Node,
-    sender_device_id: dashchat_node::DeviceId,
-    op_id: &str,
-    topic_hex: &str,
-) -> NotificationData {
-    let sender_agent_id = node.lookup_contact(sender_device_id).await.ok().flatten();
-    let sender_name = match sender_agent_id {
-        Some(agent_id) => node
-            .local_store
-            .get_profile(agent_id)
-            .await
-            .ok()
-            .flatten()
-            .map(|profile| profile.name),
+    let payload = match operation.body.as_ref() {
+        Some(body) => Some(
+            Payload::try_from_body(body)
+                .map_err(|err| anyhow!("failed to decode payload: {err:?}"))?,
+        ),
         None => None,
     };
-    let title = match &sender_name {
-        Some(name) => sonix_i18n::t!("contactRequestAccepted", { "name": name }),
-        None => sonix_i18n::t!("contactRequestAcceptedNoName"),
-    };
-    let route = sender_agent_id.map(|aid| format!("/direct-chats/{}", aid.to_hex()));
-    log::info!(
-        "op {op_id} on topic {topic_hex} has no body (auth control op), delivering contact-request-accepted notification"
-    );
-    NotificationData {
-        title: Some(title),
-        body: None,
-        icon: Some("ic_stat_icon".to_string()),
-        route,
-        ..Default::default()
-    }
-}
 
-fn new_message_generic_notification() -> NotificationData {
-    NotificationData {
-        title: Some(sonix_i18n::t!("youHaveANewMessage")),
-        body: None,
-        icon: Some("ic_stat_icon".to_string()),
-        ..Default::default()
-    }
-}
-
-#[cfg(target_os = "ios")]
-fn synced_generic_notification() -> NotificationData {
-    NotificationData {
-        title: Some(sonix_i18n::t!("syncedWithServer")),
-        body: None,
-        icon: Some("ic_stat_icon".to_string()),
-        ..Default::default()
-    }
-}
-
-#[cfg(target_os = "ios")]
-fn may_have_new_messages_generic_notification() -> NotificationData {
-    NotificationData {
-        title: Some(sonix_i18n::t!("mayHaveNewMessages")),
-        body: None,
-        icon: Some("ic_stat_icon".to_string()),
-        ..Default::default()
-    }
+    Ok(
+        notifications::build_notification_data(
+            &node,
+            topic_id,
+            &operation.header,
+            payload.as_ref(),
+        )
+        .await,
+    )
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -5,13 +5,32 @@ use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Runtime};
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub(crate) struct Settings {
     pub local_mailbox_enabled: bool,
+    #[serde(default = "default_notifications_enabled")]
     pub notifications_enabled: bool,
     pub qr_color: Option<String>,
     pub color_scheme: Option<String>,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            local_mailbox_enabled: false,
+            notifications_enabled: default_notifications_enabled(),
+            qr_color: None,
+            color_scheme: None,
+        }
+    }
+}
+
+// On desktop the OS-level permission is always granted, so default the
+// app-level toggle to ON. On mobile the user has to grant permission
+// through the OS dialog, which we tie to flipping the toggle ON.
+const fn default_notifications_enabled() -> bool {
+    cfg!(desktop)
 }
 
 pub(crate) fn load_settings<R: Runtime>(handle: &AppHandle<R>) -> Settings {

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -44,6 +44,11 @@ pub async fn async_setup(app_handle: AppHandle) -> anyhow::Result<()> {
     let fs = FileSystem::new(&app_handle)?;
     let local_data_path = fs.app_data_dir().clone();
 
+    let notified_operations_store =
+        crate::notifications::NotifiedOperationsStore::open(&fs.notified_operations_db_path())
+            .await?;
+    app_handle.manage(notified_operations_store);
+
     #[cfg(not(mobile))]
     {
         app_handle.set_menu(crate::menu::build_menu(&app_handle)?)?;
@@ -156,7 +161,7 @@ fn spawn_notification_loop(
             };
             let simplified_operation = match simplify(
                 notification.header.hash(),
-                notification.header,
+                notification.header.clone(),
                 Some(Body::new(&body[..])),
             ) {
                 Ok(o) => o,
@@ -169,6 +174,8 @@ fn spawn_notification_loop(
             if let Err(err) = app_handle.emit("p2panda://new-operation", simplified_operation) {
                 log::error!("Failed to emit operation: {err:?}");
             }
+
+            crate::notifications::show_sync_notification(&app_handle, &notification).await;
 
             // Small delay between emissions to avoid overwhelming the WebKitGTK
             // event loop with rapid-fire events (which can freeze the webview).

--- a/ui/src/lib/components/layout/SettingsPanel.svelte
+++ b/ui/src/lib/components/layout/SettingsPanel.svelte
@@ -136,21 +136,19 @@
 					></wa-icon>
 				{/snippet}
 			</ListItem>
-			{#if isMobile}
-				<ListItem
-					link
-					class={isActive('/settings/notifications') ? 'active' : ''}
-					linkProps={{ href: '/settings/notifications' }}
-					data-testid="settings-notifications-link"
-					title={m.notifications()}
-					chevron={false}
-				>
-					{#snippet media()}
-						<wa-icon src={wrapPathInSvg(mdiBellOutline)} style="font-size: 28px"
-						></wa-icon>
-					{/snippet}
-				</ListItem>
-			{/if}
+			<ListItem
+				link
+				class={isActive('/settings/notifications') ? 'active' : ''}
+				linkProps={{ href: '/settings/notifications' }}
+				data-testid="settings-notifications-link"
+				title={m.notifications()}
+				chevron={false}
+			>
+				{#snippet media()}
+					<wa-icon src={wrapPathInSvg(mdiBellOutline)} style="font-size: 28px"
+					></wa-icon>
+				{/snippet}
+			</ListItem>
 		</List>
 
 		{#if !isMobile}


### PR DESCRIPTION
Fixes https://github.com/dash-chat/dash-chat/issues/283

- Plugin fork: route + MessagingStyle support and per-platform route-suppression in show.
- Sync-path notifications wired through show_sync_notification.
- NotifiedOperationsStore (SQLite) dedups push and sync; desktop notifications default ON.
