### PR TITLE
Fix iOS build: bump notification plugin macOS target to 10.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -201,7 +201,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2307,7 +2307,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2694,7 +2694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4021,7 +4021,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
+ "windows-registry 0.5.3",
 ]
 
 [[package]]
@@ -5361,7 +5361,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5832,7 +5832,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6636,7 +6636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8233,7 +8233,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8338,7 +8338,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8544,7 +8544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8989,7 +8989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-notification"
 version = "2.3.3"
-source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#fbc217dd6b68a47219471edc2f7fe52aae268d80"
+source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#e2dc06ab50a5275c7f1968a171f9708a2b7a2f80"
 dependencies = [
  "log",
  "notify-rust",
@@ -9945,7 +9945,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-notification-macros"
 version = "0.1.0"
-source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#fbc217dd6b68a47219471edc2f7fe52aae268d80"
+source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#e2dc06ab50a5275c7f1968a171f9708a2b7a2f80"
 dependencies = [
  "jni 0.21.1",
  "libc",
@@ -9959,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-notification-models"
 version = "0.1.0"
-source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#fbc217dd6b68a47219471edc2f7fe52aae268d80"
+source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#e2dc06ab50a5275c7f1968a171f9708a2b7a2f80"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -10213,7 +10213,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10790,7 +10790,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10871,7 +10871,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11552,7 +11552,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2046,7 +2046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3910,7 +3910,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -8984,16 +8984,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
@@ -9934,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-notification"
 version = "2.3.3"
-source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#6d8519f28c8a02aebd236e9ab1b4fcba8a7cd42f"
+source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#fbc217dd6b68a47219471edc2f7fe52aae268d80"
 dependencies = [
  "log",
  "notify-rust",
@@ -9955,7 +9945,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-notification-macros"
 version = "0.1.0"
-source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#6d8519f28c8a02aebd236e9ab1b4fcba8a7cd42f"
+source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#fbc217dd6b68a47219471edc2f7fe52aae268d80"
 dependencies = [
  "jni 0.21.1",
  "libc",
@@ -9969,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-notification-models"
 version = "0.1.0"
-source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#6d8519f28c8a02aebd236e9ab1b4fcba8a7cd42f"
+source = "git+https://github.com/guillemcordoba/plugins-workspace?branch=push-notifications#fbc217dd6b68a47219471edc2f7fe52aae268d80"
 dependencies = [
  "rand 0.8.6",
  "serde",

--- a/src-tauri/src/notifications/mod.rs
+++ b/src-tauri/src/notifications/mod.rs
@@ -87,7 +87,7 @@ fn show_notification_from_data(handle: &AppHandle, data: NotificationData) -> an
     }
     builder = builder.sound(data.sound.unwrap_or_else(|| "default".to_string()));
     if let Some(style) = data.conversation_style {
-        builder = builder.conversation_style(style.sender_id);
+        builder = builder.conversation_style(style);
     }
     builder.show()?;
     Ok(())

--- a/src-tauri/src/notifications/mod.rs
+++ b/src-tauri/src/notifications/mod.rs
@@ -226,6 +226,7 @@ async fn chat_message_notification(
         notification_data.group = Some("dashchat.chats".to_string());
         notification_data.conversation_style = Some(tauri_plugin_notification::ConversationStyle {
             sender_id: sender_id_hex.clone(),
+            conversation_title: None,
         });
     }
 
@@ -236,6 +237,7 @@ async fn chat_message_notification(
     {
         notification_data.conversation_style = Some(tauri_plugin_notification::ConversationStyle {
             sender_id: sender_id_hex,
+            conversation_title: None,
         });
     }
 


### PR DESCRIPTION
## Summary
- Firebase iOS SDK transitively pulls a `nanopb` version that now requires macOS 10.15. The `tauri-plugin-notification` fork's `Package.swift` declared `macOS 10.13`, so SPM rejected the build with errors like `the library 'FirebaseMessaging' requires macos 10.13, but depends on the product 'nanopb' which requires macos 10.15`.
- Bumped the fork's `Package.swift` to `.macOS(.v10_15)` (`iOS(.v13)` unchanged) and points the dash-chat lockfile at that fix.
- The notification-plugin fork's branch also picked up an unrelated builder-API change in intermediate commits — `conversation_style(...)` now takes the full `ConversationStyle` struct instead of just `style.sender_id`. Updated the one call site in `src-tauri/src/notifications/mod.rs` to match.

## Test plan
- [ ] iOS build CI passes on this branch
- [ ] Notifications still work on iOS / Android (manual smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)