### PR TITLE
Mailbox discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -201,7 +201,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1966,6 +1966,7 @@ dependencies = [
  "iana-time-zone",
  "if-watch",
  "image",
+ "iroh",
  "jni 0.21.1",
  "libc",
  "log",
@@ -2147,7 +2148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2453,7 +2454,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2840,7 +2841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3468,8 +3469,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4225,12 +4226,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
+ "windows-registry 0.5.3",
 ]
 
 [[package]]
@@ -4245,7 +4246,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5679,7 +5680,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6076,7 +6077,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash 2.1.2",
  "rustls 0.23.41",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -6121,7 +6122,7 @@ checksum = "b3c1520eacd33fd6b009e2e70116b05508ade51db5e0d315ff8bf6b702148c2b"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -6164,7 +6165,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6290,7 +6291,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -6977,7 +6978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -7018,7 +7019,7 @@ dependencies = [
 [[package]]
 name = "p2panda"
 version = "0.6.1"
-source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#c2e1a3ba1f69f791837a97582b07f0ec270d8710"
+source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#5a9fb88c194a4ad09b343ed5e5734206d99d63e2"
 dependencies = [
  "futures-util",
  "p2panda-auth",
@@ -7039,7 +7040,7 @@ dependencies = [
 [[package]]
 name = "p2panda-auth"
 version = "0.6.1"
-source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#c2e1a3ba1f69f791837a97582b07f0ec270d8710"
+source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#5a9fb88c194a4ad09b343ed5e5734206d99d63e2"
 dependencies = [
  "p2panda-core",
  "p2panda-store",
@@ -7056,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "p2panda-core"
 version = "0.6.1"
-source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#c2e1a3ba1f69f791837a97582b07f0ec270d8710"
+source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#5a9fb88c194a4ad09b343ed5e5734206d99d63e2"
 dependencies = [
  "blake3",
  "ciborium",
@@ -7071,7 +7072,7 @@ dependencies = [
 [[package]]
 name = "p2panda-discovery"
 version = "0.6.1"
-source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#c2e1a3ba1f69f791837a97582b07f0ec270d8710"
+source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#5a9fb88c194a4ad09b343ed5e5734206d99d63e2"
 dependencies = [
  "blake3",
  "futures-util",
@@ -7086,7 +7087,7 @@ dependencies = [
 [[package]]
 name = "p2panda-encryption"
 version = "0.6.1"
-source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#c2e1a3ba1f69f791837a97582b07f0ec270d8710"
+source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#5a9fb88c194a4ad09b343ed5e5734206d99d63e2"
 dependencies = [
  "chacha20poly1305",
  "curve25519-dalek 4.1.3",
@@ -7109,7 +7110,7 @@ dependencies = [
 [[package]]
 name = "p2panda-net"
 version = "0.6.1"
-source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#c2e1a3ba1f69f791837a97582b07f0ec270d8710"
+source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#5a9fb88c194a4ad09b343ed5e5734206d99d63e2"
 dependencies = [
  "ciborium",
  "futures-channel",
@@ -7137,7 +7138,7 @@ dependencies = [
 [[package]]
 name = "p2panda-spaces"
 version = "0.6.1"
-source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#c2e1a3ba1f69f791837a97582b07f0ec270d8710"
+source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#5a9fb88c194a4ad09b343ed5e5734206d99d63e2"
 dependencies = [
  "p2panda-auth",
  "p2panda-core",
@@ -7151,7 +7152,7 @@ dependencies = [
 [[package]]
 name = "p2panda-store"
 version = "0.6.1"
-source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#c2e1a3ba1f69f791837a97582b07f0ec270d8710"
+source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#5a9fb88c194a4ad09b343ed5e5734206d99d63e2"
 dependencies = [
  "p2panda-core",
  "rand 0.10.1",
@@ -7165,7 +7166,7 @@ dependencies = [
 [[package]]
 name = "p2panda-stream"
 version = "0.6.1"
-source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#c2e1a3ba1f69f791837a97582b07f0ec270d8710"
+source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#5a9fb88c194a4ad09b343ed5e5734206d99d63e2"
 dependencies = [
  "futures-core",
  "p2panda-core",
@@ -7178,7 +7179,7 @@ dependencies = [
 [[package]]
 name = "p2panda-sync"
 version = "0.6.1"
-source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#c2e1a3ba1f69f791837a97582b07f0ec270d8710"
+source = "git+https://github.com/maackle/p2panda?branch=add-groups-to-node-extensions#5a9fb88c194a4ad09b343ed5e5734206d99d63e2"
 dependencies = [
  "futures",
  "futures-util",
@@ -8301,7 +8302,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix 1.1.4",
- "windows 0.62.2",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -8696,7 +8697,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8801,7 +8802,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9007,7 +9008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9468,7 +9469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10778,7 +10779,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11354,7 +11355,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11435,7 +11436,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12079,7 +12080,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12737,8 +12738,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.18",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]

--- a/crates/dashchat-node/src/error.rs
+++ b/crates/dashchat-node/src/error.rs
@@ -8,6 +8,9 @@ pub enum Error {
     #[error("Failed to initialize topic: {0}")]
     InitializeTopic(String),
 
+    #[error("Failed to register bootstrap node: {0}")]
+    RegisterBootstrap(String),
+
     #[error("Failed to author operation: {0}")]
     AuthorOperation(String),
 

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -4,7 +4,7 @@ pub(crate) mod publish;
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::PathBuf;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use crate::blob_sync::{BlobFetchConfig, BlobFetchPool, BlobSync, SENTINEL_OP_HASH};
 use crate::compat::Capabilities;
@@ -38,15 +38,9 @@ use crate::{
     AgentId, AsBody, ChatId, ChatReaction, DeviceGroupId, DeviceGroupPayload, DeviceId,
     DirectChatId, MediaBundle, MediaMetaKind, MediaMetadata, OutgoingFile, OutgoingMedia,
 };
-use dashchat_utils::NETWORK_ID;
+use dashchat_utils::{NETWORK_ID, RELAY_URL};
 
 pub use app_processing::Notification;
-
-pub static RELAY_URL: LazyLock<RelayUrl> = LazyLock::new(|| {
-    "https://euc1-1.relay.n0.iroh-canary.iroh.link"
-        .parse()
-        .expect("valid relay URL")
-});
 
 #[derive(Clone, Debug)]
 pub struct NodeConfig {

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -983,6 +983,13 @@ impl Node {
             .await
             .map_err(|e| AddContactError::StoreContact(e.to_string()))?;
 
+        // Register the scanned contact as a bootstrap so p2panda discovery can
+        // reach it directly over the internet (relay + pkarr), rather than
+        // depending on a mutually-reachable mailbox to introduce the two nodes.
+        self.register_bootstrap_node(*contact.device_pubkey)
+            .await
+            .map_err(|e| Error::RegisterBootstrap(e.to_string()))?;
+
         // SPACES: Register the member in the spaces manager
 
         // Must subscribe to the new member's device group in order to receive their

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -381,6 +381,26 @@ impl Node {
             .expect("device id is a valid endpoint id")
     }
 
+    /// The underlying iroh endpoint. An in-process mailbox shares this so its
+    /// `/health` response advertises the node's dialing address.
+    pub async fn iroh_endpoint(&self) -> Result<iroh::Endpoint> {
+        Ok(self.endpoint.endpoint().await?)
+    }
+
+    /// Add a mailbox's dialing address (relay + direct addresses) to the
+    /// p2panda address book so the iroh blob downloader can reach the mailbox
+    /// by its EndpointId. The address is learned out-of-band from the mailbox's
+    /// `/health` endpoint.
+    pub async fn insert_mailbox_addr(&self, addr: iroh::EndpointAddr) -> Result<()> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.actor_tx
+            .send(Command::RegisterMailboxAddr { addr, reply_tx })
+            .await
+            .map_err(|err| anyhow::anyhow!("send to actor error: {err}"))?;
+        reply_rx.await??;
+        Ok(())
+    }
+
     #[cfg(feature = "testing")]
     /// The node's iroh-blobs protocol handle, sharing its blob store. An
     /// in-process mailbox uses this so relayed blobs land in—and are served

--- a/crates/dashchat-node/src/node/actor.rs
+++ b/crates/dashchat-node/src/node/actor.rs
@@ -50,6 +50,10 @@ pub(crate) enum Command {
         relay_url: RelayUrl,
         reply_tx: oneshot::Sender<Result<(), NodeActorError>>,
     },
+    RegisterMailboxAddr {
+        addr: iroh::EndpointAddr,
+        reply_tx: oneshot::Sender<Result<(), NodeActorError>>,
+    },
     Shutdown {
         reply_tx: oneshot::Sender<()>,
     },
@@ -171,6 +175,10 @@ impl Actor {
                                 let _ = reply_tx.send(result);
 
                             },
+                            Command::RegisterMailboxAddr { addr, reply_tx } => {
+                                let result = self.handle_register_mailbox_addr(addr).await;
+                                let _ = reply_tx.send(result);
+                            },
                             Command::Shutdown { reply_tx } => {
                                 // Drop self and then break out of the processing loop which will
                                 // cause the actor task to complete.
@@ -268,6 +276,14 @@ impl Actor {
         relay_url: RelayUrl,
     ) -> Result<(), NodeActorError> {
         self.inner.insert_bootstrap(node_id, relay_url).await?;
+        Ok(())
+    }
+
+    async fn handle_register_mailbox_addr(
+        &self,
+        addr: iroh::EndpointAddr,
+    ) -> Result<(), NodeActorError> {
+        self.inner.insert_node_addr(addr).await?;
         Ok(())
     }
 

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -529,29 +529,39 @@ impl Node {
         // via a dedicated channel.
         if let Source::ExternalStream { .. } = source {
             let node_id: NodeId = operation.author().into();
-
-            // Only register the bootstrap if we didn't already do so.
-            if self
-                .registered_bootstraps
-                .lock()
-                .await
-                .insert((node_id, RELAY_URL.clone()))
-            {
-                debug!(node_id = %node_id, "add bootstrap node");
-                let (reply_tx, reply_rx) = oneshot::channel();
-                self.actor_tx
-                    .send(Command::RegisterBootstrap {
-                        node_id,
-                        relay_url: RELAY_URL.clone(),
-                        reply_tx,
-                    })
-                    .await
-                    .map_err(|err| anyhow::anyhow!("send to actor error: {err}"))?;
-
-                reply_rx.await??;
-            };
+            self.register_bootstrap_node(node_id).await?;
         }
 
+        Ok(())
+    }
+
+    /// Register a single node as a bootstrap (on the shared relay) so p2panda
+    /// discovery can reach it. Deduplicated so repeated calls are cheap. Used
+    /// both for mailbox-stream authors and for a freshly-scanned contact, the
+    /// latter letting two nodes connect directly over the internet (relay +
+    /// pkarr) without depending on a mutually-reachable mailbox.
+    pub(crate) async fn register_bootstrap_node(&self, node_id: NodeId) -> anyhow::Result<()> {
+        if !self
+            .registered_bootstraps
+            .lock()
+            .await
+            .insert((node_id, RELAY_URL.clone()))
+        {
+            return Ok(());
+        }
+
+        debug!(node_id = %node_id, "add bootstrap node");
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.actor_tx
+            .send(Command::RegisterBootstrap {
+                node_id,
+                relay_url: RELAY_URL.clone(),
+                reply_tx,
+            })
+            .await
+            .map_err(|err| anyhow::anyhow!("send to actor error: {err}"))?;
+
+        reply_rx.await??;
         Ok(())
     }
 

--- a/crates/dashchat-node/tests/mailbox_blob_sync.rs
+++ b/crates/dashchat-node/tests/mailbox_blob_sync.rs
@@ -187,3 +187,26 @@ async fn media_blob_relays_through_mailbox_when_sender_offline() {
 
     server.stop().await;
 }
+
+/// A node can add a mailbox's dialing address to its p2panda address book.
+///
+/// This exercises the full client-side wiring added for mailbox dialability:
+/// `Node::insert_mailbox_addr` → the `RegisterMailboxAddr` actor command → the
+/// p2panda `Node::insert_node_addr` → `AddressBook::insert_node_info`. Without
+/// this path the iroh blob downloader can't reach a mailbox by its EndpointId.
+/// We feed it a real `EndpointAddr` (the host node's own) and assert the insert
+/// succeeds end-to-end.
+#[tokio::test(flavor = "multi_thread")]
+async fn node_inserts_mailbox_addr_into_address_book() {
+    let config = NodeConfig::testing();
+
+    // A stand-in "mailbox" endpoint: any real, well-formed EndpointAddr works.
+    let host = TestNode::new(config.clone(), "host").await;
+    let mailbox_addr = host.iroh_endpoint().await.unwrap().addr();
+
+    let client = TestNode::new(config.clone(), "client").await;
+    client
+        .insert_mailbox_addr(mailbox_addr)
+        .await
+        .expect("inserting a mailbox addr into the address book should succeed");
+}

--- a/crates/dashchat-node/tests/mailbox_blob_sync.rs
+++ b/crates/dashchat-node/tests/mailbox_blob_sync.rs
@@ -50,7 +50,7 @@ async fn media_blob_relays_through_mailbox_when_sender_offline() {
         db_path,
         relay.blobs(),
         relay.blob_downloader(),
-        relay.endpoint_id(),
+        relay.iroh_endpoint().await.unwrap(),
         Some(mailbox_server::FetchConfig {
             concurrency: 4,
             attempt_timeout: Duration::from_secs(10),

--- a/crates/dashchat-utils/src/lib.rs
+++ b/crates/dashchat-utils/src/lib.rs
@@ -10,3 +10,9 @@ pub use retry_with_backoff::retry_with_backoff;
 pub use singleton_task_with_retries::SingletonTaskWithRetries;
 
 pub const NETWORK_ID: &[u8; 32] = b"usability, reliability, security";
+
+pub static RELAY_URL: std::sync::LazyLock<iroh::RelayUrl> = std::sync::LazyLock::new(|| {
+    "https://euc1-1.relay.n0.iroh-canary.iroh.link"
+        .parse()
+        .expect("valid relay URL")
+});

--- a/crates/mailbox-local-server/src/lib.rs
+++ b/crates/mailbox-local-server/src/lib.rs
@@ -69,7 +69,7 @@ pub async fn spawn_local_mailbox_server(
             let _ = stop_signal_rx.await;
         };
         if let Err(e) =
-            mailbox_server::spawn_server(db_path, addr, None, Some(blob_sync), None, signal).await
+            mailbox_server::spawn_server(db_path, addr, None, Some(blob_sync), signal).await
         {
             log::error!("Local mailbox server failed: {e:?}");
         }

--- a/crates/mailbox-local-server/src/lib.rs
+++ b/crates/mailbox-local-server/src/lib.rs
@@ -47,12 +47,12 @@ pub async fn spawn_local_mailbox_server(
     db_path: PathBuf,
     blobs: BlobsProtocol,
     downloader: Downloader,
-    endpoint_id: EndpointId,
+    endpoint: iroh::Endpoint,
     fetch_config: Option<FetchConfig>,
 ) -> anyhow::Result<LocalMailboxServer> {
     let port = free_port()?;
 
-    let mut blob_sync = BlobSync::shared(blobs, downloader, endpoint_id);
+    let mut blob_sync = BlobSync::shared(blobs, downloader, endpoint);
     if let Some(fetch_config) = fetch_config {
         blob_sync = blob_sync.with_fetch_config(fetch_config);
     }
@@ -69,7 +69,7 @@ pub async fn spawn_local_mailbox_server(
             let _ = stop_signal_rx.await;
         };
         if let Err(e) =
-            mailbox_server::spawn_server(db_path, addr, None, Some(blob_sync), signal).await
+            mailbox_server::spawn_server(db_path, addr, None, Some(blob_sync), None, signal).await
         {
             log::error!("Local mailbox server failed: {e:?}");
         }

--- a/crates/mailbox-server/Cargo.toml
+++ b/crates/mailbox-server/Cargo.toml
@@ -46,6 +46,7 @@ optional = true
 
 [dev-dependencies]
 mailbox-server = { path = ".", features = ["test_utils"] }
+iroh = { workspace = true }
 tempfile = "3.14"
 push-notifications-client = { path = "../push-notifications-client" }
 push-notifications-server = { path = "../push-notifications-server", features = ["test-utils"] }

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -138,10 +138,11 @@ impl BlobSync {
         root: PathBuf,
         relay_url: Option<iroh::RelayUrl>,
     ) -> anyhow::Result<Self> {
-        let mut builder = iroh::Endpoint::builder(presets::Minimal).secret_key(secret_key);
+        let mut builder = iroh::Endpoint::builder(presets::N0).secret_key(secret_key);
         if let Some(relay_url) = relay_url {
-            builder = builder
-                .relay_mode(iroh::RelayMode::Custom(iroh::RelayMap::from_iter([relay_url])));
+            builder = builder.relay_mode(iroh::RelayMode::Custom(iroh::RelayMap::from_iter([
+                relay_url,
+            ])));
         }
         let endpoint = builder.bind().await?;
 

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -110,7 +110,12 @@ pub struct BlobSync {
     pub blobs: iroh_blobs::BlobsProtocol,
     pub(crate) fetch_pool: BlobFetchPool,
     downloader: Downloader,
-    endpoint_id: iroh::EndpointId,
+    /// The iroh endpoint blobs are served from. Held both to keep a
+    /// standalone server's endpoint alive and to read its live [`EndpointAddr`]
+    /// (relay + direct addresses) for the `/health` response so clients can
+    /// dial this mailbox by its EndpointId. In the shared model this is a clone
+    /// of the in-process node's endpoint.
+    endpoint: iroh::Endpoint,
     fetch_config: FetchConfig,
     /// True when this BlobSync owns its blob store (standalone server) and is
     /// therefore responsible for GCing stored blobs. False when sharing an
@@ -118,17 +123,32 @@ pub struct BlobSync {
     enable_gc: bool,
     /// Held only when this BlobSync owns its iroh endpoint (standalone server).
     /// `None` when sharing an in-process node's endpoint, in which case the
-    /// node keeps the endpoint, router, and blob store alive.
-    _endpoint: Option<iroh::Endpoint>,
+    /// node keeps the router and blob store alive.
     _router: Option<Router>,
 }
 
 impl BlobSync {
-    pub async fn new(secret_key: iroh::SecretKey, root: PathBuf) -> anyhow::Result<Self> {
-        let endpoint = iroh::Endpoint::builder(presets::N0)
-            .secret_key(secret_key)
-            .bind()
-            .await?;
+    /// Build a standalone mailbox BlobSync that owns its own iroh endpoint and
+    /// blob store. When `relay_url` is set the endpoint registers with that
+    /// relay so it is reachable behind NAT and its advertised [`EndpointAddr`]
+    /// includes the relay; the call waits (bounded) for the relay connection so
+    /// the first `/health` response carries a complete address.
+    pub async fn new(
+        secret_key: iroh::SecretKey,
+        root: PathBuf,
+        relay_url: Option<iroh::RelayUrl>,
+    ) -> anyhow::Result<Self> {
+        let mut builder = iroh::Endpoint::builder(presets::Minimal).secret_key(secret_key);
+        if let Some(relay_url) = relay_url {
+            builder = builder
+                .relay_mode(iroh::RelayMode::Custom(iroh::RelayMap::from_iter([relay_url])));
+        }
+        let endpoint = builder.bind().await?;
+
+        // `endpoint.addr()` only includes the relay once the endpoint has
+        // connected to it, so wait for that before serving `/health`. Bounded
+        // so an unreachable relay can't block server startup indefinitely.
+        let _ = tokio::time::timeout(Duration::from_secs(10), endpoint.online()).await;
 
         let db_path = root.join("blobs.db");
         let mut options = iroh_blobs::store::fs::options::Options::new(&root);
@@ -145,16 +165,14 @@ impl BlobSync {
         let router = Router::builder(endpoint.clone())
             .accept(mixed_alpn, blobs.clone())
             .spawn();
-        let endpoint_id = endpoint.id();
 
         Ok(Self {
             blobs,
             fetch_pool: BlobFetchPool::default(),
             downloader,
-            endpoint_id,
+            endpoint,
             fetch_config: FetchConfig::default(),
             enable_gc: true,
-            _endpoint: Some(endpoint),
             _router: Some(router),
         })
     }
@@ -162,20 +180,20 @@ impl BlobSync {
     /// Build a mailbox BlobSync that shares an existing iroh endpoint and blob
     /// store (the in-process node's) instead of creating its own. Relayed blobs
     /// land in the shared store and are served by the node's existing protocol,
-    /// so the mailbox's EndpointId is the node's EndpointId.
+    /// so the mailbox's EndpointId is the node's EndpointId and its advertised
+    /// `EndpointAddr` is the node's.
     pub fn shared(
         blobs: iroh_blobs::BlobsProtocol,
         downloader: Downloader,
-        endpoint_id: iroh::EndpointId,
+        endpoint: iroh::Endpoint,
     ) -> Self {
         Self {
             blobs,
             fetch_pool: BlobFetchPool::default(),
             downloader,
-            endpoint_id,
+            endpoint,
             fetch_config: FetchConfig::default(),
             enable_gc: false,
-            _endpoint: None,
             _router: None,
         }
     }
@@ -192,7 +210,13 @@ impl BlobSync {
     }
 
     pub fn endpoint_id(&self) -> iroh::EndpointId {
-        self.endpoint_id
+        self.endpoint.id()
+    }
+
+    /// The endpoint's current dialing address (relay + direct addresses),
+    /// served via `/health` so clients can reach this mailbox by its EndpointId.
+    pub fn endpoint_addr(&self) -> iroh::EndpointAddr {
+        self.endpoint.addr()
     }
 
     pub fn fetch_pool(&self) -> &BlobFetchPool {
@@ -319,7 +343,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let key = iroh::SecretKey::generate();
         let expected = key.public();
-        let bs = BlobSync::new(key, dir.path().to_path_buf()).await.unwrap();
+        let bs = BlobSync::new(key, dir.path().to_path_buf(), None)
+            .await
+            .unwrap();
         assert_eq!(bs.endpoint_id(), expected);
     }
 

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -149,7 +149,15 @@ impl BlobSync {
         // `endpoint.addr()` only includes the relay once the endpoint has
         // connected to it, so wait for that before serving `/health`. Bounded
         // so an unreachable relay can't block server startup indefinitely.
-        let _ = tokio::time::timeout(Duration::from_secs(10), endpoint.online()).await;
+        if let Err(e) = tokio::time::timeout(Duration::from_secs(10), endpoint.online()).await {
+            tracing::error!(
+                ?e,
+                "failed to connect to bind iroh endpoint after 10 seconds"
+            );
+            return Err(anyhow::anyhow!(
+                "failed to connect to bind iroh endpoint after 10 seconds: {e}"
+            ));
+        }
 
         let db_path = root.join("blobs.db");
         let mut options = iroh_blobs::store::fs::options::Options::new(&root);

--- a/crates/mailbox-server/src/lib.rs
+++ b/crates/mailbox-server/src/lib.rs
@@ -75,6 +75,10 @@ pub struct AppState {
 struct HealthResponse {
     status: String,
     endpoint_id: String,
+    /// The mailbox endpoint's dialing address (relay + direct addresses), so
+    /// clients can add it to their p2panda address book and dial this mailbox
+    /// by its EndpointId rather than only knowing the bare id.
+    endpoint_addr: iroh::EndpointAddr,
 }
 
 fn db_path_blobs_dir(db_path: &std::path::Path) -> std::path::PathBuf {
@@ -89,6 +93,7 @@ pub async fn spawn_server(
     addr: String,
     push_notifications_url: Option<String>,
     blob_sync: Option<BlobSync>,
+    relay_url: Option<iroh::RelayUrl>,
     signal: impl Future<Output = ()> + Send + 'static,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let db = init_db(db_path.clone())?;
@@ -104,7 +109,7 @@ pub async fn spawn_server(
             let secret_key = load_or_create_secret_key(&db_arc)
                 .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
             let blobs_root = db_path_blobs_dir(&db_path);
-            BlobSync::new(secret_key, blobs_root).await?
+            BlobSync::new(secret_key, blobs_root, relay_url).await?
         }
     };
     tracing::info!("Mailbox iroh endpoint id: {}", blob_sync.endpoint_id());
@@ -151,6 +156,7 @@ async fn health_check(State(state): State<AppState>) -> Json<HealthResponse> {
     Json(HealthResponse {
         status: "ok".to_string(),
         endpoint_id: encode_mailbox_id(state.blob_sync.endpoint_id()),
+        endpoint_addr: state.blob_sync.endpoint_addr(),
     })
 }
 

--- a/crates/mailbox-server/src/lib.rs
+++ b/crates/mailbox-server/src/lib.rs
@@ -4,6 +4,7 @@ use axum::{
     Json, Router,
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use dashchat_utils::RELAY_URL;
 use push_notifications_client::client::PushNotificationsClient;
 use redb::Database;
 use serde::{Deserialize, Serialize};
@@ -93,11 +94,12 @@ pub async fn spawn_server(
     addr: String,
     push_notifications_url: Option<String>,
     blob_sync: Option<BlobSync>,
-    relay_url: Option<iroh::RelayUrl>,
     signal: impl Future<Output = ()> + Send + 'static,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let db = init_db(db_path.clone())?;
     let db_arc = Arc::new(db);
+
+    let relay_url = Some(RELAY_URL.clone());
 
     // Spawn background cleanup task
     let cleanup_task = spawn_cleanup_task(Arc::clone(&db_arc));

--- a/crates/mailbox-server/src/main.rs
+++ b/crates/mailbox-server/src/main.rs
@@ -18,13 +18,6 @@ struct Args {
     /// URL of the push notifications server (enables push notification integration)
     #[arg(long)]
     push_notifications_url: Option<String>,
-
-    /// iroh relay URL the mailbox's blob endpoint should register with. Set this
-    /// to the same relay clients use so the mailbox is reachable behind NAT and
-    /// dialable by its EndpointId. When unset the mailbox is only reachable via
-    /// its direct (public) addresses.
-    #[arg(long)]
-    relay_url: Option<iroh::RelayUrl>,
 }
 
 #[tokio::main]
@@ -45,7 +38,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         args.addr,
         args.push_notifications_url,
         None,
-        args.relay_url,
         signal,
     )
     .await?;

--- a/crates/mailbox-server/src/main.rs
+++ b/crates/mailbox-server/src/main.rs
@@ -18,6 +18,13 @@ struct Args {
     /// URL of the push notifications server (enables push notification integration)
     #[arg(long)]
     push_notifications_url: Option<String>,
+
+    /// iroh relay URL the mailbox's blob endpoint should register with. Set this
+    /// to the same relay clients use so the mailbox is reachable behind NAT and
+    /// dialable by its EndpointId. When unset the mailbox is only reachable via
+    /// its direct (public) addresses.
+    #[arg(long)]
+    relay_url: Option<iroh::RelayUrl>,
 }
 
 #[tokio::main]
@@ -38,6 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         args.addr,
         args.push_notifications_url,
         None,
+        args.relay_url,
         signal,
     )
     .await?;

--- a/crates/mailbox-server/src/store_blips.rs
+++ b/crates/mailbox-server/src/store_blips.rs
@@ -229,7 +229,7 @@ mod tests {
     async fn store_records_blob_sources() {
         let dir = tempfile::tempdir().unwrap();
         let key = iroh::SecretKey::generate();
-        let blob_sync = crate::BlobSync::new(key, dir.path().to_path_buf())
+        let blob_sync = crate::BlobSync::new(key, dir.path().to_path_buf(), None)
             .await
             .unwrap();
         let source = iroh::SecretKey::from_bytes(&[7; 32]).public();

--- a/crates/mailbox-server/src/test_utils.rs
+++ b/crates/mailbox-server/src/test_utils.rs
@@ -26,7 +26,7 @@ pub fn create_test_db() -> (Database, NamedTempFile) {
 pub async fn test_blob_sync() -> BlobSync {
     let dir = tempfile::tempdir().expect("tempdir");
     let key = iroh::SecretKey::generate();
-    let bs = BlobSync::new(key, dir.path().to_path_buf())
+    let bs = BlobSync::new(key, dir.path().to_path_buf(), None)
         .await
         .expect("blob sync");
     std::mem::forget(dir);

--- a/crates/mailbox-server/tests/integration.rs
+++ b/crates/mailbox-server/tests/integration.rs
@@ -1,4 +1,4 @@
-use mailbox_server::{test_utils::create_test_server, GetBlipsResponse};
+use mailbox_server::{encode_mailbox_id, test_utils::create_test_server, GetBlipsResponse};
 use serde_json::json;
 
 #[tokio::test]
@@ -19,6 +19,19 @@ async fn test_health_check() {
         id.len(),
         43,
         "base64url no-pad endpoint_id should be 43 chars"
+    );
+
+    // The dialing address clients add to their address book must deserialize as
+    // an `iroh::EndpointAddr` and identify the same endpoint as `endpoint_id`.
+    // This is the wire contract the entire client-side dialability feature
+    // depends on; if it regresses, `fetch_mailbox_health` fails to parse and no
+    // mailbox is ever made dialable.
+    let endpoint_addr: iroh::EndpointAddr = serde_json::from_value(body["endpoint_addr"].clone())
+        .expect("endpoint_addr should deserialize as an iroh::EndpointAddr");
+    assert_eq!(
+        encode_mailbox_id(endpoint_addr.id),
+        id,
+        "endpoint_addr.id must match the advertised endpoint_id"
     );
 }
 

--- a/scripts/android.just
+++ b/scripts/android.just
@@ -5,13 +5,21 @@ set working-directory := '..'
 dev:
     nix develop git+file:.#androidDev --command pnpm tauri android dev --host
 
-# install the android app via adb
+# install a release build via adb
 install:
     nix develop git+file:.#androidDev --command bash -c "adb install src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk"
+
+# install a debug build via adb
+install-debug:
+    nix develop git+file:.#androidDev --command bash -c "adb install src-tauri/gen/android/app/build/outputs/apk/universal/debug/app-universal-debug.apk"
 
 # build the android app in an APK format
 build TARGETS='aarch64 armv7 i686 x86_64':
     nix develop git+file:.#androidDev --command bash -c "pnpm tauri android build --apk -t {{TARGETS}}"
+
+# build the android app in an APK format in debug mode
+build-debug TARGETS='aarch64 armv7 i686 x86_64':
+    nix develop git+file:.#androidDev --command bash -c "pnpm tauri android build --debug --apk -t {{TARGETS}}"
 
 # build the android app in AAB format
 bundle:

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,7 @@ push-notifications-client = { path = "../crates/push-notifications-client" }
 dashchat-utils = { path = "../crates/dashchat-utils" }
 
 p2panda = { workspace = true }
+iroh = { workspace = true }
 p2panda-auth = { workspace = true }
 p2panda-core = { workspace = true }
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -10,23 +10,32 @@ fn main() {
     // (set by `just dev`), and release builds fall through to the production URLs.
     let cross_compiling = std::env::var("HOST") != std::env::var("TARGET");
     if tauri_build::is_dev() && cross_compiling {
+        println!("cargo:rerun-if-env-changed=MAILBOX_URL");
         println!("cargo:rerun-if-env-changed=MAILBOX_PORT");
+        println!("cargo:rerun-if-env-changed=PUSH_NOTIFICATIONS_SERVER_URL");
         println!("cargo:rerun-if-env-changed=PUSH_NOTIFICATIONS_SERVER_PORT");
 
-        let mailbox_port = std::env::var("MAILBOX_PORT").unwrap_or_else(|_| "3000".to_string());
-        let push_port =
-            std::env::var("PUSH_NOTIFICATIONS_SERVER_PORT").unwrap_or_else(|_| "3001".to_string());
-
-        let host = local_ip().unwrap_or_else(|| {
-            println!(
-                "cargo:warning=Could not detect local IP; falling back to 127.0.0.1. \
-                 Mobile devices will not be able to reach the dev servers."
-            );
-            "127.0.0.1".to_string()
+        let mailbox_url = std::env::var("MAILBOX_URL").unwrap_or_else(|_| {
+            let port = std::env::var("MAILBOX_PORT").unwrap_or_else(|_| "3000".to_string());
+            let host = local_ip().unwrap_or_else(|| {
+                println!(
+                    "cargo:warning=Could not detect local IP; falling back to 127.0.0.1. \
+                     Mobile devices will not be able to reach the dev servers."
+                );
+                "127.0.0.1".to_string()
+            });
+            format!("http://{host}:{port}")
         });
 
-        println!("cargo:rustc-env=MAILBOX_URL=http://{host}:{mailbox_port}");
-        println!("cargo:rustc-env=PUSH_NOTIFICATIONS_SERVER_URL=http://{host}:{push_port}");
+        let push_url = std::env::var("PUSH_NOTIFICATIONS_SERVER_URL").unwrap_or_else(|_| {
+            let port = std::env::var("PUSH_NOTIFICATIONS_SERVER_PORT")
+                .unwrap_or_else(|_| "3001".to_string());
+            let host = local_ip().unwrap_or_else(|| "127.0.0.1".to_string());
+            format!("http://{host}:{port}")
+        });
+
+        println!("cargo:rustc-env=MAILBOX_URL={mailbox_url}");
+        println!("cargo:rustc-env=PUSH_NOTIFICATIONS_SERVER_URL={push_url}");
     }
 
     tauri_build::build()

--- a/src-tauri/src/mailbox.rs
+++ b/src-tauri/src/mailbox.rs
@@ -186,6 +186,21 @@ async fn handle_browse_events(
                             node.endpoint_id(),
                         ))
                         .await;
+                    // Add the mailbox's dialing address to the address book so
+                    // the blob downloader can reach it by EndpointId rather than
+                    // relying solely on p2panda mDNS resolution timing.
+                    match crate::setup::fetch_mailbox_health(&url).await {
+                        Ok(health) => {
+                            if let Err(err) = node.insert_mailbox_addr(health.endpoint_addr).await {
+                                log::warn!(
+                                    "Failed to add local mailbox {mailbox_id} addr to address book: {err}"
+                                );
+                            }
+                        }
+                        Err(err) => log::warn!(
+                            "Failed to fetch local mailbox {mailbox_id} health for address book: {err}"
+                        ),
+                    }
                     log::info!(
                         "*** Registered local mailbox client via mdns: {mailbox_id} ({url}) ***",
                     );

--- a/src-tauri/src/mailbox/server.rs
+++ b/src-tauri/src/mailbox/server.rs
@@ -30,6 +30,7 @@ pub async fn start_local_mailbox<R: Runtime>(handle: &AppHandle<R>) -> anyhow::R
 
     let node = handle.state::<Node>();
     let endpoint_id = node.endpoint_id();
+    let endpoint = node.iroh_endpoint().await?;
     let path = FileSystem::new(handle)?.local_mailbox_db_path();
     let daemon: ServiceDaemon = handle.state::<ServiceDaemon>().inner().clone();
 
@@ -41,7 +42,7 @@ pub async fn start_local_mailbox<R: Runtime>(handle: &AppHandle<R>) -> anyhow::R
         path,
         node.blobs(),
         node.blob_downloader(),
-        endpoint_id,
+        endpoint,
         None,
     )
     .await?;

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -38,21 +38,35 @@ pub(crate) async fn build_node(
 /// the real id is known. `Mailboxes::register` is idempotent.
 pub(crate) async fn register_cloud_mailbox(node: &Node) -> anyhow::Result<()> {
     let mailbox_url = crate::mailbox::default_mailbox_url();
-    let mailbox_id = fetch_mailbox_id(&mailbox_url).await?;
-    if !node.mailboxes.is_tracked(&mailbox_id).await {
-        let mailbox_client =
-            mailbox_client::toy::ToyMailboxClient::new(mailbox_id, mailbox_url, node.endpoint_id());
+    let health = fetch_mailbox_health(&mailbox_url).await?;
+    // Add the mailbox's dialing address to the p2panda address book so the iroh
+    // blob downloader can reach it by EndpointId; without this the mailbox is
+    // known only by id and is not dialable.
+    node.insert_mailbox_addr(health.endpoint_addr).await?;
+    if !node.mailboxes.is_tracked(&health.mailbox_id).await {
+        let mailbox_client = mailbox_client::toy::ToyMailboxClient::new(
+            health.mailbox_id,
+            mailbox_url,
+            node.endpoint_id(),
+        );
         node.mailboxes.register(mailbox_client).await;
     }
     Ok(())
 }
 
-/// Fetch the canonical MailboxId from the mailbox server's /health endpoint.
-/// Returns the `endpoint_id` field which is the base64url-no-pad EndpointId.
-async fn fetch_mailbox_id(base_url: &str) -> anyhow::Result<mailbox_client::MailboxId> {
+pub(crate) struct MailboxHealth {
+    pub mailbox_id: mailbox_client::MailboxId,
+    pub endpoint_addr: iroh::EndpointAddr,
+}
+
+/// Fetch a mailbox server's `/health` response: its canonical MailboxId (the
+/// base64url-no-pad EndpointId) and its dialing address (relay + direct
+/// addresses) for the p2panda address book.
+pub(crate) async fn fetch_mailbox_health(base_url: &str) -> anyhow::Result<MailboxHealth> {
     #[derive(serde::Deserialize)]
     struct HealthResponse {
         endpoint_id: String,
+        endpoint_addr: iroh::EndpointAddr,
     }
     let url = format!("{}/health", base_url.trim_end_matches('/'));
     let resp = mailbox_client::HTTP_CLIENT
@@ -62,7 +76,10 @@ async fn fetch_mailbox_id(base_url: &str) -> anyhow::Result<mailbox_client::Mail
         .error_for_status()?
         .json::<HealthResponse>()
         .await?;
-    Ok(resp.endpoint_id)
+    Ok(MailboxHealth {
+        mailbox_id: resp.endpoint_id,
+        endpoint_addr: resp.endpoint_addr,
+    })
 }
 
 pub async fn async_setup(app_handle: AppHandle) -> anyhow::Result<()> {


### PR DESCRIPTION
- [x] insert mailbox EndpointAddr (from `/health`) into p2panda's address book for iroh-blobs comms
- [x] use n0 presets for endpoints to enable DNS address lookup as fallback
- [x] during contact exchange, add peer as p2panda bootstrap node for immediate p2p sync
