### PR TITLE
Fix group member profile in group chat page

### DIFF
--- a/crates/dashchat-node/tests/mailboxes.rs
+++ b/crates/dashchat-node/tests/mailboxes.rs
@@ -1,4 +1,3 @@
-
 use std::time::Duration;
 
 use dashchat_node::{mailbox::MailboxOperation, testing::*, *};

--- a/e2e-tests/helpers/pages/group-chat/group-chat-page.ts
+++ b/e2e-tests/helpers/pages/group-chat/group-chat-page.ts
@@ -40,7 +40,10 @@ export class GroupChatPage extends TestPage {
 				);
 				for (const wrapper of wrappers) {
 					if (wrapper.textContent?.includes(t)) {
-						return wrapper.querySelector('wa-avatar')?.getAttribute('initials') ?? null;
+						const avatar = wrapper.querySelector('wa-avatar') as
+							| (Element & { initials?: string })
+							| null;
+						return avatar?.initials || null;
 					}
 				}
 				return null;

--- a/e2e-tests/helpers/pages/group-chat/group-chat-page.ts
+++ b/e2e-tests/helpers/pages/group-chat/group-chat-page.ts
@@ -31,4 +31,22 @@ export class GroupChatPage extends TestPage {
 			{ timeout, timeoutMsg: `Message "${text}" not found` },
 		);
 	}
+
+	async getAuthorInitials(messageText: string): Promise<string | null> {
+		return this.agent.execute(
+			(sel: string, t: string) => {
+				const wrappers = document.querySelectorAll<HTMLElement>(
+					`${sel} [data-message-hash]`,
+				);
+				for (const wrapper of wrappers) {
+					if (wrapper.textContent?.includes(t)) {
+						return wrapper.querySelector('wa-avatar')?.getAttribute('initials') ?? null;
+					}
+				}
+				return null;
+			},
+			tid('group-chat-messages'),
+			messageText,
+		);
+	}
 }

--- a/e2e-tests/specs/groups/group-messages.spec.ts
+++ b/e2e-tests/specs/groups/group-messages.spec.ts
@@ -1,0 +1,50 @@
+import { exchangeContacts } from '../../helpers/flows/exchange-contacts';
+import { type Agent, setupAgent } from '../../setup/setup-agents';
+
+describe('Group messages', () => {
+	let agent1: Agent;
+	let agent2: Agent;
+
+	before(async () => {
+		[agent1, agent2] = await Promise.all([
+			setupAgent('agent1'),
+			setupAgent('agent2'),
+		]);
+		await agent1.enablePreviewFeatures();
+		await agent2.enablePreviewFeatures();
+		await agent1.createProfilePage.createProfile('Alice', 'Test');
+		await agent2.createProfilePage.createProfile('Bob', 'Test');
+		await exchangeContacts(agent1, agent2);
+		await agent1.directChatPage.back.click();
+		await agent2.directChatPage.back.click();
+		await agent1.homePage.ready();
+		await agent2.homePage.ready();
+
+		await agent1.homePage.newMessageButton.click();
+		await agent1.newMessagePage.ready();
+		await agent1.newMessagePage.newGroup.click();
+
+		await agent1.newGroupPage.addMembersStep.ready();
+		await agent1.newGroupPage.addMembersStep.addContactByName('Bob');
+		await agent1.newGroupPage.addMembersStep.nextButton.click();
+
+		await agent1.newGroupPage.groupInfoStep.ready();
+		await agent1.newGroupPage.groupInfoStep.createButton.click();
+
+		await agent1.groupChatPage.ready();
+	});
+
+	it('renders messages from other group members with their avatar', async () => {
+		await agent2.homePage.chatListItem('mygroup').waitForExist();
+		await agent2.homePage.chatListItem('mygroup').click();
+		await agent2.groupChatPage.ready();
+
+		await agent2.groupChatPage.sendMessage('Hello from Bob!');
+		await agent2.groupChatPage.waitForMessage('Hello from Bob!');
+
+		await agent1.groupChatPage.waitForMessage('Hello from Bob!');
+		expect(await agent1.groupChatPage.getAuthorInitials('Hello from Bob!')).toBe(
+			'Bo',
+		);
+	});
+});

--- a/e2e-tests/specs/groups/group-messages.spec.ts
+++ b/e2e-tests/specs/groups/group-messages.spec.ts
@@ -43,8 +43,11 @@ describe('Group messages', () => {
 		await agent2.groupChatPage.waitForMessage('Hello from Bob!');
 
 		await agent1.groupChatPage.waitForMessage('Hello from Bob!');
-		expect(await agent1.groupChatPage.getAuthorInitials('Hello from Bob!')).toBe(
-			'Bo',
+		await agent1.waitUntil(
+			async () =>
+				(await agent1.groupChatPage.getAuthorInitials('Hello from Bob!')) ===
+				'Bo',
+			{ timeoutMsg: 'Avatar initials "Bo" did not appear on Bob\'s message' },
 		);
 	});
 });

