### PR TITLE
Explicit waitingForProfile flag in Avatar

### DIFF
--- a/ui/src/lib/components/profiles/Avatar.svelte
+++ b/ui/src/lib/components/profiles/Avatar.svelte
@@ -11,6 +11,7 @@
 	import type { Snippet } from 'svelte';
 
 	let {
+		waitingForProfile,
 		image,
 		initials,
 		alt,
@@ -18,6 +19,7 @@
 		id,
 		children,
 	}: {
+		waitingForProfile?: boolean | undefined;
 		image?: string | undefined;
 		initials?: string | undefined;
 		alt?: string | undefined;
@@ -41,7 +43,6 @@
 		const textAvatarStyle = `background-color: ${textAvatarData.sanitizedHexColor()}; color: ${TEXT_AVATAR_TEXT_COLOR};`;
 		return style ? `${style}; ${textAvatarStyle}` : textAvatarStyle;
 	});
-	const showPlaceholder = $derived(!avatarImage && !avatarInitials);
 </script>
 
 <span class="inline-block">
@@ -53,7 +54,7 @@
 		{alt}
 		shape="circle"
 	>
-		{#if showPlaceholder}
+		{#if waitingForProfile}
 			<wa-icon
 				slot="icon"
 				src={wrapPathInSvg(mdiAccountQuestion)}

--- a/ui/src/routes/direct-chats/[agentId]/+page.svelte
+++ b/ui/src/routes/direct-chats/[agentId]/+page.svelte
@@ -430,7 +430,7 @@
 												class="flex w-full min-w-0 flex-row items-center gap-2"
 											>
 												<span class="shrink-0">
-													<Avatar style="--size: 2.5rem" />
+													<Avatar waitingForProfile style="--size: 2.5rem" />
 												</span>
 												<span class="quiet flex-1 min-w-0 truncate">
 													{m.waitingForProfile()}
@@ -488,7 +488,7 @@
 										</Link>
 									{:else}
 										<div class="column my-6 gap-2 items-center">
-											<Avatar style="--size: 80px;" />
+											<Avatar waitingForProfile style="--size: 80px;" />
 											<span class="quiet text-xl">
 												{m.waitingForProfile()}
 											</span>

--- a/ui/src/routes/direct-chats/[agentId]/chat-settings/+page.svelte
+++ b/ui/src/routes/direct-chats/[agentId]/chat-settings/+page.svelte
@@ -99,7 +99,7 @@
 							>
 						{/if}
 					{:else}
-						<Avatar style="--size: 80px;" />
+						<Avatar waitingForProfile style="--size: 80px;" />
 						<span class="quiet text-xl">{m.waitingForProfile()}</span>
 					{/if}
 				</div>


### PR DESCRIPTION
Fixes an issue where the avatar selector in the create profile page would show the account+question mark icon, when it should show the account only icon. 