### PR TITLE
Add Signal-style "Read more" truncation for long messages

### DIFF
--- a/e2e-tests/helpers/pages/direct-chats/direct-chat-page.ts
+++ b/e2e-tests/helpers/pages/direct-chats/direct-chat-page.ts
@@ -31,6 +31,7 @@ export class DirectChatPage extends TestPage {
 	messageStatus = this.agent.$(tid('message-status'));
 	sendButton = this.agent.$(tid('message-input-send'));
 	mediaPreview = this.agent.$(tid('message-input-media-preview'));
+	readMore = this.agent.$(tid('message-read-more'));
 	composer = new Composer(this.agent);
 	connectionStatusIndicator = new ConnectionStatusIndicator(this.agent);
 	scroll = new ReverseScrollPage(this.agent, 'direct-chat-scroll');
@@ -105,6 +106,16 @@ export class DirectChatPage extends TestPage {
 					lineBoxes: range.getClientRects().length,
 				};
 			},
+			tid('direct-chat-messages'),
+			text,
+		);
+	}
+
+	/** Whether the rendered message area currently contains `text`. */
+	messageAreaContains(text: string): Promise<boolean> {
+		return this.agent.execute(
+			(sel: string, t: string) =>
+				document.querySelector(sel)?.textContent?.includes(t) ?? false,
 			tid('direct-chat-messages'),
 			text,
 		);

--- a/e2e-tests/specs/send-messages.spec.ts
+++ b/e2e-tests/specs/send-messages.spec.ts
@@ -42,4 +42,16 @@ describe('Full messaging flow', () => {
 		expect(info!.whiteSpace).toBe('pre-wrap');
 		expect(info!.lineBoxes).toBeGreaterThanOrEqual(2);
 	});
+
+	it('truncates a long message and reveals it on Read more', async () => {
+		const long = `${'A'.repeat(900)} TAIL_MARKER ${'B'.repeat(100)}`;
+		await agent1.directChatPage.sendMessage(long);
+		await agent1.directChatPage.readMore.waitForExist();
+		// The hidden tail is not rendered until expanded.
+		expect(await agent1.directChatPage.messageAreaContains('TAIL_MARKER')).toBe(
+			false,
+		);
+		await agent1.directChatPage.readMore.click();
+		await agent1.directChatPage.waitForMessage('TAIL_MARKER');
+	});
 });

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -138,6 +138,7 @@
 	"contactRequestAccepted": "{{name}} has accepted your contact request",
 	"contactRequestAcceptedNoName": "Your contact request was accepted",
 	"typeMessage": "Type a message...",
+	"readMore": "Read more",
 	"attachPhotos": "Photos",
 	"attachFile": "File",
 	"attachMenu": "Attach",

--- a/ui/src/lib/components/messages/MessageBody.svelte
+++ b/ui/src/lib/components/messages/MessageBody.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import { m } from '$lib/paraglide/messages.js';
+	import { highlightMatch } from './message-helpers';
+
+	interface Props {
+		text: string;
+		searchQuery?: string;
+	}
+
+	let { text, searchQuery = '' }: Props = $props();
+
+	// Signal-Desktop "read more" truncation constants.
+	const INITIAL_LENGTH = 800;
+	const INCREMENT_COUNT = 3000;
+	const BUFFER = 100;
+
+	const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+
+	let displayLimit = $state(INITIAL_LENGTH);
+
+	const trimmed = $derived(text.trimEnd());
+	const graphemes = $derived(
+		Array.from(segmenter.segment(trimmed), s => s.segment),
+	);
+	// Keep the whole message when only a short tail (<= BUFFER) would be hidden.
+	const truncated = $derived(graphemes.length > displayLimit + BUFFER);
+	const shown = $derived(
+		truncated ? graphemes.slice(0, displayLimit).join('') : trimmed,
+	);
+
+	function expand() {
+		displayLimit += INCREMENT_COUNT;
+	}
+</script>
+
+<span class="flex-1 whitespace-pre-wrap"
+	>{#if searchQuery}{@html highlightMatch(
+			shown,
+			searchQuery,
+		)}{:else}{shown}{/if}{#if truncated}{'… '}<button
+			type="button"
+			class="read-more"
+			data-testid="message-read-more"
+			onclick={expand}>{m.readMore()}</button
+		>{/if}</span
+>
+
+<style>
+	.read-more {
+		padding: 0;
+		border: none;
+		background: transparent;
+		color: inherit;
+		font: inherit;
+		font-weight: 700;
+		cursor: pointer;
+	}
+</style>

--- a/ui/src/lib/components/messages/MessageFromMe.svelte
+++ b/ui/src/lib/components/messages/MessageFromMe.svelte
@@ -6,11 +6,12 @@
 		MailboxTrackerStore,
 		Message,
 	} from 'dash-chat-stores';
