### PR TITLE
Preserve newlines in message bubbles

### DIFF
--- a/e2e-tests/helpers/pages/direct-chats/direct-chat-page.ts
+++ b/e2e-tests/helpers/pages/direct-chats/direct-chat-page.ts
@@ -81,6 +81,35 @@ export class DirectChatPage extends TestPage {
 		}, tid('message-status'));
 	}
 
+	/**
+	 * Inspect how the bubble text containing `text` is rendered: its computed
+	 * `white-space` and how many line boxes it occupies. Used to assert that
+	 * embedded newlines (Shift+Enter) are preserved rather than collapsed.
+	 */
+	renderedMessageLineInfo(
+		text: string,
+	): Promise<{ whiteSpace: string; lineBoxes: number } | null> {
+		return this.agent.execute(
+			(sel: string, t: string) => {
+				const container = document.querySelector(sel);
+				if (!container) return null;
+				const spans = Array.from(
+					container.querySelectorAll<HTMLElement>('span.flex-1'),
+				);
+				const span = spans.find(s => (s.textContent ?? '').includes(t));
+				if (!span) return null;
+				const range = document.createRange();
+				range.selectNodeContents(span);
+				return {
+					whiteSpace: getComputedStyle(span).whiteSpace,
+					lineBoxes: range.getClientRects().length,
+				};
+			},
+			tid('direct-chat-messages'),
+			text,
+		);
+	}
+
 	scrollBottomButtonVisible(): Promise<boolean> {
 		return this.scrollBottom.isExisting();
 	}

--- a/e2e-tests/specs/send-messages.spec.ts
+++ b/e2e-tests/specs/send-messages.spec.ts
@@ -32,4 +32,14 @@ describe('Full messaging flow', () => {
 		await agent2.directChatPage.waitForMessage('Hello from Bob!');
 		await agent1.directChatPage.waitForMessage('Hello from Bob!');
 	});
+
+	it('preserves line breaks in a multi-line message', async () => {
+		await agent1.directChatPage.sendMessage('first line\nsecond line');
+		await agent1.directChatPage.waitForMessage('second line');
+		const info =
+			await agent1.directChatPage.renderedMessageLineInfo('first line');
+		expect(info).not.toBe(null);
+		expect(info!.whiteSpace).toBe('pre-wrap');
+		expect(info!.lineBoxes).toBeGreaterThanOrEqual(2);
+	});
 });

--- a/ui/src/lib/components/messages/MessageFromMe.svelte
+++ b/ui/src/lib/components/messages/MessageFromMe.svelte
@@ -72,7 +72,7 @@
 	{/if}
 	{#if message.content.message || isLast}
 		<div class="row gap-2 mx-1" style="align-items: end">
-			<span class="flex-1">
+			<span class="flex-1 whitespace-pre-wrap">
 				{#if searchQuery}
 					{@html highlightMatch(message.content.message, searchQuery)}
 				{:else}

--- a/ui/src/lib/components/messages/MessageFromOthers.svelte
+++ b/ui/src/lib/components/messages/MessageFromOthers.svelte
@@ -86,7 +86,7 @@
 	{/if}
 	{#if message.content.message || isLast}
 		<div class="row gap-2 mx-1" style="align-items: end">
-			<span class="flex-1">
+			<span class="flex-1 whitespace-pre-wrap">
 				{#if searchQuery}
 					{@html highlightMatch(message.content.message, searchQuery)}
 				{:else}


### PR DESCRIPTION
## What

Shift+Enter already inserts a newline into the composer textarea, but the message bubble text spans had no `white-space` rule, so newlines collapsed to spaces on render. This adds `whitespace-pre-wrap` to the message text span in `MessageFromMe.svelte` and `MessageFromOthers.svelte`.

- `overflow-wrap: anywhere` is inherited from the bubble, so long unbroken strings still break.
- Scoped to the text span (not the whole bubble) so timestamp/media rows are unaffected.
- Chat-list previews use `truncate` (nowrap) — confirmed unaffected.

## Why stacked on #356

These components use the `message.content.message` shape introduced by #356 (`Message.content` went `string → { message, media }`), so this stacks on `claude/refine-local-plan-q7h8no` rather than `develop`.

## Verification

- `pnpm check` (ui) and `tsc` (e2e) clean.
- Live in the running app: sent `first line\nsecond line` Alice→Bob; both the sender (`MessageFromMe`) and receiver (`MessageFromOthers`) bubbles render two lines with computed `white-space: pre-wrap`; chat-list preview stays single-line.
- Adds an e2e case asserting the rendered text occupies ≥2 line boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)