### PR TITLE
Polish the chat list & theme to match Signal Desktop

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -4,6 +4,7 @@
 
 @theme {
 	--color-brand-primary: #007aff;
+	--color-brand-iris: #6e7bff;
 	--color-brand-red: #ff0000;
 	--color-brand-green: #00ff00;
 
@@ -159,13 +160,14 @@ li.plain span {
 /*
 	Message bubble text: nudge the body weight up so it reads closer to
 	Signal. SF Pro is a variable font, so the smaller 425 step lands as a
-	subtle bump on mobile. Desktop gets a clean Medium (500).
+	subtle bump on mobile. Desktop renders denser at standard density, so it
+	reads better at a regular 400.
 */
 .message {
 	font-weight: 425;
 }
 .wide-layout .message {
-	font-weight: 500;
+	font-weight: 400;
 }
 
 .icon-only-card {
@@ -282,6 +284,24 @@ emoji-picker {
 
 :where(.dark) .k-list-item.active > a {
 	background-color: var(--color-gray-700);
+}
+
+/* Signal-style instant row hover on pointer devices; touch devices keep the
+   tap/active feedback (and the Material ripple). Excludes the selected row so
+   .active stays prominent. The ripple reads var(--k-touch-ripple-color), so
+   neutralizing it to transparent suppresses the desktop ripple via Konsta's
+   own hook — no override of the ripple element itself. */
+@media (hover: hover) {
+	.k-list-item > a {
+		transition: none;
+		--k-touch-ripple-color: transparent;
+	}
+	.k-list-item:not(.active) > a:hover {
+		background-color: var(--color-gray-100);
+	}
+	:where(.dark) .k-list-item:not(.active) > a:hover {
+		background-color: var(--color-gray-800);
+	}
 }
 
 .k-list.rounded-2xl a.cursor-pointer {

--- a/ui/src/lib/components/chats/ChatSummary.svelte
+++ b/ui/src/lib/components/chats/ChatSummary.svelte
@@ -83,7 +83,7 @@
 				{/if}
 			</span>
 			{#if summary.unreadMessages !== 0}
-				<Badge>{summary.unreadMessages}</Badge>
+				<Badge colors={{ bg: 'bg-brand-iris' }}>{summary.unreadMessages}</Badge>
 			{/if}
 		</div>
 	{/snippet}

--- a/ui/src/lib/components/layout/ChatListPanel.svelte
+++ b/ui/src/lib/components/layout/ChatListPanel.svelte
@@ -19,10 +19,19 @@
 </script>
 
 <div class="flex flex-col relative h-full">
-	<Navbar title={m.chats()} titleClass="opacity1" transparent={true}>
+	<Navbar
+		title={m.chats()}
+		titleClass="opacity1 !text-[17px] !font-bold"
+		transparent={true}
+	>
 		{#snippet left()}
 			{#await $myProfile then myProfile}
-				<Link iconOnly href="/settings" data-testid="home-settings-link">
+				<Link
+					iconOnly
+					href="/settings"
+					class="rounded-full hover:bg-black/[.06] dark:hover:bg-white/10 [--k-touch-ripple-color:transparent]"
+					data-testid="home-settings-link"
+				>
 					<Avatar
 						image={myProfile?.avatar}
 						initials={myProfile?.name.slice(0, 2)}
@@ -35,6 +44,7 @@
 		{#snippet right()}
 			<Link
 				iconOnly
+				class="rounded-full hover:bg-black/[.06] dark:hover:bg-white/10 [--k-touch-ripple-color:transparent]"
 				onClick={() => {
 					pushState('', { sidebarPanel: 'new-message' });
 				}}

--- a/ui/src/lib/components/messages/ScrollToBottomButton.svelte
+++ b/ui/src/lib/components/messages/ScrollToBottomButton.svelte
@@ -45,7 +45,11 @@
 	data-testid="chat-scroll-bottom"
 >
 	{#if unreadCount > 0}
-		<Badge class="absolute -top-1 -end-1" data-testid="chat-unread-badge">
+		<Badge
+			class="absolute -top-1 -end-1"
+			colors={{ bg: 'bg-brand-iris' }}
+			data-testid="chat-unread-badge"
+		>
 			{unreadCount > 99 ? '99+' : unreadCount}
 		</Badge>
 	{/if}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -25,10 +25,19 @@
 </script>
 
 <Page>
-	<Navbar title={m.chats()} titleClass="opacity1" transparent={true}>
+	<Navbar
+		title={m.chats()}
+		titleClass="opacity1 !text-[17px] !font-bold"
+		transparent={true}
+	>
 		{#snippet left()}
 			{#await $myProfile then myProfile}
-				<Link iconOnly href="/settings" data-testid="home-settings-link">
+				<Link
+					iconOnly
+					href="/settings"
+					class="rounded-full hover:bg-black/[.06] dark:hover:bg-white/10 [--k-touch-ripple-color:transparent]"
+					data-testid="home-settings-link"
+				>
 					<Avatar
 						image={myProfile?.avatar}
 						initials={myProfile?.name.slice(0, 2)}
@@ -40,7 +49,12 @@
 
 		{#snippet right()}
 			{#if theme === 'ios'}
-				<Link iconOnly href="/new-message" data-testid="home-new-message-btn">
+				<Link
+					iconOnly
+					href="/new-message"
+					class="rounded-full hover:bg-black/[.06] dark:hover:bg-white/10 [--k-touch-ripple-color:transparent]"
+					data-testid="home-new-message-btn"
+				>
 					<wa-icon src={wrapPathInSvg(mdiSquareEditOutline)}> </wa-icon>
 				</Link>
 				{#if !isWideScreen.value}
@@ -78,6 +92,7 @@
 				{/await}
 				<Fab
 					class="z-20 me-4 pointer-events-auto"
+					colors={{ bgMaterial: 'bg-brand-iris', textMaterial: 'text-white' }}
 					style="align-self: end;"
 					onClick={() => goto('/new-message')}
 					data-testid="home-new-message-btn"


### PR DESCRIPTION
Chat-list & theme polish for Signal-Desktop parity. Bases on `develop` (independent of the #356 media stack — these files are untouched by it).

## Changes
- **"Chats" title** → 17px/700 on both the home page and the desktop sidebar panel (was 22px/normal on Material, 17px/semibold on iOS). Forced with `!`-important utilities since Konsta's theme classes set the weight/size.
- **Desktop message-body weight** `500 → 400` (`.wide-layout .message`); mobile stays at 425.
- **Scoped iris accent (`#6E7BFF`)** on the chat-list new-message FAB and **both** unread badges (chat-list summary + in-chat scroll-to-bottom). Applied via Konsta's per-component `colors` prop, **without** touching the shared `--k-color-md-*-primary` token — so switches/checkboxes/other primary buttons keep their default color. (The desaturated Material primary that makes other primary buttons render grey is tracked separately — see the accent-consolidation issue.)
- **Row hover + icon-button hover** on pointer devices (`@media (hover: hover)`): instant grey row hover (excludes the `.active`/selected row), icon buttons get `rounded-full hover:bg-black/[.06] dark:hover:bg-white/10`. The desktop Material **ripple is suppressed** by neutralizing Konsta's own `--k-touch-ripple-color` to `transparent` (not a hack — Konsta's ripple wave paints `background-color: var(--k-touch-ripple-color)`). Touch devices keep the ripple + tap feedback.

## Verification
`pnpm check` clean (0 errors/warnings, prettier OK). Visually verified in the running desktop app against `signal-reference/desktop/` across **Material + iOS**, **light + dark**, **narrow + wide**, and **RTL (forced `dir=rtl`)**:
- Title compact/bold; iOS centered title stays sharp (blur-fix intact).
- Unread badge + FAB render iris `rgb(110,123,255)`; a Material toggle stays the default `rgb(73,95,139)` (not iris) — confirming the primary token is untouched.
- Row transition killed; hover rule + ripple-color override present in shipped CSS and resolve correctly; `(hover: hover)` matches on desktop.
- RTL mirrors cleanly (sidebar/title/avatar/timestamp all flip; no directional properties introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)