-	import { highlightMatch, type MessagePosition } from './message-helpers';
+	import { type MessagePosition } from './message-helpers';
 	import MessageTimestamp from './MessageTimestamp.svelte';
 	import Reactions from './Reactions.svelte';
 	import MessageStatusIndicator from '$lib/components/messages/MessageStatusIndicator.svelte';
 	import MessageAttachment from './MessageAttachment.svelte';
+	import MessageBody from './MessageBody.svelte';
 	import { m } from '$lib/paraglide/messages.js';
 	import { useReactiveValue } from '$lib/stores/use-signal';
 	import { getContext } from 'svelte';
@@ -72,13 +73,7 @@
 	{/if}
 	{#if message.content.message || isLast}
 		<div class="row gap-2 mx-1" style="align-items: end">
-			<span class="flex-1 whitespace-pre-wrap">
-				{#if searchQuery}
-					{@html highlightMatch(message.content.message, searchQuery)}
-				{:else}
-					{message.content.message}
-				{/if}
-			</span>
+			<MessageBody text={message.content.message} {searchQuery} />
 
 			{#if isLast}
 				<div class="flex items-center gap-1">

--- a/ui/src/lib/components/messages/MessageFromOthers.svelte
+++ b/ui/src/lib/components/messages/MessageFromOthers.svelte
@@ -6,10 +6,11 @@
 		MailboxTrackerStore,
 		Message,
 	} from 'dash-chat-stores';
-	import { highlightMatch, type MessagePosition } from './message-helpers';
+	import { type MessagePosition } from './message-helpers';
 	import MessageTimestamp from './MessageTimestamp.svelte';
 	import Reactions from './Reactions.svelte';
 	import MessageAttachment from './MessageAttachment.svelte';
+	import MessageBody from './MessageBody.svelte';
 	import { useReactiveValue } from '$lib/stores/use-signal';
 	import { getContext } from 'svelte';
 
@@ -86,13 +87,7 @@
 	{/if}
 	{#if message.content.message || isLast}
 		<div class="row gap-2 mx-1" style="align-items: end">
-			<span class="flex-1 whitespace-pre-wrap">
-				{#if searchQuery}
-					{@html highlightMatch(message.content.message, searchQuery)}
-				{:else}
-					{message.content.message}
-				{/if}
-			</span>
+			<MessageBody text={message.content.message} {searchQuery} />
 
 			{#if isLast}
 				<MessageTimestamp timestamp={message.timestamp} class="quiet" />


### PR DESCRIPTION
## What

Long messages now truncate Signal-Desktop style: at **800** graphemes (`INITIAL_LENGTH`), with an inline bold **Read more** that reveals **3000** more per click (`INCREMENT_COUNT`), keeping the whole message when only a short tail (≤ **100**, the `BUFFER`) would be hidden.

- New `MessageBody.svelte` owns the message text span (`flex-1 whitespace-pre-wrap`).
- Grapheme-aware slicing via `Intl.Segmenter` so emoji / combining marks aren't split mid-character.
- **Search highlighting is applied *after* slicing the raw text** — never to the escaped/`<mark>`'d HTML — so truncation can't cut inside an entity or tag.
- `whitespace-pre-wrap` preserved on the body root, so the line-break fix still holds.

## Stacking

Stacked on `message-linebreaks` (#359), which is itself stacked on #356. Base here is `message-linebreaks`.

## Verification

- `pnpm check` (ui) + `tsc` (e2e) clean.
- Live in the running app: a ~1000-char message renders truncated with a bold "Read more" (font-weight 700) and the hidden tail is **absent from the DOM**; clicking reveals the full text and removes the button. Multi-line messages still render across lines (`pre-wrap` preserved). Short messages are unchanged, so search highlighting is identical to before for them.
- e2e: sends a >900-char message, asserts the tail isn't rendered, clicks Read more, asserts the tail appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)