### PR TITLE
Outline the contact-code input so it reads on white pages

### DIFF
--- a/ui/src/lib/components/layout/AddContactPanel.svelte
+++ b/ui/src/lib/components/layout/AddContactPanel.svelte
@@ -261,6 +261,7 @@
 								<List
 									nested
 									strongIos
+									outline
 									inset={isWideScreen.value || theme === 'ios'}
 								>
 									<ListInput


### PR DESCRIPTION
Desktop pages became white surfaces in bc9763b6/a41d3d42, which made the strong list card around the "Enter your contact's code" input invisible (white card on white page). Use Konsta's built-in `List outline` prop so the box keeps a visible border: `border-black/20` in light, `border-white/15` in dark (Konsta's own outline tokens), hairlines in the non-inset material layout.

Other strong list cards on content pages (group info, account, edit-name) may want the same treatment — this PR only covers the reported one.

Verified live in both themes and modes. `pnpm check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)