### PR TITLE
Support dynamic cloud mailbox ID

### DIFF
--- a/crates/dashchat-utils/src/derive_watch.rs
+++ b/crates/dashchat-utils/src/derive_watch.rs
@@ -1,0 +1,58 @@
+use std::future::Future;
+
+use tokio::sync::watch;
+
+/// Derive a new watch channel from `source` by applying an async transform to
+/// the current value and every subsequent change.
+///
+/// Spawns a single task that recomputes `map` whenever `source` changes and
+/// publishes the result on the returned receiver. The task ends when `source`
+/// is dropped or all derived receivers are dropped.
+pub async fn derive_watch<A, B, F, Fut>(
+    mut source: watch::Receiver<A>,
+    mut map: F,
+) -> watch::Receiver<B>
+where
+    A: Clone + Send + Sync + 'static,
+    B: Clone + Send + Sync + 'static,
+    F: FnMut(A) -> Fut + Send + 'static,
+    Fut: Future<Output = B> + Send,
+{
+    let arg = source.borrow().clone();
+    let (tx, rx) = watch::channel(map(arg).await);
+    tokio::spawn(async move {
+        while source.changed().await.is_ok() {
+            let arg = source.borrow().clone();
+            if tx.send(map(arg).await).is_err() {
+                break;
+            }
+        }
+    });
+    rx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn maps_initial_and_subsequent_values() {
+        let (tx, rx) = watch::channel(1u32);
+        let mut derived = derive_watch(rx, |n| async move { n * 10 }).await;
+        assert_eq!(*derived.borrow(), 10);
+
+        tx.send(5).unwrap();
+        derived.changed().await.unwrap();
+        assert_eq!(*derived.borrow(), 50);
+    }
+
+    #[tokio::test]
+    async fn task_ends_when_source_dropped() {
+        let (tx, rx) = watch::channel(0u32);
+        let mut derived = derive_watch(rx, |n| async move { n + 1 }).await;
+        assert_eq!(*derived.borrow(), 1);
+        drop(tx);
+        // No more changes once the source is gone.
+        assert!(derived.changed().await.is_err());
+    }
+}

--- a/crates/dashchat-utils/src/derive_watch.rs
+++ b/crates/dashchat-utils/src/derive_watch.rs
@@ -4,10 +4,6 @@ use tokio::sync::watch;
 
 /// Derive a new watch channel from `source` by applying an async transform to
 /// the current value and every subsequent change.
