### PR TITLE
Polish composer to match Signal Desktop; add emoji to group chats

### DIFF
--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -144,7 +144,7 @@
 	"removeAttachment": "Remove",
 	"addMoreAttachments": "Add another attachment",
 	"removeAllAttachments": "Remove all attachments",
-	"dropFilesToSend": "Drop files here to send them",
+	"dropFilesToSend": "Drop file here",
 	"saveFile": "Save file",
 	"fileSaved": "File saved",
 	"you": "You",

--- a/ui/src/lib/components/MediaDropOverlay.svelte
+++ b/ui/src/lib/components/MediaDropOverlay.svelte
@@ -133,7 +133,7 @@
 
 <style>
 	.drop-overlay {
-		position: fixed;
+		position: absolute;
 		inset: 0;
 		z-index: 30;
 		background: rgba(0, 0, 0, 0.4);

--- a/ui/src/lib/components/MessageInput.svelte
+++ b/ui/src/lib/components/MessageInput.svelte
@@ -123,11 +123,7 @@
 	ontouchstart={keepKeyboardOpen}
 	onpointerdown={keepKeyboardOpen}
 >
-	<div
-		class="message-input-bar m-2 pb-safe"
-		class:bg-md-light-surface={theme === 'material'}
-		class:dark:bg-md-dark-surface={theme === 'material'}
-	>
+	<div class="message-input-bar m-2 pb-safe">
 		<input
 			type="file"
 			accept={PHOTO_ACCEPT}
@@ -156,6 +152,36 @@
 		{/if}
 
 		<div class="row gap-2" style="align-items: flex-end; margin: 0 auto">
+			{#if onEmojiClick && !isIos}
+				<button
+					type="button"
+					class="icon-button emoji-btn"
+					onclick={onEmojiClick}
+					aria-label="Emoji"
+					data-testid="message-input-emoji"
+				>
+					<wa-icon src={wrapPathInSvg(mdiEmoticonHappyOutline)}></wa-icon>
+				</button>
+			{/if}
+
+			<div
+				class={theme === 'ios'
+					? 'input-container bg-ios-light-glass shadow-ios-light-glass backdrop-blur-lg dark:bg-ios-dark-glass dark:shadow-ios-dark-glass'
+					: 'input-container bg-gray-100 dark:bg-gray-800'}
+			>
+				<textarea
+					class="message-textarea"
+					data-testid="message-input-textarea"
+					{placeholder}
+					bind:value
+					bind:this={textarea}
+					rows="1"
+					onkeydown={handleKeydown}
+					oninput={handleInput}
+					onpaste={onPaste}
+				></textarea>
+			</div>
+
 			<div class="attach-wrapper">
 				<button
 					type="button"
@@ -207,40 +233,6 @@
 				{/if}
 			</div>
 
-			<div
-				class={theme === 'ios'
-					? 'input-container bg-ios-light-glass shadow-ios-light-glass backdrop-blur-lg dark:bg-ios-dark-glass dark:shadow-ios-dark-glass'
-					: 'input-container bg-white dark:bg-gray-800'}
-				style="padding-left: 8px"
-			>
-				{#if onEmojiClick && !isIos}
-					<button
-						type="button"
-						class="icon-button emoji-btn"
-						onclick={onEmojiClick}
-						aria-label="Emoji"
-						data-testid="message-input-emoji"
-					>
-						<wa-icon
-							style="font-size: 26px"
-							src={wrapPathInSvg(mdiEmoticonHappyOutline)}
-						></wa-icon>
-					</button>
-				{/if}
-
-				<textarea
-					class="message-textarea"
-					data-testid="message-input-textarea"
-					{placeholder}
-					bind:value
-					bind:this={textarea}
-					rows="1"
-					onkeydown={handleKeydown}
-					oninput={handleInput}
-					onpaste={onPaste}
-				></textarea>
-			</div>
-
 			{#if isMobile}
 				<button
 					type="button"
@@ -277,8 +269,8 @@
 
 	.icon-button {
 		flex-shrink: 0;
-		width: 28px;
-		height: 28px;
+		width: 34px;
+		height: 34px;
 		border: none;
 		background: transparent;
 		border-radius: 50%;
@@ -287,14 +279,10 @@
 		justify-content: center;
 		cursor: pointer;
 		color: var(--k-text-color);
-		opacity: 0.5;
-		transition:
-			opacity 0.15s ease,
-			background-color 0.15s ease;
+		transition: background-color 0.15s ease;
 	}
 
 	.icon-button:hover {
-		opacity: 0.8;
 		background: rgba(128, 128, 128, 0.1);
 	}
 
@@ -312,7 +300,7 @@
 		color: var(--k-text-color);
 		font-family: inherit;
 		min-height: 28px;
-		padding: 8px;
+		padding: 8px 12px;
 		max-height: 100px;
 		overflow-y: auto;
 	}
@@ -361,30 +349,27 @@
 	}
 
 	/* Icon sizing */
-	.icon-button :global(wa-icon),
-	.send-button :global(wa-icon) {
-		width: 22px;
-		height: 22px;
+	.icon-button :global(wa-icon) {
+		width: 20px;
+		height: 20px;
 	}
 
 	.send-button :global(wa-icon) {
+		width: 22px;
+		height: 22px;
 		margin-inline-start: 2px; /* Optical centering for send arrow */
+	}
+
+	/* Emoji + attach buttons hug the bottom as the textarea grows. */
+	.emoji-btn,
+	.attach-wrapper {
+		align-self: flex-end;
+		margin-bottom: 4px;
 	}
 
 	/* Attach button + popover */
 	.attach-wrapper {
 		position: relative;
-		align-self: flex-end;
-		margin-bottom: 4px;
-	}
-
-	.attach-button {
-		width: 40px;
-		height: 40px;
-		opacity: 0.6;
-	}
-	.attach-button:hover {
-		opacity: 0.85;
 	}
 
 	.attach-scrim {
@@ -396,9 +381,9 @@
 	.attach-menu {
 		position: absolute;
 		bottom: calc(100% + 8px);
-		inset-inline-start: 0;
+		inset-inline-end: 0;
 		z-index: 20;
-		min-width: 200px;
+		min-width: 180px;
 		border-radius: 14px;
 		padding: 6px 0;
 		background: var(--k-bars-bg-color, white);
@@ -412,13 +397,13 @@
 	.attach-menu-item {
 		display: flex;
 		align-items: center;
-		gap: 12px;
+		gap: 10px;
 		width: 100%;
-		padding: 10px 16px;
+		padding: 8px 14px;
 		border: none;
 		background: transparent;
 		cursor: pointer;
-		font-size: 15px;
+		font-size: 14px;
 		color: var(--k-text-color);
 		transition: background-color 0.1s ease;
 	}
@@ -428,8 +413,8 @@
 	}
 
 	.attach-menu-item :global(wa-icon) {
-		width: 22px;
-		height: 22px;
+		width: 18px;
+		height: 18px;
 		opacity: 0.75;
 	}
 </style>

--- a/ui/src/routes/direct-chats/[agentId]/+page.svelte
+++ b/ui/src/routes/direct-chats/[agentId]/+page.svelte
@@ -401,6 +401,9 @@
 	class="absolute inset-0"
 	data-testid="direct-chat-page"
 >
+	<MediaDropOverlay
+		onFiles={files => (messageMedia = stageFiles(messageMedia, files))}
+	/>
 	{#await $myDeviceId then myDeviceId}
 		{#await $peerProfile then profile}
 			{#await $contactRequest then contactRequest}
@@ -909,10 +912,6 @@
 							</div>
 						</div>
 					{:else}
-						<MediaDropOverlay
-							onFiles={files =>
-								(messageMedia = stageFiles(messageMedia, files))}
-						/>
 						<MessageInput
 							bind:value={messageText}
 							media={messageMedia}

--- a/ui/src/routes/group-chat/[chatId]/+page.svelte
+++ b/ui/src/routes/group-chat/[chatId]/+page.svelte
@@ -11,7 +11,14 @@
 		Hash,
 	} from 'dash-chat-stores';
 	import { createReadMessagesTracker } from '$lib/actions/track-read-messages';
-	import { Navbar, NavbarBackLink, Link, useTheme } from 'konsta/svelte';
+	import {
+		Navbar,
+		NavbarBackLink,
+		Link,
+		Sheet,
+		Block,
+		useTheme,
+	} from 'konsta/svelte';
 	import { page } from '$app/state';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
 	import { wrapPathInSvg } from '$lib/utils/icon';
@@ -23,6 +30,7 @@
 	import MessageFromOthers from '$lib/components/messages/MessageFromOthers.svelte';
 	import SystemMessage from '$lib/components/messages/SystemMessage.svelte';
 	import MessageInput from '$lib/components/MessageInput.svelte';
+	import EmojiPickerWrapper from '$lib/components/messages/EmojiPickerWrapper.svelte';
 	import MediaDropOverlay from '$lib/components/MediaDropOverlay.svelte';
 	import { stageFiles } from '$lib/utils/stage-files';
 	import ReverseScrollPage from '$lib/components/ReverseScrollPage.svelte';
@@ -61,6 +69,7 @@
 
 	let messageText = $state('');
 	let messageMedia: DraftMedia | undefined = $state(undefined);
+	let showEmojiPicker = $state(false);
 	let bottomBarHeight: number = $state(60);
 	let isAtBottom = $state(true);
 	let reverseScrollPage: ReturnType<typeof ReverseScrollPage> | undefined =
@@ -358,6 +367,24 @@
 			media={messageMedia}
 			onSend={sendMessage}
 			onMediaChange={media => (messageMedia = media)}
+			onEmojiClick={() => (showEmojiPicker = true)}
 		/>
+		<Sheet
+			class="pb-safe text-lg"
+			opened={showEmojiPicker}
+			onBackdropClick={() => (showEmojiPicker = false)}
+		>
+			<div class="flex flex-col items-center">
+				<div class="sheet-handle"></div>
+			</div>
+			<Block>
+				<EmojiPickerWrapper
+					onEmojiSelected={emoji => {
+						messageText += emoji;
+						showEmojiPicker = false;
+					}}
+				/>
+			</Block>
+		</Sheet>
 	</div>
 </div>

--- a/ui/src/routes/group-chat/[chatId]/+page.svelte
+++ b/ui/src/routes/group-chat/[chatId]/+page.svelte
@@ -170,6 +170,9 @@
 </script>
 
 <div class="absolute inset-0" data-testid="group-chat-page">
+	<MediaDropOverlay
+		onFiles={files => (messageMedia = stageFiles(messageMedia, files))}
+	/>
 	<ReverseScrollPage
 		bind:this={reverseScrollPage}
 		bind:isAtBottom
@@ -359,9 +362,6 @@
 		class:bg-md-light-surface={theme === 'material'}
 		class:dark:bg-md-dark-surface={theme === 'material'}
 	>
-		<MediaDropOverlay
-			onFiles={files => (messageMedia = stageFiles(messageMedia, files))}
-		/>
 		<MessageInput
 			bind:value={messageText}
 			media={messageMedia}


### PR DESCRIPTION
## What

**Composer (`MessageInput.svelte`)** — restyled toward Signal Desktop:
- Emoji button moved **out of the input pill to the row start**; attach (**+**) moved to the **row end** (`[emoji] [pill] [+]`), matching Signal.
- Grey pill (`bg-gray-100` / dark `bg-gray-800`).
- **Flush bar**: dropped the redundant inner surface bg. The page's bottom-bar container already paints `--color-md-*-surface` (the same var as the messages area), so the composer is flush with the page and there's no bubble bleed-through.
- 34px icon buttons, no dimmed `opacity`; attach menu anchored to the **end** (`inset-inline-end`).
- Removed the physical `padding-left: 8px` (RTL defect) → logical padding.
- **Kept the light-blue focus border** on the active pill (`:focus-within` → `#3b82f6`).

**Group-chat emoji parity** — the group-chat composer never wired `onEmojiClick`, so group chats had no emoji button. Added the same emoji-picker `Sheet` + `EmojiPickerWrapper` the direct-chat page uses.

## Deferred from this PR

The **chat-header restyle** (solid bar + hairline) that the plan grouped here is **deferred to a follow-up**: it's a subtle cross-theme change I couldn't confidently verify in light/iOS/RTL through the headless bridge, and it's cleanly separable from the composer work. Tracked as a follow-up.

## Verification (live, dark Material)

- Row order confirmed `[emoji] [pill] [attach]`; grey pill; flush bar.
- **Emoji button opens the picker** (confirmed `keepKeyboardOpen` does not block it after the relocation).
- Attach menu opens with both items, anchored to the end (`right: 0`, expands leftward).
- **Focus border** on the pill computes to `rgb(59,130,246)` when focused — preserved.
- All composer testids retained (`message-input-emoji/-attach/-attach-menu/-textarea/-photo-picker/-file-picker`), so the media-attachments e2e selectors still resolve.
- MessageInput has **zero physical directional CSS** (all logical properties) → RTL-safe by construction. (Runtime Farsi toggle was inconclusive via the harness.)
- `pnpm check` clean (0/0, prettier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)