### PR TITLE
Retry invoke at startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ The Rust workspace is one Cargo workspace covering the Tauri app crate (`src-tau
 
 **Frontend Patterns:**
 - Signalium for reactive state management
-- Tauri commands invoked via `invoke()` from `@tauri-apps/api`
+- **STRICT: All Tauri commands must be invoked via `invokeAfterSetup()` from `packages/stores/src/utils/invoke-after-setup.ts`, never `invoke()` from `@tauri-apps/api` directly.** At startup the webview can invoke node-backed commands before `async_setup` finishes managing the node; `invokeAfterSetup()` retries the transient "state not managed" error until the backend is ready. Importing `invoke` directly from `@tauri-apps/api/core` (outside `invoke-after-setup.ts` itself) is a defect — flag it in review.
 - UI built with Konsta UI components (mobile-first design)
 - Internationalization using @inlang/paraglide-js
 - Image compression before upload

--- a/packages/stores/src/chats/chats-client.ts
+++ b/packages/stores/src/chats/chats-client.ts
@@ -1,7 +1,6 @@
-import { invoke } from '@tauri-apps/api/core';
-
 import { Hash, VerifyingKey } from '../p2panda/types';
 import { ChatId } from '../types';
+import { invoke } from '../utils/invoke';
 
 export interface IChatsClient {
 	createGroup(initialMembers: VerifyingKey[]): Promise<ChatId>;

--- a/packages/stores/src/chats/chats-client.ts
+++ b/packages/stores/src/chats/chats-client.ts
@@ -1,6 +1,6 @@
 import { Hash, VerifyingKey } from '../p2panda/types';
 import { ChatId } from '../types';
-import { invoke } from '../utils/invoke';
+import { invokeAfterSetup } from '../utils/invoke-after-setup';
 
 export interface IChatsClient {
 	createGroup(initialMembers: VerifyingKey[]): Promise<ChatId>;
@@ -10,17 +10,17 @@ export interface IChatsClient {
 
 export class ChatsClient implements IChatsClient {
 	createGroup(initialMembers: VerifyingKey[]): Promise<ChatId> {
-		return invoke('create_group', {
+		return invokeAfterSetup('create_group', {
 			initialMembers,
 		});
 	}
 
 	getGroupChats(): Promise<Array<ChatId>> {
-		return invoke('get_group_chats');
+		return invokeAfterSetup('get_group_chats');
 	}
 
 	markMessagesRead(chatId: ChatId, messageHashes: Hash[]): Promise<void> {
-		return invoke('mark_messages_read', {
+		return invokeAfterSetup('mark_messages_read', {
 			chatId,
 			messageHashes,
 		});

--- a/packages/stores/src/contacts/contacts-client.ts
+++ b/packages/stores/src/contacts/contacts-client.ts
@@ -1,7 +1,7 @@
 import { LogsClient, waitForOperation } from '../p2panda/logs-client';
 import { AgentId, DeviceId, type TopicId } from '../p2panda/types';
 import { ContactCode, Payload } from '../types';
-import { invoke } from '../utils/invoke';
+import { invokeAfterSetup } from '../utils/invoke-after-setup';
 
 export interface Profile {
 	name: string;
@@ -61,30 +61,30 @@ export class ContactsClient implements IContactsClient {
 	constructor(protected logsClient: LogsClient<Payload>) {}
 
 	myAgentId(): Promise<AgentId> {
-		return invoke('my_agent_id');
+		return invokeAfterSetup('my_agent_id');
 	}
 
 	myDeviceId(): Promise<DeviceId> {
-		return invoke('my_device_id');
+		return invokeAfterSetup('my_device_id');
 	}
 
 	async setProfile(profile: Profile): Promise<void> {
-		return invoke('set_profile', {
+		return invokeAfterSetup('set_profile', {
 			profile,
 		});
 	}
 
 	createContactCode(): Promise<ContactCode> {
-		return invoke('create_contact_code');
+		return invokeAfterSetup('create_contact_code');
 	}
 
 	activeInboxTopics(): Promise<TopicId[]> {
-		return invoke('active_inbox_topics');
+		return invokeAfterSetup('active_inbox_topics');
 	}
 
 	async addContact(contactCode: ContactCode): Promise<void> {
 		await Promise.all([
-			invoke('add_contact', { contactCode }),
+			invokeAfterSetup('add_contact', { contactCode }),
 			waitForOperation(
 				this.logsClient,
 				op =>
@@ -96,7 +96,7 @@ export class ContactsClient implements IContactsClient {
 
 	async rejectContactRequest(agentId: AgentId): Promise<void> {
 		await Promise.all([
-			invoke('reject_contact_request', { agentId }),
+			invokeAfterSetup('reject_contact_request', { agentId }),
 			waitForOperation(
 				this.logsClient,
 				op =>
@@ -107,11 +107,11 @@ export class ContactsClient implements IContactsClient {
 	}
 
 	// getContacts(): Promise<Array<VerifyingKey>> {
-	// 	return invoke('get_contacts');
+	// 	return invokeAfterSetup('get_contacts');
 	// }
 
 	// removeContact(contactId: ContactId): Promise<void> {
-	// 	return invoke('remove_contact', {
+	// 	return invokeAfterSetup('remove_contact', {
 	// 		contactId,
 	// 	});
 	// }

--- a/packages/stores/src/contacts/contacts-client.ts
+++ b/packages/stores/src/contacts/contacts-client.ts
@@ -1,8 +1,7 @@
-import { invoke } from '@tauri-apps/api/core';
-
 import { LogsClient, waitForOperation } from '../p2panda/logs-client';
 import { AgentId, DeviceId, type TopicId } from '../p2panda/types';
 import { ContactCode, Payload } from '../types';
+import { invoke } from '../utils/invoke';
 
 export interface Profile {
 	name: string;

--- a/packages/stores/src/devices/devices-client.ts
+++ b/packages/stores/src/devices/devices-client.ts
@@ -1,5 +1,5 @@
 import { type TopicId } from '../p2panda/types';
-import { invoke } from '../utils/invoke';
+import { invokeAfterSetup } from '../utils/invoke-after-setup';
 
 export interface IDevicesClient {
 	myDeviceGroupTopicId(): Promise<TopicId>;
@@ -7,6 +7,6 @@ export interface IDevicesClient {
 
 export class DevicesClient implements IDevicesClient {
 	myDeviceGroupTopicId(): Promise<TopicId> {
-		return invoke('my_device_group_topic');
+		return invokeAfterSetup('my_device_group_topic');
 	}
 }

--- a/packages/stores/src/devices/devices-client.ts
+++ b/packages/stores/src/devices/devices-client.ts
@@ -1,6 +1,5 @@
-import { invoke } from '@tauri-apps/api/core';
-
 import { type TopicId } from '../p2panda/types';
+import { invoke } from '../utils/invoke';
 
 export interface IDevicesClient {
 	myDeviceGroupTopicId(): Promise<TopicId>;

--- a/packages/stores/src/direct-chats/direct-chat-client.ts
+++ b/packages/stores/src/direct-chats/direct-chat-client.ts
@@ -1,6 +1,6 @@
 import { AgentId, Hash } from '../p2panda/types';
 import { ChatId, ChatReaction, OutgoingMedia } from '../types';
-import { invoke } from '../utils/invoke';
+import { invokeAfterSetup } from '../utils/invoke-after-setup';
 
 export interface IDirectChatClient {
 	chatId(peer: AgentId): Promise<ChatId>;
@@ -15,7 +15,7 @@ export interface IDirectChatClient {
 
 export class DirectChatClient implements IDirectChatClient {
 	chatId(peer: AgentId): Promise<ChatId> {
-		return invoke('direct_chat_id', {
+		return invokeAfterSetup('direct_chat_id', {
 			peer,
 		});
 	}
@@ -25,7 +25,7 @@ export class DirectChatClient implements IDirectChatClient {
 		message: string,
 		media: OutgoingMedia | null,
 	): Promise<Hash> {
-		return invoke('send_message', {
+		return invokeAfterSetup('send_message', {
 			chatId,
 			message,
 			media,
@@ -33,14 +33,14 @@ export class DirectChatClient implements IDirectChatClient {
 	}
 
 	markMessagesRead(chatId: ChatId, messageHashes: Hash[]): Promise<void> {
-		return invoke('mark_messages_read', {
+		return invokeAfterSetup('mark_messages_read', {
 			chatId,
 			messageHashes,
 		});
 	}
 
 	async sendReaction(chatId: ChatId, content: ChatReaction): Promise<void> {
-		return invoke('send_reaction', {
+		return invokeAfterSetup('send_reaction', {
 			chatId,
 			content,
 		});

--- a/packages/stores/src/direct-chats/direct-chat-client.ts
+++ b/packages/stores/src/direct-chats/direct-chat-client.ts
@@ -1,7 +1,6 @@
-import { invoke } from '@tauri-apps/api/core';
-
 import { AgentId, Hash } from '../p2panda/types';
 import { ChatId, ChatReaction, OutgoingMedia } from '../types';
+import { invoke } from '../utils/invoke';
 
 export interface IDirectChatClient {
 	chatId(peer: AgentId): Promise<ChatId>;

--- a/packages/stores/src/group-chats/group-chat-client.ts
+++ b/packages/stores/src/group-chats/group-chat-client.ts
@@ -1,6 +1,6 @@
 import { AgentId, DeviceId, Hash } from '../p2panda/types';
 import { ChatId, GroupInfo, OutgoingMedia } from '../types';
-import { invoke } from '../utils/invoke';
+import { invokeAfterSetup } from '../utils/invoke-after-setup';
 
 export interface GroupMember {
 	agentId: AgentId;
@@ -31,14 +31,14 @@ export interface IGroupChatClient {
 
 export class GroupChatClient implements IGroupChatClient {
 	async getMembers(chatId: ChatId): Promise<GroupMember[]> {
-		return invoke('get_group_members', { chatId });
+		return invokeAfterSetup('get_group_members', { chatId });
 	}
 
 	async addMember(chatId: ChatId, member: AgentId): Promise<void> {
-		await invoke('add_group_member', { chatId, agentId: member });
+		await invokeAfterSetup('add_group_member', { chatId, agentId: member });
 	}
 	async removeMember(chatId: ChatId, member: AgentId): Promise<void> {
-		await invoke('remove_group_member', { chatId, agentId: member });
+		await invokeAfterSetup('remove_group_member', { chatId, agentId: member });
 	}
 
 	sendMessage(
@@ -46,17 +46,17 @@ export class GroupChatClient implements IGroupChatClient {
 		message: string,
 		media: OutgoingMedia | null,
 	): Promise<Hash> {
-		return invoke('send_message', {
+		return invokeAfterSetup('send_message', {
 			chatId,
 			message,
 			media,
 		});
 	}
 	markMessagesRead(chatId: ChatId, messageHashes: Hash[]): Promise<void> {
-		return invoke('mark_messages_read', { chatId, messageHashes });
+		return invokeAfterSetup('mark_messages_read', { chatId, messageHashes });
 	}
 	setInfo(chatId: ChatId, info: GroupInfo): Promise<void> {
-		return invoke('set_group_info', { chatId, info });
+		return invokeAfterSetup('set_group_info', { chatId, info });
 	}
 	async promoteToAdministrator(
 		chatId: ChatId,
@@ -68,7 +68,7 @@ export class GroupChatClient implements IGroupChatClient {
 	): Promise<void> {}
 
 	async leaveGroup(chatId: ChatId): Promise<void> {
-		await invoke('leave_group', { chatId });
+		await invokeAfterSetup('leave_group', { chatId });
 	}
 
 	async deleteGroup(): Promise<void> {}

--- a/packages/stores/src/group-chats/group-chat-client.ts
+++ b/packages/stores/src/group-chats/group-chat-client.ts
@@ -1,7 +1,6 @@
-import { invoke } from '@tauri-apps/api/core';
-
 import { AgentId, DeviceId, Hash } from '../p2panda/types';
 import { ChatId, GroupInfo, OutgoingMedia } from '../types';
+import { invoke } from '../utils/invoke';
 
 export interface GroupMember {
 	agentId: AgentId;

--- a/packages/stores/src/index.ts
+++ b/packages/stores/src/index.ts
@@ -31,3 +31,4 @@ export * from './mailbox-tracker/mailbox-tracker-store.js';
 export * from './mailbox-tracker/types.js';
 
 export * from './utils/memo.js';
+export * from './utils/invoke-after-setup.js';

--- a/packages/stores/src/p2panda/tauri-logs-client.ts
+++ b/packages/stores/src/p2panda/tauri-logs-client.ts
@@ -1,25 +1,25 @@
 import { listen } from '@tauri-apps/api/event';
 import { type UnsubscribeFunction } from 'emittery';
 
-import { invoke } from '../utils/invoke';
+import { invokeAfterSetup } from '../utils/invoke-after-setup';
 import type { LogsClient } from './logs-client';
 import type { SimplifiedOperation } from './simplified-types';
 import type { TopicId, VerifyingKey } from './types';
 
 export class TauriLogsClient<PAYLOAD> implements LogsClient<PAYLOAD> {
 	// myPubKey(): Promise<VerifyingKey> {
-	// 	return invoke('my_pub_key');
+	// 	return invokeAfterSetup('my_pub_key');
 	// }
 
 	async getLog(
 		topicId: TopicId,
 		author: VerifyingKey,
 	): Promise<SimplifiedOperation<PAYLOAD>[]> {
-		return invoke('get_log', { topicId, author });
+		return invokeAfterSetup('get_log', { topicId, author });
 	}
 
 	async getAuthorsForTopic(topicId: TopicId): Promise<VerifyingKey[]> {
-		return invoke('get_authors', { topicId });
+		return invokeAfterSetup('get_authors', { topicId });
 	}
 
 	onNewOperation(

--- a/packages/stores/src/p2panda/tauri-logs-client.ts
+++ b/packages/stores/src/p2panda/tauri-logs-client.ts
@@ -1,7 +1,7 @@
-import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { type UnsubscribeFunction } from 'emittery';
 
+import { invoke } from '../utils/invoke';
 import type { LogsClient } from './logs-client';
 import type { SimplifiedOperation } from './simplified-types';
 import type { TopicId, VerifyingKey } from './types';

--- a/packages/stores/src/settings/settings-client.ts
+++ b/packages/stores/src/settings/settings-client.ts
@@ -1,6 +1,7 @@
-import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { type UnsubscribeFunction } from 'emittery';
+
+import { invoke } from '../utils/invoke';
 
 export interface Settings {
 	qr_color: string | null;

--- a/packages/stores/src/settings/settings-client.ts
+++ b/packages/stores/src/settings/settings-client.ts
@@ -1,7 +1,7 @@
 import { listen } from '@tauri-apps/api/event';
 import { type UnsubscribeFunction } from 'emittery';
 
-import { invoke } from '../utils/invoke';
+import { invokeAfterSetup } from '../utils/invoke-after-setup';
 
 export interface Settings {
 	qr_color: string | null;
@@ -20,15 +20,15 @@ export interface ISettingsClient {
 
 export class SettingsClient implements ISettingsClient {
 	getSettings(): Promise<Settings> {
-		return invoke('get_settings');
+		return invokeAfterSetup('get_settings');
 	}
 
 	setSetting(key: string, value: unknown): Promise<void> {
-		return invoke('set_setting', { key, value });
+		return invokeAfterSetup('set_setting', { key, value });
 	}
 
 	setLocalMailboxEnabled(enabled: boolean): Promise<void> {
-		return invoke('set_local_mailbox_enabled', { enabled });
+		return invokeAfterSetup('set_local_mailbox_enabled', { enabled });
 	}
 
 	setNotificationsEnabled(enabled: boolean): Promise<void> {

--- a/packages/stores/src/utils/invoke-after-setup.ts
+++ b/packages/stores/src/utils/invoke-after-setup.ts
@@ -20,20 +20,20 @@ const isBackendNotReady = (error: unknown): boolean => {
 	return message.includes(BACKEND_NOT_READY);
 };
 
-const delay = (ms: number): Promise<void> =>
+export const sleep = (ms: number): Promise<void> =>
 	new Promise(resolve => setTimeout(resolve, ms));
 
-export async function invoke<T>(
+export async function invokeAfterSetup<T>(
 	cmd: string,
 	args?: InvokeArgs,
 	options?: InvokeOptions,
 ): Promise<T> {
-	for (let attempt = 0; ; attempt++) {
+	for (let attempt = 1; ; attempt++) {
 		try {
 			return await tauriInvoke<T>(cmd, args, options);
 		} catch (error) {
 			if (!isBackendNotReady(error) || attempt >= MAX_ATTEMPTS) throw error;
-			await delay(RETRY_DELAY_MS);
+			await sleep(RETRY_DELAY_MS);
 		}
 	}
 }

--- a/packages/stores/src/utils/invoke.ts
+++ b/packages/stores/src/utils/invoke.ts
@@ -1,0 +1,39 @@
+import {
+	type InvokeArgs,
+	type InvokeOptions,
+	invoke as tauriInvoke,
+} from '@tauri-apps/api/core';
+
+// Tauri returns this framework error when a command needs managed state that
+// hasn't been registered yet. At startup the webview can invoke node-backed
+// commands before `async_setup` reaches `app_handle.manage(node)` (the node is
+// built before it is managed). The error is transient — retry briefly until the
+// node is managed. Every other error propagates immediately.
+const BACKEND_NOT_READY = 'state not managed';
+
+const MAX_ATTEMPTS = 50;
+const RETRY_DELAY_MS = 100;
+
+const isBackendNotReady = (error: unknown): boolean => {
+	const message =
+		typeof error === 'string' ? error : ((error as Error)?.message ?? '');
+	return message.includes(BACKEND_NOT_READY);
+};
+
+const delay = (ms: number): Promise<void> =>
+	new Promise(resolve => setTimeout(resolve, ms));
+
+export async function invoke<T>(
+	cmd: string,
+	args?: InvokeArgs,
+	options?: InvokeOptions,
+): Promise<T> {
+	for (let attempt = 0; ; attempt++) {
+		try {
+			return await tauriInvoke<T>(cmd, args, options);
+		} catch (error) {
+			if (!isBackendNotReady(error) || attempt >= MAX_ATTEMPTS) throw error;
+			await delay(RETRY_DELAY_MS);
+		}
+	}
+}

--- a/packages/stores/src/utils/tauri-channel.ts
+++ b/packages/stores/src/utils/tauri-channel.ts
@@ -1,5 +1,7 @@
-import { Channel, invoke } from '@tauri-apps/api/core';
+import { Channel } from '@tauri-apps/api/core';
 import { type ReactivePromise, relay } from 'signalium';
+
+import { invoke } from './invoke';
 
 interface TauriChannelInternals {
 	id: number;

--- a/packages/stores/src/utils/tauri-channel.ts
+++ b/packages/stores/src/utils/tauri-channel.ts
@@ -1,7 +1,7 @@
 import { Channel } from '@tauri-apps/api/core';
 import { type ReactivePromise, relay } from 'signalium';
 
-import { invoke } from './invoke';
+import { invokeAfterSetup } from './invoke-after-setup';
 
 interface TauriChannelInternals {
 	id: number;
@@ -37,7 +37,7 @@ export function subscribeChannel<T>(
 		channel.onmessage = v => {
 			state.value = v;
 		};
-		invoke(command, { onEvent: channel, ...args });
+		invokeAfterSetup(command, { onEvent: channel, ...args });
 		return () => unregisterChannel(channel);
 	});
 }

--- a/ui/src/lib/utils/gallery.ts
+++ b/ui/src/lib/utils/gallery.ts
@@ -8,10 +8,13 @@ import {
 	requestAlbums,
 	requestPhotosAuth,
 } from '@gbyte/tauri-plugin-ios-photos';
-import { invoke } from '@tauri-apps/api/core';
 import { appCacheDir, join } from '@tauri-apps/api/path';
 import { writeFile } from '@tauri-apps/plugin-fs';
-import type { FileAttachment, PhotoAttachment } from 'dash-chat-stores';
+import {
+	type FileAttachment,
+	type PhotoAttachment,
+	invokeAfterSetup,
+} from 'dash-chat-stores';
 import { AndroidFs, AndroidPublicImageDir } from 'tauri-plugin-android-fs-api';
 import { view } from 'tauri-plugin-view-api';
 
@@ -80,7 +83,7 @@ async function getOrCreateAlbum(title: string): Promise<string> {
  * Mobile-only; the caller handles desktop/browser saving.
  */
 export async function saveAndOpenFile(file: FileAttachment): Promise<void> {
-	const path = await invoke<string>('save_blob_to_cache', {
+	const path = await invokeAfterSetup<string>('save_blob_to_cache', {
 		hash: file.hash,
 		name: file.name,
 	});

--- a/ui/src/lib/utils/mailto.ts
+++ b/ui/src/lib/utils/mailto.ts
@@ -1,6 +1,6 @@
-import { invoke } from '@tauri-apps/api/core';
 import { appCacheDir, join } from '@tauri-apps/api/path';
 import { mkdir, writeFile } from '@tauri-apps/plugin-fs';
+import { invokeAfterSetup } from 'dash-chat-stores';
 
 interface MailtoRequest {
 	subject: string;
@@ -14,7 +14,7 @@ export async function sendMailto(request: MailtoRequest): Promise<void> {
 	let body = request.body;
 	if (request.includeDebugLog) {
 		try {
-			const redactedPath = await invoke<string>('get_redacted_log');
+			const redactedPath = await invokeAfterSetup<string>('get_redacted_log');
 			attachments = [redactedPath];
 		} catch (e) {
 			console.error('Failed to get redacted log for mailto:', e);
@@ -27,7 +27,7 @@ export async function sendMailto(request: MailtoRequest): Promise<void> {
 		attachments = [...(attachments ?? []), ...paths];
 	}
 
-	await invoke('plugin:mailto|mailto', {
+	await invokeAfterSetup('plugin:mailto|mailto', {
 		request: {
 			email: 'support@dashchat.org',
 			subject: request.subject,

--- a/ui/src/lib/utils/theme.ts
+++ b/ui/src/lib/utils/theme.ts
@@ -6,8 +6,8 @@ async function setSystemBarsStyle(
 	statusBarStyle: BarStyle,
 	navigationBarStyle: BarStyle,
 ) {
-	const { invoke } = await import('@tauri-apps/api/core');
-	await invoke('plugin:system-bars-styles|set_style', {
+	const { invokeAfterSetup } = await import('dash-chat-stores');
+	await invokeAfterSetup('plugin:system-bars-styles|set_style', {
 		statusBarStyle,
 		navigationBarStyle,
 		navigationBarTransparent: true,

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -4,9 +4,9 @@
 
 	import '../app.css';
 	import { setContext } from 'svelte';
-	import { invoke } from '@tauri-apps/api/core';
 
 	import {
+		invokeAfterSetup,
 		ChatsClient,
 		ChatsStore,
 		LogsStore,
@@ -147,9 +147,9 @@
 
 		mailboxTrackerStore = new MailboxTrackerStore();
 
-		invoke('log_webview_info', { userAgent: navigator.userAgent }).catch(
-			() => {},
-		);
+		invokeAfterSetup('log_webview_info', {
+			userAgent: navigator.userAgent,
+		}).catch(() => {});
 	}
 
 	setContext('settings-store', settingsStore);

--- a/ui/src/routes/settings/account/+page.svelte
+++ b/ui/src/routes/settings/account/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { invoke } from '@tauri-apps/api/core';
+	import { invokeAfterSetup } from 'dash-chat-stores';
 	import { goto } from '$app/navigation';
 	import { m } from '$lib/paraglide/messages.js';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
@@ -25,7 +25,7 @@
 		try {
 			// On success the app exits immediately,
 			// so no code after this line executes on the happy path.
-			await invoke('delete_account');
+			await invokeAfterSetup('delete_account');
 		} catch (e) {
 			console.error(e);
 			showToast(m.errorDeleteAccount(), 'error');


### PR DESCRIPTION
The app setup process has a race between the backend dash chat `Node` being ready and managed by the tauri app, and the frontend code invoking functions that need the `Node` already managed.

Up until now, this has worked because we haven't seen node initialization processes take long enough to trigger it. I can reliably reproduce the issue now in v0.19.4-staging.

We solve this by centralizing all invoke calls, and catching the node initialization error, and retrying the invoke call.