-///
-/// Spawns a single task that recomputes `map` whenever `source` changes and
-/// publishes the result on the returned receiver. The task ends when `source`
-/// is dropped or all derived receivers are dropped.
 pub async fn derive_watch<A, B, F, Fut>(
     mut source: watch::Receiver<A>,
     mut map: F,

--- a/crates/dashchat-utils/src/lib.rs
+++ b/crates/dashchat-utils/src/lib.rs
@@ -1,7 +1,9 @@
+mod derive_watch;
 mod fetch_loop;
 mod retry_with_backoff;
 mod singleton_task_with_retries;
 
+pub use derive_watch::derive_watch;
 pub use fetch_loop::{fetch_loop, FetchConfig, FetchPool};
 pub use retry_with_backoff::retry_with_backoff;
 pub use singleton_task_with_retries::SingletonTaskWithRetries;

--- a/crates/mailbox-client/src/lib.rs
+++ b/crates/mailbox-client/src/lib.rs
@@ -31,6 +31,11 @@ pub static HTTP_CLIENT: Lazy<reqwest::Client> = Lazy::new(|| {
 pub trait MailboxClient<Item: MailboxItem>: Send + Sync + 'static {
     fn id(&self) -> MailboxId;
 
+    /// The base URL this client talks to, if it has one.
+    fn url(&self) -> Option<String> {
+        None
+    }
+
     /// Publish an operation to the mailbox for the given topic.
     async fn publish(&self, ops: Vec<Item>) -> Result<(), anyhow::Error>;
 

--- a/crates/mailbox-client/src/manager.rs
+++ b/crates/mailbox-client/src/manager.rs
@@ -144,7 +144,7 @@ impl<Item: MailboxItem> TrackedMailbox<Item> {
         }
     }
 
-    async fn client(&self) -> Arc<dyn MailboxClient<Item>> {
+    pub async fn client(&self) -> Arc<dyn MailboxClient<Item>> {
         self.client.lock().await.clone()
     }
 

--- a/crates/mailbox-client/src/toy.rs
+++ b/crates/mailbox-client/src/toy.rs
@@ -50,6 +50,10 @@ where
         self.id.clone()
     }
 
+    fn url(&self) -> Option<String> {
+        Some(self.base_url.clone())
+    }
+
     async fn publish(&self, ops: Vec<Item>) -> Result<(), anyhow::Error> {
         if ops.is_empty() {
             return Ok(());

--- a/packages/stores/src/mailbox-tracker/mailbox-tracker-store.ts
+++ b/packages/stores/src/mailbox-tracker/mailbox-tracker-store.ts
@@ -1,13 +1,11 @@
-import { Channel, invoke } from '@tauri-apps/api/core';
-import { ReactivePromise, reactive, relay } from 'signalium';
+import { ReactivePromise, reactive } from 'signalium';
 
 import type { DeviceId, TopicId } from '../p2panda/types';
-import { unregisterChannel } from '../utils/tauri-channel';
+import { subscribeChannel } from '../utils/tauri-channel';
 import {
 	type MailboxConnectionState,
 	type MailboxId,
 	type MailboxSyncState,
-	PRODUCTION_MAILBOX_ID,
 } from './types';
 
 // Flip the UI to "disconnected" after this many consecutive errors. Intentionally
@@ -34,43 +32,23 @@ export interface IMailboxTrackerStore {
 }
 
 export class MailboxTrackerStore implements IMailboxTrackerStore {
-	activeMailboxIds = reactive(
-		(): ReactivePromise<MailboxId[]> =>
-			relay<MailboxId[]>(state => {
-				const channel = new Channel<MailboxId[]>();
-				channel.onmessage = v => {
-					state.value = v;
-				};
-				invoke('mailbox_subscribe_active_ids', { onEvent: channel });
-				return () => unregisterChannel(channel);
-			}),
+	activeMailboxIds = reactive(() =>
+		subscribeChannel<MailboxId[]>('mailbox_subscribe_active_ids'),
 	);
 
-	allMailboxIds = reactive(
-		(): ReactivePromise<MailboxId[]> =>
-			relay<MailboxId[]>(state => {
-				const channel = new Channel<MailboxId[]>();
-				channel.onmessage = v => {
-					state.value = v;
-				};
-				invoke('mailbox_subscribe_all_ids', { onEvent: channel });
-				return () => unregisterChannel(channel);
-			}),
+	allMailboxIds = reactive(() =>
+		subscribeChannel<MailboxId[]>('mailbox_subscribe_all_ids'),
 	);
 
-	connectionState = reactive(
-		(mailboxId: MailboxId): ReactivePromise<MailboxConnectionState> =>
-			relay<MailboxConnectionState>(state => {
-				const channel = new Channel<MailboxConnectionState>();
-				channel.onmessage = v => {
-					state.value = v;
-				};
-				invoke('mailbox_subscribe_connection_state', {
-					onEvent: channel,
-					mailboxId,
-				});
-				return () => unregisterChannel(channel);
-			}),
+	connectionState = reactive((mailboxId: MailboxId) =>
+		subscribeChannel<MailboxConnectionState>(
+			'mailbox_subscribe_connection_state',
+			{ mailboxId },
+		),
+	);
+
+	cloudMailboxId = reactive(() =>
+		subscribeChannel<MailboxId | null>('mailbox_subscribe_cloud_id'),
 	);
 
 	connectionStatus = reactive(async () => {
@@ -80,8 +58,9 @@ export class MailboxTrackerStore implements IMailboxTrackerStore {
 			activeMailboxIds.map(mailboxId => this.connectionState(mailboxId)),
 		);
 
+		const cloudId = await this.cloudMailboxId();
 		const cloudMailboxIndex = activeMailboxIds.findIndex(
-			mailboxId => mailboxId === PRODUCTION_MAILBOX_ID,
+			mailboxId => mailboxId === cloudId,
 		);
 
 		const connectedToCloudMailboxServer =
@@ -111,19 +90,10 @@ export class MailboxTrackerStore implements IMailboxTrackerStore {
 		};
 	});
 
-	syncState = reactive(
-		(mailboxId: MailboxId): ReactivePromise<MailboxSyncState> =>
-			relay<MailboxSyncState>(state => {
-				const channel = new Channel<MailboxSyncState>();
-				channel.onmessage = v => {
-					state.value = v;
-				};
-				invoke('mailbox_subscribe_sync_state', {
-					onEvent: channel,
-					mailboxId,
-				});
-				return () => unregisterChannel(channel);
-			}),
+	syncState = reactive((mailboxId: MailboxId) =>
+		subscribeChannel<MailboxSyncState>('mailbox_subscribe_sync_state', {
+			mailboxId,
+		}),
 	);
 
 	/// Per-(topic, author) view across every mailbox we've ever synced with.
@@ -168,13 +138,13 @@ export class MailboxTrackerStore implements IMailboxTrackerStore {
 				seq,
 			);
 
+			const cloudId = await this.cloudMailboxId();
 			const localMailboxes = syncedMailboxes.filter(
-				mailbox => mailbox !== PRODUCTION_MAILBOX_ID,
+				mailbox => mailbox !== cloudId,
 			);
 
-			const syncedWithCloudMailbox = syncedMailboxes.includes(
-				PRODUCTION_MAILBOX_ID,
-			);
+			const syncedWithCloudMailbox =
+				cloudId != null && syncedMailboxes.includes(cloudId);
 			const syncedWithAnyLocalMailbox = localMailboxes.length > 0;
 
 			return {

--- a/packages/stores/src/mailbox-tracker/types.ts
+++ b/packages/stores/src/mailbox-tracker/types.ts
@@ -2,10 +2,6 @@ import type { DeviceId, TopicId } from '../p2panda/types';
 
 export type MailboxId = string;
 
-/// Id of the production cloud mailbox.
-/// Kept in sync with `PRODUCTION_MAILBOX_ID` in `src-tauri/src/mailbox.rs`.
-export const PRODUCTION_MAILBOX_ID: MailboxId = 'dashchat-mailbox';
-
 export type SyncStatus = 'Active' | 'Degraded' | 'Stopped';
 
 export interface MailboxConnectionState {

--- a/packages/stores/src/mock/mailbox-tracker-store.ts
+++ b/packages/stores/src/mock/mailbox-tracker-store.ts
@@ -5,9 +5,10 @@ import {
 	type MailboxConnectionState,
 	type MailboxId,
 	type MailboxSyncState,
-	PRODUCTION_MAILBOX_ID,
 } from '../mailbox-tracker/types';
 import type { DeviceId, TopicId } from '../p2panda/types';
+
+const MOCK_MAILBOX_ID: MailboxId = 'mock-mailbox';
 
 const syncedToInfinity: MailboxSyncState = new Proxy({} as MailboxSyncState, {
 	get: () =>
@@ -26,13 +27,9 @@ const constant = <T>(value: T): ReactivePromise<T> =>
 	});
 
 export class MockMailboxTrackerStore implements IMailboxTrackerStore {
-	activeMailboxIds = reactive(() =>
-		constant<MailboxId[]>([PRODUCTION_MAILBOX_ID]),
-	);
+	activeMailboxIds = reactive(() => constant<MailboxId[]>([MOCK_MAILBOX_ID]));
 
-	allMailboxIds = reactive(() =>
-		constant<MailboxId[]>([PRODUCTION_MAILBOX_ID]),
-	);
+	allMailboxIds = reactive(() => constant<MailboxId[]>([MOCK_MAILBOX_ID]));
 
 	connectionState = reactive((_mailboxId: MailboxId) =>
 		constant<MailboxConnectionState>({
@@ -51,7 +48,7 @@ export class MockMailboxTrackerStore implements IMailboxTrackerStore {
 			_topicId: TopicId,
 			_author: DeviceId,
 		): Promise<Record<MailboxId, number>> => ({
-			[PRODUCTION_MAILBOX_ID]: Number.MAX_SAFE_INTEGER,
+			[MOCK_MAILBOX_ID]: Number.MAX_SAFE_INTEGER,
 		}),
 	);
 
@@ -60,6 +57,6 @@ export class MockMailboxTrackerStore implements IMailboxTrackerStore {
 			_topicId: TopicId,
 			_author: DeviceId,
 			_seq: number,
-		): Promise<MailboxId[]> => [PRODUCTION_MAILBOX_ID],
+		): Promise<MailboxId[]> => [MOCK_MAILBOX_ID],
 	);
 }

--- a/packages/stores/src/utils/tauri-channel.ts
+++ b/packages/stores/src/utils/tauri-channel.ts
@@ -1,4 +1,5 @@
-import type { Channel } from '@tauri-apps/api/core';
+import { Channel, invoke } from '@tauri-apps/api/core';
+import { type ReactivePromise, relay } from 'signalium';
 
 interface TauriChannelInternals {
 	id: number;
@@ -21,3 +22,20 @@ export function unregisterChannel<T>(channel: Channel<T>): void {
 }
 
 export type UnsubscribeFn = () => void;
+
+/// Bridge a backend streaming command (one that pushes updates over a Tauri
+/// `Channel`) into a signalium `ReactivePromise`, unregistering the channel on
+/// teardown.
+export function subscribeChannel<T>(
+	command: string,
+	args: Record<string, unknown> = {},
+): ReactivePromise<T> {
+	return relay<T>(state => {
+		const channel = new Channel<T>();
+		channel.onmessage = v => {
+			state.value = v;
+		};
+		invoke(command, { onEvent: channel, ...args });
+		return () => unregisterChannel(channel);
+	});
+}

--- a/src-tauri/src/commands/mailbox_state.rs
+++ b/src-tauri/src/commands/mailbox_state.rs
@@ -6,6 +6,8 @@ use serde::Serialize;
 use tauri::{ipc::Channel, State};
 use tokio::sync::watch;
 
+use crate::mailbox::default_mailbox_url;
+
 async fn forward<T>(mut rx: watch::Receiver<T>, on_event: Channel<T>) -> Result<(), String>
 where
     T: Serialize + Clone + Send + Sync + 'static,
@@ -30,6 +32,33 @@ pub async fn mailbox_subscribe_active_ids(
     node: State<'_, Node>,
 ) -> Result<(), String> {
     forward(node.mailboxes.active_mailbox_ids(), on_event).await
+}
+
+/// The id of the registered mailbox whose URL is the cloud URL, if any.
+async fn cloud_mailbox_id(node: &Node, ids: &BTreeSet<MailboxId>) -> Option<MailboxId> {
+    let cloud_url = crate::mailbox::default_mailbox_url();
+    for id in ids {
+        if let Some(tm) = node.mailboxes.tracked_mailbox(id).await {
+            if tm.client().await.url().as_deref() == Some(&cloud_url) {
+                return Some(id.clone());
+            }
+        }
+    }
+    None
+}
+
+#[tauri::command]
+pub async fn mailbox_subscribe_cloud_id(
+    on_event: Channel<Option<MailboxId>>,
+    node: State<'_, Node>,
+) -> Result<(), String> {
+    let node = (*node).clone();
+    let rx = dashchat_utils::derive_watch(node.mailboxes.active_mailbox_ids(), move |ids| {
+        let node = node.clone();
+        async move { cloud_mailbox_id(&node, &ids).await }
+    })
+    .await;
+    forward(rx, on_event).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/mailbox_state.rs
+++ b/src-tauri/src/commands/mailbox_state.rs
@@ -6,8 +6,6 @@ use serde::Serialize;
 use tauri::{ipc::Channel, State};
 use tokio::sync::watch;
 
-use crate::mailbox::default_mailbox_url;
-
 async fn forward<T>(mut rx: watch::Receiver<T>, on_event: Channel<T>) -> Result<(), String>
 where
     T: Serialize + Clone + Send + Sync + 'static,
@@ -34,28 +32,15 @@ pub async fn mailbox_subscribe_active_ids(
     forward(node.mailboxes.active_mailbox_ids(), on_event).await
 }
 
-/// The id of the registered mailbox whose URL is the cloud URL, if any.
-async fn cloud_mailbox_id(node: &Node, ids: &BTreeSet<MailboxId>) -> Option<MailboxId> {
-    let cloud_url = crate::mailbox::default_mailbox_url();
-    for id in ids {
-        if let Some(tm) = node.mailboxes.tracked_mailbox(id).await {
-            if tm.client().await.url().as_deref() == Some(&cloud_url) {
-                return Some(id.clone());
-            }
-        }
-    }
-    None
-}
-
 #[tauri::command]
 pub async fn mailbox_subscribe_cloud_id(
     on_event: Channel<Option<MailboxId>>,
     node: State<'_, Node>,
 ) -> Result<(), String> {
     let node = (*node).clone();
-    let rx = dashchat_utils::derive_watch(node.mailboxes.active_mailbox_ids(), move |ids| {
+    let rx = dashchat_utils::derive_watch(node.mailboxes.active_mailbox_ids(), move |_ids| {
         let node = node.clone();
-        async move { cloud_mailbox_id(&node, &ids).await }
+        async move { crate::mailbox::cloud_mailbox_id(&node).await }
     })
     .await;
     forward(rx, on_event).await

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -116,6 +116,7 @@ pub fn run() {
             commands::mailbox_state::mailbox_subscribe_all_ids,
             commands::mailbox_state::mailbox_subscribe_connection_state,
             commands::mailbox_state::mailbox_subscribe_sync_state,
+            commands::mailbox_state::mailbox_subscribe_cloud_id,
         ])
         // .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_notification::init())

--- a/src-tauri/src/mailbox.rs
+++ b/src-tauri/src/mailbox.rs
@@ -37,6 +37,27 @@ pub fn default_mailbox_url() -> String {
     PRODUCTION_MAILBOX_URL.to_string()
 }
 
+/// The id of the registered mailbox whose URL is the cloud URL, if any.
+///
+/// "Cloud" is an app-level concept — the generic `Mailboxes` manager has no
+/// notion of it — so we identify it by matching `default_mailbox_url()` against
+/// each registered mailbox's client URL. Returns `None` while the cloud mailbox
+/// is not (yet) registered (e.g. offline).
+pub(crate) async fn cloud_mailbox_id(
+    node: &dashchat_node::Node,
+) -> Option<mailbox_client::MailboxId> {
+    let cloud_url = default_mailbox_url();
+    let ids = node.mailboxes.active_mailbox_ids().borrow().clone();
+    for id in ids {
+        if let Some(tm) = node.mailboxes.tracked_mailbox(&id).await {
+            if tm.client().await.url().as_deref() == Some(&cloud_url) {
+                return Some(id);
+            }
+        }
+    }
+    None
+}
+
 pub fn spawn_local_mailbox_mdns_discovery<R: Runtime>(
     handle: &AppHandle<R>,
     node: dashchat_node::Node,

--- a/src-tauri/src/mailbox.rs
+++ b/src-tauri/src/mailbox.rs
@@ -9,7 +9,6 @@ use tauri::{AppHandle, Manager, Runtime};
 const MDNS_SERVICE_TYPE: &str = "_dashchat._tcp.local.";
 #[cfg(feature = "e2e-tests")]
 const MDNS_SERVICE_TYPE: &str = "_dashchat-e2e._tcp.local.";
-pub(crate) const PRODUCTION_MAILBOX_ID: &str = "dashchat-mailbox";
 pub(crate) const PRODUCTION_MAILBOX_URL: &str = "https://mailbox.production.darksoil.studio";
 
 #[cfg(not(mobile))]

--- a/src-tauri/src/notifications/push_notifications/node_cache.rs
+++ b/src-tauri/src/notifications/push_notifications/node_cache.rs
@@ -38,6 +38,11 @@ pub async fn get_node(data_path: &PathBuf) -> anyhow::Result<Node> {
     log::info!("No nodes in the cache, building node from scratch.");
 
     let node = crate::setup::build_node(data_path.clone(), None, None, true).await?;
+    // Best-effort: the extension only runs when a push arrives (network present),
+    // so resolve and register the cloud mailbox once so the sync below can fetch.
+    if let Err(err) = crate::setup::register_cloud_mailbox(&node).await {
+        log::warn!("failed to register cloud mailbox in push extension: {err:?}");
+    }
     map.insert(data_path.clone(), node.clone());
 
     Ok(node)

--- a/src-tauri/src/notifications/push_notifications/receive_push_notification.rs
+++ b/src-tauri/src/notifications/push_notifications/receive_push_notification.rs
@@ -170,8 +170,14 @@ async fn handle_push_notification(
 
     log::info!("dashchat node built successfully.");
 
-    // Trigger a mailbox sync to fetch the new operation
-    node.mailboxes.trigger_sync();
+    // Fetch the new operation. Wake the cloud mailbox specifically so a
+    // backed-off (Stopped/Degraded) cloud mailbox is force-polled immediately;
+    // fall back to a general trigger if it isn't registered yet.
+    if let Some(cloud_id) = crate::mailbox::cloud_mailbox_id(&node).await {
+        node.mailboxes.wakeup(cloud_id);
+    } else {
+        node.mailboxes.trigger_sync();
+    }
 
     // Poll for the operation to arrive (up to 15 seconds)
     // PERF: consider adding the ability for the op store to notify when an op is stored,

--- a/src-tauri/src/notifications/push_notifications/receive_push_notification.rs
+++ b/src-tauri/src/notifications/push_notifications/receive_push_notification.rs
@@ -171,8 +171,7 @@ async fn handle_push_notification(
     log::info!("dashchat node built successfully.");
 
     // Trigger a mailbox sync to fetch the new operation
-    node.mailboxes
-        .wakeup(crate::mailbox::PRODUCTION_MAILBOX_ID.to_string());
+    node.mailboxes.trigger_sync();
 
     // Poll for the operation to arrive (up to 15 seconds)
     // PERF: consider adding the ability for the op store to notify when an op is stored,

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -29,18 +29,20 @@ pub(crate) async fn build_node(
     let config = if no_p2p { config.no_p2p() } else { config };
     let node = Node::new(data_path, config, notification_tx, topic_subscribed_tx).await?;
 
+    Ok(node)
+}
+
+/// Resolve the cloud mailbox id from its `/health` endpoint and register it on
+/// the node. Returns an error (registering nothing) when the server is
+/// unreachable — there is intentionally no fallback id, so callers retry until
+/// the real id is known. `Mailboxes::register` is idempotent.
+pub(crate) async fn register_cloud_mailbox(node: &Node) -> anyhow::Result<()> {
     let mailbox_url = crate::mailbox::default_mailbox_url();
-    let mailbox_id = fetch_mailbox_id(&mailbox_url)
-        .await
-        .unwrap_or_else(|err| {
-            log::warn!("Failed to fetch mailbox id from {mailbox_url}/health: {err:?}. Falling back to hardcoded id.");
-            crate::mailbox::PRODUCTION_MAILBOX_ID.to_string()
-        });
+    let mailbox_id = fetch_mailbox_id(&mailbox_url).await?;
     let mailbox_client =
         mailbox_client::toy::ToyMailboxClient::new(mailbox_id, mailbox_url, node.endpoint_id());
     node.mailboxes.register(mailbox_client).await;
-
-    Ok(node)
+    Ok(())
 }
 
 /// Fetch the canonical MailboxId from the mailbox server's /health endpoint.
@@ -113,6 +115,26 @@ pub async fn async_setup(app_handle: AppHandle) -> anyhow::Result<()> {
     .await?;
 
     app_handle.manage(node.clone());
+
+    // Resolve and register the cloud mailbox in the background. Its id comes
+    // from the server's /health endpoint, so while offline it stays unknown;
+    // retry forever until the server is reachable.
+    {
+        let node = node.clone();
+        tokio::spawn(async move {
+            let _ = dashchat_utils::retry_with_backoff(
+                None,
+                std::time::Duration::from_secs(2),
+                std::time::Duration::from_secs(10),
+                "register cloud mailbox",
+                || {
+                    let node = node.clone();
+                    async move { register_cloud_mailbox(&node).await }
+                },
+            )
+            .await;
+        });
+    }
 
     #[cfg(mobile)]
     {


### PR DESCRIPTION
- Spawn a register cloud mailbox task on startup to obtain the mailbox ID as soon as we get a connection.
- Remove all references to the static "dashchat-mailbox" mailbox ID.