--- a/packages/stores/src/group-chats/group-chat-client.ts
+++ b/packages/stores/src/group-chats/group-chat-client.ts
@@ -1,15 +1,16 @@
 import { invoke } from '@tauri-apps/api/core';
 
-import { AgentId } from '../p2panda/types';
+import { AgentId, DeviceId } from '../p2panda/types';
 import { ChatId, MessageContent } from '../types';
 
-export interface GroupMemberData {
+export interface GroupMember {
 	agentId: AgentId;
+	deviceIds: DeviceId[];
 	isAdmin: boolean;
 }
 
 export interface IGroupChatClient {
-	getMembers(chatId: ChatId): Promise<GroupMemberData[]>;
+	getMembers(chatId: ChatId): Promise<GroupMember[]>;
 	addMember(chatId: ChatId, member: AgentId): Promise<void>;
 	removeMember(chatId: ChatId, member: AgentId): Promise<void>;
 
@@ -23,14 +24,8 @@ export interface IGroupChatClient {
 }
 
 export class GroupChatClient implements IGroupChatClient {
-	async getMembers(chatId: ChatId): Promise<GroupMemberData[]> {
-		const members: [AgentId, boolean][] = await invoke('get_group_members', {
-			chatId,
-		});
-		return members.map(([agentId, isAdmin]) => ({
-			agentId,
-			isAdmin,
-		}));
+	async getMembers(chatId: ChatId): Promise<GroupMember[]> {
+		return invoke('get_group_members', { chatId });
 	}
 
 	async addMember(chatId: ChatId, member: AgentId): Promise<void> {

--- a/packages/stores/src/group-chats/group-chat-store.ts
+++ b/packages/stores/src/group-chats/group-chat-store.ts
@@ -22,8 +22,9 @@ export interface GroupInfo {
 	avatar: string | undefined;
 }
 
-export interface GroupMember {
+export interface GroupMemberWithProfile {
 	agentId: AgentId;
+	devicesIds: DeviceId[];
 	profile: Profile | undefined;
 	admin: boolean;
 }
@@ -128,24 +129,38 @@ export class GroupChatStore {
 		const myAgentId = await this.contactsStore.myAgentId();
 		const data = await this.membersData();
 		const entry = data.find(m => m.agentId === myAgentId);
-		return this.buildMember(myAgentId, entry?.isAdmin ?? false);
+		return this.buildMember(
+			myAgentId,
+			entry?.deviceIds ?? [],
+			entry?.isAdmin ?? false,
+		);
 	});
 
 	allMembers = reactive(async () => {
 		const data = await this.membersData();
 		const entries = await Promise.all(
-			data.map(async ({ agentId, isAdmin }) => {
-				const member = await this.buildMember(agentId, isAdmin);
+			data.map(async ({ agentId, deviceIds, isAdmin }) => {
+				const member = await this.buildMember(agentId, deviceIds, isAdmin);
 				return [agentId, member] as const;
 			}),
 		);
-		return Object.fromEntries(entries) as Record<AgentId, GroupMember>;
+		return Object.fromEntries(entries) as Record<
+			AgentId,
+			GroupMemberWithProfile
+		>;
 	});
 
-	private buildMember = reactive(async (agentId: AgentId, admin: boolean) => {
-		const profile = await this.contactsStore.profiles(agentId);
-		return { agentId, profile, admin } satisfies GroupMember;
-	});
+	private buildMember = reactive(
+		async (agentId: AgentId, devices: DeviceId[], admin: boolean) => {
+			const profile = await this.contactsStore.profiles(agentId);
+			return {
+				agentId,
+				devicesIds: devices,
+				profile,
+				admin,
+			} satisfies GroupMemberWithProfile;
+		},
+	);
 
 	summary = reactive(async (): Promise<ChatSummary> => {
 		const info = await this.info();

--- a/packages/stores/src/group-chats/group-chat-store.ts
+++ b/packages/stores/src/group-chats/group-chat-store.ts
@@ -24,7 +24,7 @@ export interface GroupInfo {
 
 export interface GroupMemberWithProfile {
 	agentId: AgentId;
-	devicesIds: DeviceId[];
+	deviceIds: DeviceId[];
 	profile: Profile | undefined;
 	admin: boolean;
 }
@@ -151,11 +151,11 @@ export class GroupChatStore {
 	});
 
 	private buildMember = reactive(
-		async (agentId: AgentId, devices: DeviceId[], admin: boolean) => {
+		async (agentId: AgentId, deviceIds: DeviceId[], admin: boolean) => {
 			const profile = await this.contactsStore.profiles(agentId);
 			return {
 				agentId,
-				devicesIds: devices,
+				deviceIds,
 				profile,
 				admin,
 			} satisfies GroupMemberWithProfile;

--- a/packages/stores/src/mock/group-chat-client.ts
+++ b/packages/stores/src/mock/group-chat-client.ts
@@ -1,12 +1,12 @@
 import type {
-	GroupMemberData,
+	GroupMember,
 	IGroupChatClient,
 } from '../group-chats/group-chat-client';
 import type { AgentId, PublicKey } from '../p2panda/types';
 import type { ChatId, MessageContent } from '../types';
 
 export class MockGroupChatClient implements IGroupChatClient {
-	async getMembers(_chatId: ChatId): Promise<GroupMemberData[]> {
+	async getMembers(_chatId: ChatId): Promise<GroupMember[]> {
 		return [];
 	}
 	async addMember(_chatId: ChatId, _member: AgentId): Promise<void> {}

--- a/src-tauri/src/commands/chats.rs
+++ b/src-tauri/src/commands/chats.rs
@@ -1,7 +1,16 @@
-use dashchat_node::{AgentId, ChatId, ChatMessageContent, ChatReaction, Node};
+use dashchat_node::{AgentId, ChatId, ChatMessageContent, ChatReaction, DeviceId, Node};
 use p2panda_auth::{Access, AccessLevel};
 use p2panda_core::Hash;
+use serde::{Deserialize, Serialize};
 use tauri::State;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupMember {
+    pub agent_id: AgentId,
+    pub device_ids: Vec<DeviceId>,
+    pub is_admin: bool,
+}
 
 #[tauri::command]
 pub async fn create_group(
@@ -69,14 +78,15 @@ pub async fn get_group_chats(node: State<'_, Node>) -> Result<Vec<ChatId>, Strin
 pub async fn get_group_members(
     chat_id: ChatId,
     node: State<'_, Node>,
-) -> Result<Vec<(AgentId, bool)>, String> {
+) -> Result<Vec<GroupMember>, String> {
     let members = node
         .get_group_members(chat_id)
         .await
         .map_err(|e| format!("Failed to get group members: {e:?}"))?;
     let my_device_id = node.device_id();
     let my_agent_id = node.agent_id();
-    let mut result = Vec::with_capacity(members.len());
+    let mut grouped: std::collections::BTreeMap<AgentId, GroupMember> =
+        std::collections::BTreeMap::new();
     for (device_id, access) in members {
         let agent_id = if device_id == my_device_id {
             my_agent_id
@@ -90,7 +100,14 @@ pub async fn get_group_members(
                         .expect("DeviceId is a valid 32-byte key")
                 })
         };
-        result.push((agent_id, access.level >= AccessLevel::Manage));
+        let is_admin = access.level >= AccessLevel::Manage;
+        let entry = grouped.entry(agent_id).or_insert_with(|| GroupMember {
+            agent_id,
+            device_ids: Vec::new(),
+            is_admin: false,
+        });
+        entry.device_ids.push(device_id);
+        entry.is_admin = is_admin;
     }
-    Ok(result)
+    Ok(grouped.into_values().collect())
 }

--- a/src-tauri/src/commands/chats.rs
+++ b/src-tauri/src/commands/chats.rs
@@ -107,7 +107,7 @@ pub async fn get_group_members(
             is_admin: false,
         });
         entry.device_ids.push(device_id);
-        entry.is_admin = is_admin;
+        entry.is_admin |= is_admin;
     }
     Ok(grouped.into_values().collect())
 }

--- a/ui/src/lib/components/messages/MessageFromOthers.svelte
+++ b/ui/src/lib/components/messages/MessageFromOthers.svelte
@@ -81,7 +81,6 @@
 
 <style>
 	:global(.others-message) {
-		align-self: start;
 		margin: 0;
 		min-width: 0;
 		overflow-wrap: anywhere;

--- a/ui/src/routes/group-chat/[chatId]/+page.svelte
+++ b/ui/src/routes/group-chat/[chatId]/+page.svelte
@@ -113,17 +113,17 @@
 										/>
 									</div>
 								{:else}
+									{@const author = Object.values(members).find(m =>
+										m.devices.includes(message.author),
+									)}
 									<div
 										class="row items-end gap-2 self-start max-w-[85%]"
 										data-message-hash={hash}
 									>
 										{#if position === 'last' || position === 'single'}
 											<Avatar
-												image={members[message.author]?.profile?.avatar}
-												initials={members[message.author]?.profile?.name.slice(
-													0,
-													2,
-												)}
+												image={author?.profile?.avatar}
+												initials={author?.profile?.name.slice(0, 2)}
 												style="--size: 2.5rem"
 											/>
 										{:else}

--- a/ui/src/routes/group-chat/[chatId]/+page.svelte
+++ b/ui/src/routes/group-chat/[chatId]/+page.svelte
@@ -114,7 +114,7 @@
 									</div>
 								{:else}
 									{@const author = Object.values(members).find(m =>
-										m.devices.includes(message.author),
+										m.deviceIds.includes(message.author),
 									)}
 									<div
 										class="row items-end gap-2 self-start max-w-[85%]"


### PR DESCRIPTION
- Return a new `GroupMember` struct from the `get_group_members()` command. 
- Renamed `GroupMemberData` to `GroupMember` in the frontend.
- Renamed `GroupMember` to `GroupMemberWithProfile` in the frontend.
- Show the profile for the group member with the author's public key in the array of devices_ids.