### PR TITLE
Successfully receive App Links on Android

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       '@tauri-apps/plugin-clipboard-manager':
         specifier: ^2.3.2
         version: 2.3.2
+      '@tauri-apps/plugin-deep-link':
+        specifier: ^2.4.9
+        version: 2.4.9
       '@tauri-apps/plugin-dialog':
         specifier: ^2.6.0
         version: 2.6.0
@@ -1375,56 +1378,67 @@ packages:
     resolution: {integrity: sha512-IoerZJ4l1wRMopEHRKOO16e04iXRDyZFZnNZKrWeNquh5d6bucjezgd+OxG03mOMTnS1x7hilzb3uURPkJ0OfA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.3':
     resolution: {integrity: sha512-ZYdtqgHTDfvrJHSh3W22TvjWxwOgc3ThK/XjgcNGP2DIwFIPeAPNsQxrJO5XqleSlgDux2VAoWQ5iJrtaC1TbA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.3':
     resolution: {integrity: sha512-NcViG7A0YtuFDA6xWSgmFb6iPFzHlf5vcqb2p0lGEbT+gjrEEz8nC/EeDHvx6mnGXnGCC1SeVV+8u+smj0CeGQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.3':
     resolution: {integrity: sha512-d3pY7LWno6SYNXRm6Ebsq0DJGoiLXTb83AIPCXl9fmtIQs/rXoS8SJxxUNtFbJ5MiOvs+7y34np77+9l4nfFMw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.3':
     resolution: {integrity: sha512-3y5GA0JkBuirLqmjwAKwB0keDlI6JfGYduMlJD/Rl7fvb4Ni8iKdQs1eiunMZJhwDWdCvrcqXRY++VEBbvk6Eg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.3':
     resolution: {integrity: sha512-AUUH65a0p3Q0Yfm5oD2KVgzTKgwPyp9DSXc3UA7DtxhEb/WSPfbG4wqXeSN62OG5gSo18em4xv6dbfcUGXcagw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.3':
     resolution: {integrity: sha512-1makPhFFVBqZE+XFg3Dkq+IkQ7JvmUrwwqaYBL2CE+ZpxPaqkGaiWFEWVGyvTwZace6WLJHwjVh/+CXbKDGPmg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.3':
     resolution: {integrity: sha512-OOFJa28dxfl8kLOPMUOQBCO6z3X2SAfzIE276fwT52uXDWUS178KWq0pL7d6p1kz7pkzA0yQwtqL0dEPoVcRWg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.3':
     resolution: {integrity: sha512-jMdsML2VI5l+V7cKfZx3ak+SLlJ8fKvLJ0Eoa4b9/vCUrzXKgoKxvHqvJ/mkWhFiyp88nCkM5S2v6nIwRtPcgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.3':
     resolution: {integrity: sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.3':
     resolution: {integrity: sha512-BCFkJjgk+WFzP+tcSMXq77ymAPIxsX9lFJWs+2JzuZTLtksJ2o5hvgTdIcZ5+oKzUDMwI0PfWzRBYAydAHF2Mw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.3':
     resolution: {integrity: sha512-KTD/EqjZF3yvRaWUJdD1cW+IQBk4fbQaHYJUmP8N4XoKFZilVL8cobFSTDnjTtxWJQ3JYaMgF4nObY/+nYkumA==}
@@ -1563,24 +1577,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1618,6 +1636,9 @@ packages:
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
 
+  '@tauri-apps/api@2.11.1':
+    resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
+
   '@tauri-apps/api@2.8.0':
     resolution: {integrity: sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw==}
 
@@ -1644,30 +1665,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.8.4':
     resolution: {integrity: sha512-zumFeaU1Ws5Ay872FTyIm7z8kfzEHu8NcIn8M6TxbJs0a7GRV21KBdpW1zNj2qy7HynnpQCqjAYXTUUmm9JAOw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.8.4':
     resolution: {integrity: sha512-qiqbB3Zz6IyO201f+1ojxLj65WYj8mixL5cOMo63nlg8CIzsP23cPYUrx1YaDPsCLszKZo7tVs14pc7BWf+/aQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.8.4':
     resolution: {integrity: sha512-TaqaDd9Oy6k45Hotx3pOf+pkbsxLaApv4rGd9mLuRM1k6YS/aw81YrsMryYPThrxrScEIUcmNIHaHsLiU4GMkw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.8.4':
     resolution: {integrity: sha512-ot9STAwyezN8w+bBHZ+bqSQIJ0qPZFlz/AyscpGqB/JnJQVDFQcRDmUPFEaAtt2UUHSWzN3GoTJ5ypqLBp2WQA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.8.4':
     resolution: {integrity: sha512-+2aJ/g90dhLiOLFSD1PbElXX3SoMdpO7HFPAZB+xot3CWlAZD1tReUFy7xe0L5GAR16ZmrxpIDM9v9gn5xRy/w==}
@@ -1697,6 +1723,9 @@ packages:
 
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
     resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
 
   '@tauri-apps/plugin-dialog@2.6.0':
     resolution: {integrity: sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==}
@@ -3310,24 +3339,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -5942,6 +5975,8 @@ snapshots:
 
   '@tauri-apps/api@2.10.1': {}
 
+  '@tauri-apps/api@2.11.1': {}
+
   '@tauri-apps/api@2.8.0': {}
 
   '@tauri-apps/cli-darwin-arm64@2.8.4':
@@ -5998,6 +6033,10 @@ snapshots:
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
     dependencies:
       '@tauri-apps/api': 2.8.0
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-dialog@2.6.0':
     dependencies:

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -118,7 +118,7 @@ pub fn run() {
             commands::mailbox_state::mailbox_subscribe_sync_state,
             commands::mailbox_state::mailbox_subscribe_cloud_id,
         ])
-        // .plugin(tauri_plugin_deep_link::init())
+        .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_dialog::init())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -140,7 +140,9 @@ pub fn run() {
             #[cfg(any(target_os = "linux", windows))]
             {
                 use tauri_plugin_deep_link::DeepLinkExt;
-                app.deep_link().register_all()?;
+                if let Err(err) = app.deep_link().register_all() {
+                    log::error!("Failed to register deep links: {err:?}");
+                }
             }
 
             let handle = app.handle().clone();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -57,25 +57,24 @@ pub fn run() {
             // E2E tests run multiple built instances side-by-side;
             // skip single-instance, updater, and MCP bridge plugins.
         } else {
-            // single-instance must be registered before deep-link so it can
-            // forward deep link URLs from a second process to this one.
-            builder = builder.plugin(tauri_plugin_single_instance::init(
-                move |app, _argv, _cwd| {
-                    use tauri::Manager;
-
-                    if let Some(w) = app.get_webview_window("main") {
-                        let _ = w.set_focus();
-                    } else if let Err(err) = tray::show_or_create_main_window(app) {
-                        log::error!("Failed to show/create main window: {err:?}");
-                    }
-                },
-            ));
-
             if tauri::is_dev() {
                 // MCP for Claude Code to control the tauri app
                 builder = builder.plugin(tauri_plugin_mcp_bridge::init());
             } else {
+                // single-instance must be registered before deep-link so it can
+                // forward deep link URLs from a second process to this one.
                 builder = builder
+                    .plugin(tauri_plugin_single_instance::init(
+                        move |app, _argv, _cwd| {
+                            use tauri::Manager;
+
+                            if let Some(w) = app.get_webview_window("main") {
+                                let _ = w.set_focus();
+                            } else if let Err(err) = tray::show_or_create_main_window(app) {
+                                log::error!("Failed to show/create main window: {err:?}");
+                            }
+                        },
+                    ))
                     .plugin(tauri_plugin_autostart::init(
                         tauri_plugin_autostart::MacosLauncher::LaunchAgent,
                         Some(vec!["--minimized"]),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,28 +56,33 @@ pub fn run() {
         if cfg!(feature = "e2e-tests") {
             // E2E tests run multiple built instances side-by-side;
             // skip single-instance, updater, and MCP bridge plugins.
-        } else if tauri::is_dev() {
-            // MCP for Claude Code to control the tauri app
-            builder = builder.plugin(tauri_plugin_mcp_bridge::init());
         } else {
-            builder = builder
-                .plugin(tauri_plugin_single_instance::init(
-                    move |app, _argv, _cwd| {
-                        use tauri::Manager;
+            // single-instance must be registered before deep-link so it can
+            // forward deep link URLs from a second process to this one.
+            builder = builder.plugin(tauri_plugin_single_instance::init(
+                move |app, _argv, _cwd| {
+                    use tauri::Manager;
 
-                        if let Some(w) = app.get_webview_window("main") {
-                            let _ = w.set_focus();
-                        } else if let Err(err) = tray::show_or_create_main_window(app) {
-                            log::error!("Failed to show/create main window: {err:?}");
-                        }
-                    },
-                ))
-                .plugin(tauri_plugin_autostart::init(
-                    tauri_plugin_autostart::MacosLauncher::LaunchAgent,
-                    Some(vec!["--minimized"]),
-                ))
-                .plugin(tauri_plugin_updater::Builder::new().build())
-                .plugin(tauri_plugin_keepawake::init());
+                    if let Some(w) = app.get_webview_window("main") {
+                        let _ = w.set_focus();
+                    } else if let Err(err) = tray::show_or_create_main_window(app) {
+                        log::error!("Failed to show/create main window: {err:?}");
+                    }
+                },
+            ));
+
+            if tauri::is_dev() {
+                // MCP for Claude Code to control the tauri app
+                builder = builder.plugin(tauri_plugin_mcp_bridge::init());
+            } else {
+                builder = builder
+                    .plugin(tauri_plugin_autostart::init(
+                        tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+                        Some(vec!["--minimized"]),
+                    ))
+                    .plugin(tauri_plugin_updater::Builder::new().build())
+                    .plugin(tauri_plugin_keepawake::init());
+            }
         }
     }
 
@@ -135,6 +140,12 @@ pub fn run() {
             _ => {}
         })
         .setup(move |app| {
+            #[cfg(any(target_os = "linux", windows))]
+            {
+                use tauri_plugin_deep_link::DeepLinkExt;
+                app.deep_link().register_all()?;
+            }
+
             let handle = app.handle().clone();
 
             let result: anyhow::Result<()> =

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,32 +56,30 @@ pub fn run() {
         if cfg!(feature = "e2e-tests") {
             // E2E tests run multiple built instances side-by-side;
             // skip single-instance, updater, and MCP bridge plugins.
+        } else if tauri::is_dev() {
+            // MCP for Claude Code to control the tauri app
+            builder = builder.plugin(tauri_plugin_mcp_bridge::init());
         } else {
-            if tauri::is_dev() {
-                // MCP for Claude Code to control the tauri app
-                builder = builder.plugin(tauri_plugin_mcp_bridge::init());
-            } else {
-                // single-instance must be registered before deep-link so it can
-                // forward deep link URLs from a second process to this one.
-                builder = builder
-                    .plugin(tauri_plugin_single_instance::init(
-                        move |app, _argv, _cwd| {
-                            use tauri::Manager;
+            // single-instance must be registered before deep-link so it can
+            // forward deep link URLs from a second process to this one.
+            builder = builder
+                .plugin(tauri_plugin_single_instance::init(
+                    move |app, _argv, _cwd| {
+                        use tauri::Manager;
 
-                            if let Some(w) = app.get_webview_window("main") {
-                                let _ = w.set_focus();
-                            } else if let Err(err) = tray::show_or_create_main_window(app) {
-                                log::error!("Failed to show/create main window: {err:?}");
-                            }
-                        },
-                    ))
-                    .plugin(tauri_plugin_autostart::init(
-                        tauri_plugin_autostart::MacosLauncher::LaunchAgent,
-                        Some(vec!["--minimized"]),
-                    ))
-                    .plugin(tauri_plugin_updater::Builder::new().build())
-                    .plugin(tauri_plugin_keepawake::init());
-            }
+                        if let Some(w) = app.get_webview_window("main") {
+                            let _ = w.set_focus();
+                        } else if let Err(err) = tray::show_or_create_main_window(app) {
+                            log::error!("Failed to show/create main window: {err:?}");
+                        }
+                    },
+                ))
+                .plugin(tauri_plugin_autostart::init(
+                    tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+                    Some(vec!["--minimized"]),
+                ))
+                .plugin(tauri_plugin_updater::Builder::new().build())
+                .plugin(tauri_plugin_keepawake::init());
         }
     }
 

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -219,7 +219,7 @@
 	"errorApplyStyle": "Failed to apply style. Please try again.",
 	"errorSendErrorReport": "Failed to send error report. Please try again.",
 	"errorLeavingGroup": "Failed to leave group. Please try again.",
-	"receivedUnrecognizedLink": "Received unrecognized link: {{url}}",
+	"errorReceivedUnrecognizedLink": "Received unrecognized link: {{url}}",
 	"errorLeavingGroupOnlyAdmin": "Before you leave, you must choose at least one new admin for this group.",
 	"mute": "Mute",
 	"search": "Search",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -219,6 +219,7 @@
 	"errorApplyStyle": "Failed to apply style. Please try again.",
 	"errorSendErrorReport": "Failed to send error report. Please try again.",
 	"errorLeavingGroup": "Failed to leave group. Please try again.",
+	"receivedUnrecognizedLink": "Received unrecognized link: {{url}}",
 	"errorLeavingGroupOnlyAdmin": "Before you leave, you must choose at least one new admin for this group.",
 	"mute": "Mute",
 	"search": "Search",

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,6 +23,7 @@
 		"@tauri-apps/api": "^2",
 		"@tauri-apps/plugin-barcode-scanner": "^2.4.2",
 		"@tauri-apps/plugin-clipboard-manager": "^2.3.2",
+		"@tauri-apps/plugin-deep-link": "^2.4.9",
 		"@tauri-apps/plugin-dialog": "^2.6.0",
 		"@tauri-apps/plugin-fs": "^2.4.5",
 		"@tauri-apps/plugin-log": "^2",

--- a/ui/src/lib/deep-links/add-contact.ts
+++ b/ui/src/lib/deep-links/add-contact.ts
@@ -1,0 +1,12 @@
+import { goto } from '$app/navigation';
+import { showToast } from '$lib/utils/toasts';
+
+export const path = '/add-contact/{{code}}';
+
+export function handle({ code }: Record<string, string>) {
+	// TODO: This is temporary until another PR actually uses the code to add
+	//       the contact (hence why it doesn't use paraglide messages)
+	goto('/new-message/add-contact').then(() =>
+		showToast(`Got a deep link with code: ${code}`),
+	);
+}

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -1,16 +1,15 @@
-import { goto } from '$app/navigation';
+import * as addContact from '$lib/deep-links/add-contact';
 import { m } from '$lib/paraglide/messages.js';
 import { getCurrent, onOpenUrl } from '@tauri-apps/plugin-deep-link';
 
 import { showToast } from './toasts';
 
-function handleAddContactLink(code: string) {
-	goto('/new-message/add-contact').then(() =>
-		// TODO: This is temporary until another PR actually uses the code to add
-		//       the contact (hence why it doesn't use paraglide messages)
-		showToast(`Got a deep link with code: ${code}`),
-	);
-}
+type DeepLinkHandler = {
+	path: string;
+	handle: (params: Record<string, string>) => void;
+};
+
+const handlers: DeepLinkHandler[] = [addContact];
 
 const HTTPS_DEEP_LINK_BASE_URL = 'https://dashchat\\.org';
 const SCHEME_DEEP_LINK_BASE_URL = 'dash-chat:/';
@@ -45,10 +44,16 @@ function matchesDeepLinkPath(
 
 function handleUrls(urls: string[]) {
 	for (const url of urls) {
-		const match = matchesDeepLinkPath(url, '/add-contact/{{code}}');
-		if (match?.code) {
-			handleAddContactLink(match.code);
-		} else {
+		let matched = false;
+		for (const handler of handlers) {
+			const params = matchesDeepLinkPath(url, handler.path);
+			if (params) {
+				handler.handle(params);
+				matched = true;
+				break;
+			}
+		}
+		if (!matched) {
 			console.log('[deep-link] url did not match pattern:', url);
 			showToast(m.receivedUnrecognizedLink({ url }));
 		}

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -7,6 +7,8 @@ import { showToast } from './toasts';
 function handleAddContactLink(code: string) {
 	console.log('[deep-link] handling add-contact link with code:', code);
 	goto('/new-message/add-contact').then(() =>
+		// TODO: This is temporary until another PR actually uses the code to add
+		//       the contact (hence why it doesn't use paraglide messages)
 		showToast(`Got a deep link with code: ${code}`),
 	);
 }
@@ -14,18 +16,40 @@ function handleAddContactLink(code: string) {
 const HTTPS_DEEP_LINK_BASE_URL = 'https://dashchat\\.org';
 const SCHEME_DEEP_LINK_BASE_URL = 'dash-chat:/';
 
-function buildDeepLinkRegex(path: string): RegExp {
-	return new RegExp(
-		`^(?:${HTTPS_DEEP_LINK_BASE_URL}|${SCHEME_DEEP_LINK_BASE_URL})${path.replace(/\//g, '\\/')}$`,
+function matchesDeepLinkPath(
+	url: string,
+	path: string,
+): Record<string, string> | null {
+	const names: string[] = [];
+	const pattern = path
+		.replace(/\//g, '\\/')
+		.replace(/\{\{(\w+)\}\}/g, (_, name: string) => {
+			names.push(name);
+			return '([^\\/?#]+)';
+		});
+	const match = url.match(
+		new RegExp(
+			`^(?:${HTTPS_DEEP_LINK_BASE_URL}|${SCHEME_DEEP_LINK_BASE_URL})${pattern}$`,
+		),
+	);
+	if (!match) return null;
+	return Object.fromEntries(
+		names.map((name, i) => {
+			try {
+				return [name, decodeURIComponent(match[i + 1])];
+			} catch {
+				return [name, match[i + 1]];
+			}
+		}),
 	);
 }
 
 function handleUrls(urls: string[]) {
 	console.log('[deep-link] handling urls:', urls);
 	for (const url of urls) {
-		const code = url.match(buildDeepLinkRegex('/add-contact/(.+)'))?.[1];
-		if (code) {
-			handleAddContactLink(code);
+		const match = matchesDeepLinkPath(url, '/add-contact/{{code}}');
+		if (match?.code) {
+			handleAddContactLink(match.code);
 		} else {
 			console.log('[deep-link] url did not match pattern:', url);
 			showToast(m.receivedUnrecognizedLink({ url }));

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -42,6 +42,15 @@ function matchesDeepLinkPath(
 	);
 }
 
+function sanitizeUrl(url: string): string {
+	try {
+		const u = new URL(url);
+		return `${u.protocol}//${u.host}`;
+	} catch {
+		return '(unparseable)';
+	}
+}
+
 function handleUrls(urls: string[]) {
 	for (const url of urls) {
 		let matched = false;
@@ -54,7 +63,7 @@ function handleUrls(urls: string[]) {
 			}
 		}
 		if (!matched) {
-			console.log('[deep-link] url did not match pattern:', url);
+			console.log('[deep-link] url did not match pattern:', sanitizeUrl(url));
 			showToast(m.errorReceivedUnrecognizedLink({ url }));
 		}
 	}

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -62,21 +62,28 @@ function handleUrls(urls: string[]) {
 
 const handledLaunchUrls = new Set<string>();
 
+// Resolved once getCurrent() completes so the onOpenUrl callback can safely
+// dedup against launch URLs without a startup race.
+const launchUrlsReady: Promise<void> = getCurrent()
+	.then(urls => {
+		if (urls) {
+			for (const url of urls) handledLaunchUrls.add(url);
+		}
+	})
+	.catch(err => {
+		console.error('[deep-link] failed to read launch deep links:', err);
+	});
+
 export function handleLaunchDeepLink() {
-	getCurrent()
-		.then(urls => {
-			if (urls) {
-				for (const url of urls) handledLaunchUrls.add(url);
-				handleUrls(urls);
-			}
-		})
-		.catch(err => {
-			console.error('[deep-link] failed to read launch deep links:', err);
-		});
+	launchUrlsReady.then(() => {
+		const urls = [...handledLaunchUrls];
+		if (urls.length > 0) handleUrls(urls);
+	});
 }
 
 export function listenForDeepLinks(): () => void {
-	const unlistenPromise = onOpenUrl(urls => {
+	const unlistenPromise = onOpenUrl(async urls => {
+		await launchUrlsReady;
 		const fresh = urls.filter(url => !handledLaunchUrls.delete(url));
 		if (fresh.length > 0) handleUrls(fresh);
 	}).catch(err => {

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -75,14 +75,15 @@ function handleUrls(urls: string[]) {
 	}
 }
 
-const handledLaunchUrls = new Set<string>();
+const launchUrls = new Set<string>();
+let launchUrlsConsumed = false;
 
 // Resolved once getCurrent() completes so the onOpenUrl callback can safely
 // dedup against launch URLs without a startup race.
 const launchUrlsReady: Promise<void> = getCurrent()
 	.then(urls => {
 		if (urls) {
-			for (const url of urls) handledLaunchUrls.add(url);
+			for (const url of urls) launchUrls.add(url);
 		}
 	})
 	.catch(err => {
@@ -91,7 +92,8 @@ const launchUrlsReady: Promise<void> = getCurrent()
 
 export function handleLaunchDeepLink() {
 	launchUrlsReady.then(() => {
-		const urls = [...handledLaunchUrls];
+		const urls = [...launchUrls];
+		launchUrlsConsumed = true;
 		if (urls.length > 0) handleUrls(urls);
 	});
 }
@@ -99,7 +101,11 @@ export function handleLaunchDeepLink() {
 export function listenForDeepLinks(): () => void {
 	const unlistenPromise = onOpenUrl(async urls => {
 		await launchUrlsReady;
-		const fresh = urls.filter(url => !handledLaunchUrls.delete(url));
+		// If the launch handler hasn't run yet, skip URLs it will handle.
+		// Once it has run (or if it never will), treat everything as fresh.
+		const fresh = launchUrlsConsumed
+			? urls
+			: urls.filter(url => !launchUrls.has(url));
 		if (fresh.length > 0) handleUrls(fresh);
 	}).catch(err => {
 		console.error('[deep-link] failed to register listener:', err);

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -70,7 +70,7 @@ function handleUrls(urls: string[]) {
 		}
 		if (!matched) {
 			console.log('[deep-link] url did not match pattern:', sanitizeUrl(url));
-			showToast(m.errorReceivedUnrecognizedLink({ url }));
+			showToast(m.errorReceivedUnrecognizedLink({ url }), 'error');
 		}
 	}
 }

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -55,7 +55,7 @@ function handleUrls(urls: string[]) {
 		}
 		if (!matched) {
 			console.log('[deep-link] url did not match pattern:', url);
-			showToast(m.receivedUnrecognizedLink({ url }));
+			showToast(m.errorReceivedUnrecognizedLink({ url }));
 		}
 	}
 }

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -1,23 +1,41 @@
 import { goto } from '$app/navigation';
-import { onOpenUrl } from '@tauri-apps/plugin-deep-link';
+import { getCurrent, onOpenUrl } from '@tauri-apps/plugin-deep-link';
 
 import { showToast } from './toasts';
+
+const DEEP_LINK_BASE_URL = 'https://dashchat.org';
+
+function handleAddContactLink(code: string) {
+	console.log('[deep-link] handling add-contact link with code:', code);
+	goto('/new-message/add-contact').then(() =>
+		showToast(`Got a deep link with code: ${code}`),
+	);
+}
+
+function handleUrls(urls: string[]) {
+	console.log('[deep-link] handling urls:', urls);
+	for (const url of urls) {
+		const match = url.match(
+			new RegExp(`${DEEP_LINK_BASE_URL}/add-contact/(.+)`),
+		);
+		if (match) {
+			const code = match[1];
+			handleAddContactLink(code);
+		} else {
+			console.log('[deep-link] url did not match pattern:', url);
+		}
+	}
+}
+
+export async function handleLaunchDeepLink() {
+	const urls = await getCurrent();
+	if (urls) handleUrls(urls);
+}
 
 export function listenForDeepLinks(): () => void {
 	const unlistenPromise = onOpenUrl(urls => {
 		console.log('[deep-link] onOpenUrl fired, urls:', urls);
-		for (const url of urls) {
-			const match = url.match(/https:\/\/dashchat\.org\/add-contact\/(.+)/);
-			if (match) {
-				const code = match[1];
-				console.log('[deep-link] matched, code:', code);
-				goto('/new-message/add-contact').then(() =>
-					showToast(`Got a deep link with code: ${code}`),
-				);
-			} else {
-				console.log('[deep-link] url did not match pattern:', url);
-			}
-		}
+		handleUrls(urls);
 	})
 		.then(fn => fn)
 		.catch(err => {

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -1,4 +1,5 @@
 import { goto } from '$app/navigation';
+import { m } from '$lib/paraglide/messages.js';
 import { getCurrent, onOpenUrl } from '@tauri-apps/plugin-deep-link';
 
 import { showToast } from './toasts';
@@ -27,7 +28,7 @@ function handleUrls(urls: string[]) {
 			handleAddContactLink(code);
 		} else {
 			console.log('[deep-link] url did not match pattern:', url);
-			showToast(`Received unrecognized link: ${url}`);
+			showToast(m.receivedUnrecognizedLink({ url }));
 		}
 	}
 }

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -1,0 +1,31 @@
+import { goto } from '$app/navigation';
+import { onOpenUrl } from '@tauri-apps/plugin-deep-link';
+
+import { showToast } from './toasts';
+
+export function listenForDeepLinks(): () => void {
+	const unlistenPromise = onOpenUrl(urls => {
+		console.log('[deep-link] onOpenUrl fired, urls:', urls);
+		for (const url of urls) {
+			const match = url.match(/https:\/\/dashchat\.org\/add-contact\/(.+)/);
+			if (match) {
+				const code = match[1];
+				console.log('[deep-link] matched, code:', code);
+				goto('/new-message/add-contact').then(() =>
+					showToast(`Got a deep link with code: ${code}`),
+				);
+			} else {
+				console.log('[deep-link] url did not match pattern:', url);
+			}
+		}
+	})
+		.then(fn => fn)
+		.catch(err => {
+			console.error('[deep-link] failed to register listener:', err);
+			return () => {};
+		});
+
+	return () => {
+		unlistenPromise.then(fn => fn());
+	};
+}

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -27,25 +27,29 @@ function handleUrls(urls: string[]) {
 			handleAddContactLink(code);
 		} else {
 			console.log('[deep-link] url did not match pattern:', url);
+			showToast(`Received unrecognized link: ${url}`);
 		}
 	}
 }
 
-export async function handleLaunchDeepLink() {
-	const urls = await getCurrent();
-	if (urls) handleUrls(urls);
+export function handleLaunchDeepLink() {
+	getCurrent()
+		.then(urls => {
+			if (urls) handleUrls(urls);
+		})
+		.catch(err => {
+			console.error('[deep-link] failed to read launch deep links:', err);
+		});
 }
 
 export function listenForDeepLinks(): () => void {
 	const unlistenPromise = onOpenUrl(urls => {
 		console.log('[deep-link] onOpenUrl fired, urls:', urls);
 		handleUrls(urls);
-	})
-		.then(fn => fn)
-		.catch(err => {
-			console.error('[deep-link] failed to register listener:', err);
-			return () => {};
-		});
+	}).catch(err => {
+		console.error('[deep-link] failed to register listener:', err);
+		return () => {};
+	});
 
 	return () => {
 		unlistenPromise.then(fn => fn());

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -3,8 +3,6 @@ import { getCurrent, onOpenUrl } from '@tauri-apps/plugin-deep-link';
 
 import { showToast } from './toasts';
 
-const DEEP_LINK_BASE_URL = 'https://dashchat.org';
-
 function handleAddContactLink(code: string) {
 	console.log('[deep-link] handling add-contact link with code:', code);
 	goto('/new-message/add-contact').then(() =>
@@ -12,14 +10,20 @@ function handleAddContactLink(code: string) {
 	);
 }
 
+const HTTPS_DEEP_LINK_BASE_URL = 'https://dashchat\\.org';
+const SCHEME_DEEP_LINK_BASE_URL = 'dash-chat:/';
+
+function buildDeepLinkRegex(path: string): RegExp {
+	return new RegExp(
+		`^(?:${HTTPS_DEEP_LINK_BASE_URL}|${SCHEME_DEEP_LINK_BASE_URL})${path.replace(/\//g, '\\/')}$`,
+	);
+}
+
 function handleUrls(urls: string[]) {
 	console.log('[deep-link] handling urls:', urls);
 	for (const url of urls) {
-		const match = url.match(
-			new RegExp(`${DEEP_LINK_BASE_URL}/add-contact/(.+)`),
-		);
-		if (match) {
-			const code = match[1];
+		const code = url.match(buildDeepLinkRegex('/add-contact/(.+)'))?.[1];
+		if (code) {
 			handleAddContactLink(code);
 		} else {
 			console.log('[deep-link] url did not match pattern:', url);

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -57,10 +57,15 @@ function handleUrls(urls: string[]) {
 	}
 }
 
+const handledLaunchUrls = new Set<string>();
+
 export function handleLaunchDeepLink() {
 	getCurrent()
 		.then(urls => {
-			if (urls) handleUrls(urls);
+			if (urls) {
+				for (const url of urls) handledLaunchUrls.add(url);
+				handleUrls(urls);
+			}
 		})
 		.catch(err => {
 			console.error('[deep-link] failed to read launch deep links:', err);
@@ -70,7 +75,8 @@ export function handleLaunchDeepLink() {
 export function listenForDeepLinks(): () => void {
 	const unlistenPromise = onOpenUrl(urls => {
 		console.log('[deep-link] onOpenUrl fired, urls:', urls);
-		handleUrls(urls);
+		const fresh = urls.filter(url => !handledLaunchUrls.delete(url));
+		if (fresh.length > 0) handleUrls(fresh);
 	}).catch(err => {
 		console.error('[deep-link] failed to register listener:', err);
 		return () => {};

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -11,8 +11,12 @@ type DeepLinkHandler = {
 
 const handlers: DeepLinkHandler[] = [addContact];
 
-const HTTPS_DEEP_LINK_BASE_URL = 'https://dashchat\\.org';
-const SCHEME_DEEP_LINK_BASE_URL = 'dash-chat:/';
+function escapeRegex(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const HTTPS_DEEP_LINK_BASE_URL = escapeRegex('https://dashchat.org');
+const SCHEME_DEEP_LINK_BASE_URL = escapeRegex('dash-chat:/');
 
 function matchesDeepLinkPath(
 	url: string,
@@ -20,11 +24,13 @@ function matchesDeepLinkPath(
 ): Record<string, string> | null {
 	const names: string[] = [];
 	const pattern = path
-		.replace(/\//g, '\\/')
-		.replace(/\{\{(\w+)\}\}/g, (_, name: string) => {
-			names.push(name);
-			return '([^\\/?#]+)';
-		});
+		.split(/\{\{(\w+)\}\}/g)
+		.map((chunk, i) => {
+			if (i % 2 === 0) return escapeRegex(chunk);
+			names.push(chunk);
+			return '([^/?#]+)';
+		})
+		.join('');
 	const match = url.match(
 		new RegExp(
 			`^(?:${HTTPS_DEEP_LINK_BASE_URL}|${SCHEME_DEEP_LINK_BASE_URL})${pattern}(?:[?#].*)?$`,

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -5,7 +5,6 @@ import { getCurrent, onOpenUrl } from '@tauri-apps/plugin-deep-link';
 import { showToast } from './toasts';
 
 function handleAddContactLink(code: string) {
-	console.log('[deep-link] handling add-contact link with code:', code);
 	goto('/new-message/add-contact').then(() =>
 		// TODO: This is temporary until another PR actually uses the code to add
 		//       the contact (hence why it doesn't use paraglide messages)
@@ -45,7 +44,6 @@ function matchesDeepLinkPath(
 }
 
 function handleUrls(urls: string[]) {
-	console.log('[deep-link] handling urls:', urls);
 	for (const url of urls) {
 		const match = matchesDeepLinkPath(url, '/add-contact/{{code}}');
 		if (match?.code) {
@@ -74,7 +72,6 @@ export function handleLaunchDeepLink() {
 
 export function listenForDeepLinks(): () => void {
 	const unlistenPromise = onOpenUrl(urls => {
-		console.log('[deep-link] onOpenUrl fired, urls:', urls);
 		const fresh = urls.filter(url => !handledLaunchUrls.delete(url));
 		if (fresh.length > 0) handleUrls(fresh);
 	}).catch(err => {

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -27,7 +27,7 @@ function matchesDeepLinkPath(
 		});
 	const match = url.match(
 		new RegExp(
-			`^(?:${HTTPS_DEEP_LINK_BASE_URL}|${SCHEME_DEEP_LINK_BASE_URL})${pattern}$`,
+			`^(?:${HTTPS_DEEP_LINK_BASE_URL}|${SCHEME_DEEP_LINK_BASE_URL})${pattern}(?:[?#].*)?$`,
 		),
 	);
 	if (!match) return null;

--- a/ui/src/lib/utils/deep-links.ts
+++ b/ui/src/lib/utils/deep-links.ts
@@ -75,8 +75,10 @@ function handleUrls(urls: string[]) {
 	}
 }
 
+// URLs delivered at launch, populated before launchUrlsReady resolves.
+// The onOpenUrl listener removes each URL on first sight so it only dedupes
+// one re-delivery, not all future deliveries of the same URL.
 const launchUrls = new Set<string>();
-let launchUrlsConsumed = false;
 
 // Resolved once getCurrent() completes so the onOpenUrl callback can safely
 // dedup against launch URLs without a startup race.
@@ -93,7 +95,6 @@ const launchUrlsReady: Promise<void> = getCurrent()
 export function handleLaunchDeepLink() {
 	launchUrlsReady.then(() => {
 		const urls = [...launchUrls];
-		launchUrlsConsumed = true;
 		if (urls.length > 0) handleUrls(urls);
 	});
 }
@@ -101,11 +102,10 @@ export function handleLaunchDeepLink() {
 export function listenForDeepLinks(): () => void {
 	const unlistenPromise = onOpenUrl(async urls => {
 		await launchUrlsReady;
-		// If the launch handler hasn't run yet, skip URLs it will handle.
-		// Once it has run (or if it never will), treat everything as fresh.
-		const fresh = launchUrlsConsumed
-			? urls
-			: urls.filter(url => !launchUrls.has(url));
+		// Remove each URL from launchUrls on first sight — if the plugin
+		// re-delivers a launch URL, skip it exactly once; after that, treat
+		// further deliveries as genuinely new.
+		const fresh = urls.filter(url => !launchUrls.delete(url));
 		if (fresh.length > 0) handleUrls(fresh);
 	}).catch(err => {
 		console.error('[deep-link] failed to register listener:', err);

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -44,7 +44,10 @@
 	import { showToast } from '$lib/utils/toasts';
 	import { isIos, isMobile, isTauriEnv } from '$lib/utils/environment';
 	import { forwardConsoleToTauriLog } from '$lib/utils/logs';
-	import { listenForDeepLinks } from '$lib/utils/deep-links';
+	import {
+		listenForDeepLinks,
+		handleLaunchDeepLink,
+	} from '$lib/utils/deep-links';
 
 	import { m } from '$lib/paraglide/messages.js';
 	import { getLocale, type Locale, setLocale } from '$lib/paraglide/runtime';
@@ -191,6 +194,7 @@
 	});
 
 	if (isTauriEnv()) {
+		handleLaunchDeepLink();
 		$effect(() => listenForDeepLinks());
 	}
 </script>

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -195,8 +195,11 @@
 
 	if (isTauriEnv()) {
 		handleLaunchDeepLink();
-		$effect(() => listenForDeepLinks());
 	}
+	$effect(() => {
+		if (!isTauriEnv()) return;
+		return listenForDeepLinks();
+	});
 </script>
 
 {#if showToolbar}

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -44,6 +44,7 @@
 	import { showToast } from '$lib/utils/toasts';
 	import { isIos, isMobile, isTauriEnv } from '$lib/utils/environment';
 	import { forwardConsoleToTauriLog } from '$lib/utils/logs';
+	import { listenForDeepLinks } from '$lib/utils/deep-links';
 
 	import { m } from '$lib/paraglide/messages.js';
 	import { getLocale, type Locale, setLocale } from '$lib/paraglide/runtime';
@@ -188,6 +189,10 @@
 			isWideScreen.value,
 		);
 	});
+
+	if (isTauriEnv()) {
+		$effect(() => listenForDeepLinks());
+	}
 </script>
 
 {#if showToolbar}


### PR DESCRIPTION
When the app is installed on Android, it will register for app links (deep links) of the form `https://dashchat.org/add-contact/CODE`. 

When a link of that sort is clicked, it will be received by the dash chat app (opening it if it wasn't already opened). It will redirect to the add contact page, and display a toast for the moment demonstrating that it received the code. It will not actually add the contact (that's another PR).

Also in this PR, scheme links of the form `dash-chat://add-contact/CODE` are supported through the same pipeline, as we may need these on desktop.