### PR TITLE
Restore group member name on first message

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -72,6 +72,35 @@ wa-icon[slot='end'] {
 	color: #9ca3af;
 }
 
+:root {
+	--sender-color-0: #c92a39;
+	--sender-color-1: #a44b1a;
+	--sender-color-2: #805c00;
+	--sender-color-3: #4a781f;
+	--sender-color-4: #1f7a5e;
+	--sender-color-5: #156f8f;
+	--sender-color-6: #1f5fb6;
+	--sender-color-7: #4f3fa6;
+	--sender-color-8: #823f96;
+	--sender-color-9: #aa2f63;
+	--sender-color-10: #8c4824;
+	--sender-color-11: #4a5566;
+}
+.dark {
+	--sender-color-0: #ff7178;
+	--sender-color-1: #ff9a55;
+	--sender-color-2: #e6b04a;
+	--sender-color-3: #94c160;
+	--sender-color-4: #5dc9a5;
+	--sender-color-5: #5fc6e0;
+	--sender-color-6: #75a8f0;
+	--sender-color-7: #a094e8;
+	--sender-color-8: #c780d8;
+	--sender-color-9: #f870a0;
+	--sender-color-10: #d39062;
+	--sender-color-11: #98a8b8;
+}
+
 .dark-quiet {
 	color: var(--wa-color-neutral-80);
 }

--- a/ui/src/lib/components/messages/MessageFromOthers.svelte
+++ b/ui/src/lib/components/messages/MessageFromOthers.svelte
@@ -19,8 +19,7 @@
 		searchQuery,
 		onToggleReaction,
 		chatId,
-		senderName,
-		senderColor,
+		sender,
 	}: {
 		message: Message;
 		position: MessagePosition;
@@ -28,8 +27,7 @@
 		chatId: ChatId;
 		searchQuery: string;
 		onToggleReaction: (emoji: string) => void;
-		senderName?: string;
-		senderColor?: string;
+		sender?: { name: string; color: string };
 	} = $props();
 
 	const isLast = $derived(position === 'last' || position === 'single');
@@ -63,13 +61,13 @@
 	contentWrapPadding="p-2"
 	class={`message others-message ${position}-message ${isOfflineMessage ? 'offline-message' : ''}`}
 >
-	{#if senderName}
+	{#if sender}
 		<div
 			class="mx-1 mb-0.5 text-sm font-semibold text-start"
-			style="color: {senderColor}"
+			style="color: {sender.color}"
 			data-testid="group-message-sender-name"
 		>
-			{senderName}
+			{sender.name}
 		</div>
 	{/if}
 	<div class="row gap-2 mx-1" style="align-items: end">

--- a/ui/src/lib/components/messages/MessageFromOthers.svelte
+++ b/ui/src/lib/components/messages/MessageFromOthers.svelte
@@ -19,6 +19,8 @@
 		searchQuery,
 		onToggleReaction,
 		chatId,
+		senderName,
+		senderColor,
 	}: {
 		message: Message;
 		position: MessagePosition;
@@ -26,6 +28,8 @@
 		chatId: ChatId;
 		searchQuery: string;
 		onToggleReaction: (emoji: string) => void;
+		senderName?: string;
+		senderColor?: string;
 	} = $props();
 
 	const isLast = $derived(position === 'last' || position === 'single');
@@ -59,6 +63,15 @@
 	contentWrapPadding="p-2"
 	class={`message others-message ${position}-message ${isOfflineMessage ? 'offline-message' : ''}`}
 >
+	{#if senderName}
+		<div
+			class="mx-1 mb-0.5 text-sm font-semibold text-start"
+			style="color: {senderColor}"
+			data-testid="group-message-sender-name"
+		>
+			{senderName}
+		</div>
+	{/if}
 	<div class="row gap-2 mx-1" style="align-items: end">
 		<span class="flex-1">
 			{#if searchQuery}

--- a/ui/src/lib/components/messages/message-helpers.ts
+++ b/ui/src/lib/components/messages/message-helpers.ts
@@ -10,6 +10,16 @@ export function messagePosition(
 	return 'middle';
 }
 
+const SENDER_COLOR_COUNT = 12;
+
+export function senderColor(authorId: string): string {
+	let hash = 0;
+	for (let i = 0; i < authorId.length; i++) {
+		hash = (hash * 31 + authorId.charCodeAt(i)) >>> 0;
+	}
+	return `var(--sender-color-${hash % SENDER_COLOR_COUNT})`;
+}
+
 function escapeHtml(text: string): string {
 	return text
 		.replace(/&/g, '&amp;')

--- a/ui/src/routes/group-chat/[chatId]/+page.svelte
+++ b/ui/src/routes/group-chat/[chatId]/+page.svelte
@@ -22,7 +22,10 @@
 	import MessageInput from '$lib/components/MessageInput.svelte';
 	import ReverseScrollPage from '$lib/components/ReverseScrollPage.svelte';
 	import ScrollToBottomButton from '$lib/components/messages/ScrollToBottomButton.svelte';
-	import { messagePosition } from '$lib/components/messages/message-helpers';
+	import {
+		messagePosition,
+		senderColor,
+	} from '$lib/components/messages/message-helpers';
 	import { showToast } from '$lib/utils/toasts';
 	import { m } from '$lib/paraglide/messages';
 
@@ -204,6 +207,8 @@
 										{@const author = Object.values(members).find(m =>
 											m.deviceIds.includes(message.author),
 										)}
+										{@const showSender =
+											position === 'first' || position === 'single'}
 										<div
 											class="row items-end gap-2 self-start max-w-[85%]"
 											data-message-hash={hash}
@@ -227,6 +232,12 @@
 												{chatId}
 												searchQuery=""
 												onToggleReaction={() => {}}
+												senderName={showSender
+													? author?.profile?.name
+													: undefined}
+												senderColor={showSender
+													? senderColor(message.author)
+													: undefined}
 											/>
 										</div>
 									{/if}

--- a/ui/src/routes/group-chat/[chatId]/+page.svelte
+++ b/ui/src/routes/group-chat/[chatId]/+page.svelte
@@ -207,8 +207,6 @@
 										{@const author = Object.values(members).find(m =>
 											m.deviceIds.includes(message.author),
 										)}
-										{@const showSender =
-											position === 'first' || position === 'single'}
 										<div
 											class="row items-end gap-2 self-start max-w-[85%]"
 											data-message-hash={hash}
@@ -232,11 +230,13 @@
 												{chatId}
 												searchQuery=""
 												onToggleReaction={() => {}}
-												senderName={showSender
-													? author?.profile?.name
-													: undefined}
-												senderColor={showSender
-													? senderColor(message.author)
+												sender={(position === 'first' ||
+													position === 'single') &&
+												author?.profile?.name
+													? {
+															name: author.profile.name,
+															color: senderColor(message.author),
+														}
 													: undefined}
 											/>
 										</div>


### PR DESCRIPTION
Re-applies the changes from PR #317 (`fix/add-name-to-other-member-message`), which were merged into the `fix/group-chat-unread-messages` branch *after* PR #316 had already been merged into `develop`. As a result those commits never reached `develop` and the sender name in `MessageFromOthers` was silently lost on the group chat route.

Cherry-picks:
- `bdc1d68e` — Add group member name to their first message
- `63043537` — Unify sender prop

Conflict resolved in `ui/src/routes/group-chat/[chatId]/+page.svelte` to preserve the current 2-letter / 2rem avatar styling (unrelated change introduced after PR #317).