### PR TITLE
Message servers can discover clients' iroh endpoint addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -201,7 +201,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2148,7 +2148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2453,7 +2453,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2840,7 +2840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3468,8 +3468,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4225,12 +4225,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
+ "windows-registry 0.5.3",
 ]
 
 [[package]]
@@ -4245,7 +4245,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5672,7 +5672,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6065,7 +6065,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash 2.1.2",
  "rustls 0.23.41",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -6110,7 +6110,7 @@ checksum = "3137a52df66c20090a889828d1c655f21f52294cba64e5c4fbb04fc83eee7c8e"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -6153,7 +6153,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6279,7 +6279,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -6966,7 +6966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7007,7 +7007,7 @@ dependencies = [
 [[package]]
 name = "p2panda"
 version = "0.6.1"
-source = "git+https://github.com/guillemcordoba/p2panda?branch=dashchat#8de45ba2846e59ad2306689ed34a9aecdafb22f8"
+source = "git+https://github.com/dash-chat/p2panda?branch=dashchat#225018d9a7ddcf1228fb4cd158842948056ddda3"
 dependencies = [
  "futures-util",
  "p2panda-auth",
@@ -7028,7 +7028,7 @@ dependencies = [
 [[package]]
 name = "p2panda-auth"
 version = "0.6.1"
-source = "git+https://github.com/guillemcordoba/p2panda?branch=dashchat#8de45ba2846e59ad2306689ed34a9aecdafb22f8"
+source = "git+https://github.com/dash-chat/p2panda?branch=dashchat#225018d9a7ddcf1228fb4cd158842948056ddda3"
 dependencies = [
  "p2panda-core",
  "p2panda-store",
@@ -7045,7 +7045,7 @@ dependencies = [
 [[package]]
 name = "p2panda-core"
 version = "0.6.1"
-source = "git+https://github.com/guillemcordoba/p2panda?branch=dashchat#8de45ba2846e59ad2306689ed34a9aecdafb22f8"
+source = "git+https://github.com/dash-chat/p2panda?branch=dashchat#225018d9a7ddcf1228fb4cd158842948056ddda3"
 dependencies = [
  "blake3",
  "ciborium",
@@ -7060,7 +7060,7 @@ dependencies = [
 [[package]]
 name = "p2panda-discovery"
 version = "0.6.1"
-source = "git+https://github.com/guillemcordoba/p2panda?branch=dashchat#8de45ba2846e59ad2306689ed34a9aecdafb22f8"
+source = "git+https://github.com/dash-chat/p2panda?branch=dashchat#225018d9a7ddcf1228fb4cd158842948056ddda3"
 dependencies = [
  "blake3",
  "futures-util",
@@ -7075,7 +7075,7 @@ dependencies = [
 [[package]]
 name = "p2panda-encryption"
 version = "0.6.1"
-source = "git+https://github.com/guillemcordoba/p2panda?branch=dashchat#8de45ba2846e59ad2306689ed34a9aecdafb22f8"
+source = "git+https://github.com/dash-chat/p2panda?branch=dashchat#225018d9a7ddcf1228fb4cd158842948056ddda3"
 dependencies = [
  "chacha20poly1305",
  "curve25519-dalek 4.1.3",
@@ -7098,7 +7098,7 @@ dependencies = [
 [[package]]
 name = "p2panda-net"
 version = "0.6.1"
-source = "git+https://github.com/guillemcordoba/p2panda?branch=dashchat#8de45ba2846e59ad2306689ed34a9aecdafb22f8"
+source = "git+https://github.com/dash-chat/p2panda?branch=dashchat#225018d9a7ddcf1228fb4cd158842948056ddda3"
 dependencies = [
  "ciborium",
  "futures-channel",
@@ -7126,7 +7126,7 @@ dependencies = [
 [[package]]
 name = "p2panda-spaces"
 version = "0.6.1"
-source = "git+https://github.com/guillemcordoba/p2panda?branch=dashchat#8de45ba2846e59ad2306689ed34a9aecdafb22f8"
+source = "git+https://github.com/dash-chat/p2panda?branch=dashchat#225018d9a7ddcf1228fb4cd158842948056ddda3"
 dependencies = [
  "p2panda-auth",
  "p2panda-core",
@@ -7140,7 +7140,7 @@ dependencies = [
 [[package]]
 name = "p2panda-store"
 version = "0.6.1"
-source = "git+https://github.com/guillemcordoba/p2panda?branch=dashchat#8de45ba2846e59ad2306689ed34a9aecdafb22f8"
+source = "git+https://github.com/dash-chat/p2panda?branch=dashchat#225018d9a7ddcf1228fb4cd158842948056ddda3"
 dependencies = [
  "p2panda-core",
  "rand 0.10.1",
@@ -7154,7 +7154,7 @@ dependencies = [
 [[package]]
 name = "p2panda-stream"
 version = "0.6.1"
-source = "git+https://github.com/guillemcordoba/p2panda?branch=dashchat#8de45ba2846e59ad2306689ed34a9aecdafb22f8"
+source = "git+https://github.com/dash-chat/p2panda?branch=dashchat#225018d9a7ddcf1228fb4cd158842948056ddda3"
 dependencies = [
  "futures-core",
  "p2panda-core",
@@ -7167,7 +7167,7 @@ dependencies = [
 [[package]]
 name = "p2panda-sync"
 version = "0.6.1"
-source = "git+https://github.com/guillemcordoba/p2panda?branch=dashchat#8de45ba2846e59ad2306689ed34a9aecdafb22f8"
+source = "git+https://github.com/dash-chat/p2panda?branch=dashchat#225018d9a7ddcf1228fb4cd158842948056ddda3"
 dependencies = [
  "futures",
  "futures-util",
@@ -8290,7 +8290,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix 1.1.4",
- "windows 0.62.2",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -8685,7 +8685,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8790,7 +8790,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8996,7 +8996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9457,7 +9457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10767,7 +10767,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11343,7 +11343,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11424,7 +11424,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12068,7 +12068,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12726,8 +12726,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.18",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,16 +26,16 @@ mailbox-client = { path = "crates/mailbox-client" }
 mailbox-server = { path = "crates/mailbox-server" }
 mailbox-local-server = { path = "crates/mailbox-local-server" }
 
-p2panda = { git = "https://github.com/guillemcordoba/p2panda", branch = "dashchat" }
-p2panda-auth = { git = "https://github.com/guillemcordoba/p2panda", branch = "dashchat", features = [
+p2panda = { git = "https://github.com/dash-chat/p2panda", branch = "dashchat" }
+p2panda-auth = { git = "https://github.com/dash-chat/p2panda", branch = "dashchat", features = [
   "processor",
 ] }
-p2panda-core = { git = "https://github.com/guillemcordoba/p2panda", branch = "dashchat" }
-p2panda-net = { git = "https://github.com/guillemcordoba/p2panda", branch = "dashchat" }
-p2panda-store = { git = "https://github.com/guillemcordoba/p2panda", branch = "dashchat", features = [
+p2panda-core = { git = "https://github.com/dash-chat/p2panda", branch = "dashchat" }
+p2panda-net = { git = "https://github.com/dash-chat/p2panda", branch = "dashchat" }
+p2panda-store = { git = "https://github.com/dash-chat/p2panda", branch = "dashchat", features = [
   "sqlite",
 ] }
-p2panda-spaces = { git = "https://github.com/guillemcordoba/p2panda", branch = "dashchat", features = [
+p2panda-spaces = { git = "https://github.com/dash-chat/p2panda", branch = "dashchat", features = [
   "test_utils",
 ] }
 
@@ -53,13 +53,13 @@ iroh-blobs = { git = "https://github.com/maackle/iroh-blobs", branch = "main" }
 # task can't poison the store and abort the process. See the iOS push-extension /
 # shared-DB crash investigation.
 # [patch."https://github.com/p2panda/p2panda"]
-# p2panda = { git = "https://github.com/guillemcordoba/p2panda", branch = "dashchat" }
-# p2panda-auth = { git = "https://github.com/guillemcordoba/p2panda", branch = "dashchat" }
-# p2panda-core = { git = "https://github.com/guillemcordoba/p2panda", branch = "dashchat" }
-# p2panda-store = { git = "https://github.com/guillemcordoba/p2panda", branch = "dashchat" }
-# p2panda-spaces = { git = "https://github.com/guillemcordoba/p2panda", branch = "dashchat" }
-# p2panda-net = { git = "https://github.com/guillemcordoba/p2panda", branch = "dashchat" }
-# p2panda-stream = { git = "https://github.com/guillemcordoba/p2panda", branch = "dashchat" }
-# p2panda-sync = { git = "https://github.com/guillemcordoba/p2panda", branch = "dashchat" }
-# p2panda-discovery = { git = "https://github.com/guillemcordoba/p2panda", branch = "dashchat" }
-# p2panda-encryption = { git = "https://github.com/guillemcordoba/p2panda", branch = "dashchat" }
+# p2panda = { git = "https://github.com/dash-chat/p2panda", branch = "dashchat" }
+# p2panda-auth = { git = "https://github.com/dash-chat/p2panda", branch = "dashchat" }
+# p2panda-core = { git = "https://github.com/dash-chat/p2panda", branch = "dashchat" }
+# p2panda-store = { git = "https://github.com/dash-chat/p2panda", branch = "dashchat" }
+# p2panda-spaces = { git = "https://github.com/dash-chat/p2panda", branch = "dashchat" }
+# p2panda-net = { git = "https://github.com/dash-chat/p2panda", branch = "dashchat" }
+# p2panda-stream = { git = "https://github.com/dash-chat/p2panda", branch = "dashchat" }
+# p2panda-sync = { git = "https://github.com/dash-chat/p2panda", branch = "dashchat" }
+# p2panda-discovery = { git = "https://github.com/dash-chat/p2panda", branch = "dashchat" }
+# p2panda-encryption = { git = "https://github.com/dash-chat/p2panda", branch = "dashchat" }

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -381,14 +381,32 @@ impl Node {
         Ok(self.endpoint.endpoint().await?)
     }
 
-    /// Add a mailbox's dialing address (relay + direct addresses) to the
-    /// p2panda address book so the iroh blob downloader can reach the mailbox
-    /// by its EndpointId. The address is learned out-of-band from the mailbox's
-    /// `/health` endpoint.
-    pub async fn insert_mailbox_addr(&self, addr: iroh::EndpointAddr) -> Result<()> {
+    /// Wait until the iroh endpoint has connected to its relay, so that
+    /// `iroh_endpoint().addr()` includes the relay URL. Without this a NAT'd
+    /// peer we hand our address to (e.g. a cloud mailbox) may only learn our
+    /// direct addresses and fail to dial us back. No-op when no relay is
+    /// configured (tests, the push extension's no-p2p node), where `online()`
+    /// would never resolve.
+    pub async fn wait_endpoint_online(&self, timeout: std::time::Duration) -> Result<()> {
+        if self.config.relay_url.is_none() {
+            return Ok(());
+        }
+        let endpoint = self.iroh_endpoint().await?;
+        tokio::time::timeout(timeout, endpoint.online())
+            .await
+            .map_err(|_| anyhow::anyhow!("iroh endpoint did not connect to relay within {timeout:?}"))?;
+        Ok(())
+    }
+
+    /// Add a peer's dialing address (relay + direct addresses) to the p2panda
+    /// address book so the iroh blob downloader can reach that peer by its
+    /// EndpointId. Used both for mailbox addresses learned from a mailbox's
+    /// `/health` endpoint and for arbitrary peer addresses forwarded by a
+    /// mailbox's `/peers/register` endpoint.
+    pub async fn insert_peer_addr(&self, addr: iroh::EndpointAddr) -> Result<()> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.actor_tx
-            .send(Command::RegisterMailboxAddr { addr, reply_tx })
+            .send(Command::RegisterPeerAddr { addr, reply_tx })
             .await
             .map_err(|err| anyhow::anyhow!("send to actor error: {err}"))?;
         reply_rx.await??;

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -113,7 +113,7 @@ pub struct Node {
 
     pub mailboxes: Mailboxes<MailboxOperation, OpStore>,
 
-    config: NodeConfig,
+    pub config: NodeConfig,
 
     notification_tx: Option<mpsc::Sender<Notification>>,
     topic_subscribed_tx: Option<mpsc::Sender<TopicId>>,
@@ -379,23 +379,6 @@ impl Node {
     /// `/health` response advertises the node's dialing address.
     pub async fn iroh_endpoint(&self) -> Result<iroh::Endpoint> {
         Ok(self.endpoint.endpoint().await?)
-    }
-
-    /// Wait until the iroh endpoint has connected to its relay, so that
-    /// `iroh_endpoint().addr()` includes the relay URL. Without this a NAT'd
-    /// peer we hand our address to (e.g. a cloud mailbox) may only learn our
-    /// direct addresses and fail to dial us back. No-op when no relay is
-    /// configured (tests, the push extension's no-p2p node), where `online()`
-    /// would never resolve.
-    pub async fn wait_endpoint_online(&self, timeout: std::time::Duration) -> Result<()> {
-        if self.config.relay_url.is_none() {
-            return Ok(());
-        }
-        let endpoint = self.iroh_endpoint().await?;
-        tokio::time::timeout(timeout, endpoint.online())
-            .await
-            .map_err(|_| anyhow::anyhow!("iroh endpoint did not connect to relay within {timeout:?}"))?;
-        Ok(())
     }
 
     /// Add a peer's dialing address (relay + direct addresses) to the p2panda

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -395,6 +395,15 @@ impl Node {
         Ok(())
     }
 
+    pub async fn node_addr_known(&self, addr: iroh::EndpointAddr) -> Result<bool> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.actor_tx
+            .send(Command::NodeAddrKnown { addr, reply_tx })
+            .await
+            .map_err(|err| anyhow::anyhow!("send to actor error: {err}"))?;
+        Ok(reply_rx.await??)
+    }
+
     #[cfg(feature = "testing")]
     /// The node's iroh-blobs protocol handle, sharing its blob store. An
     /// in-process mailbox uses this so relayed blobs land in—and are served

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -396,15 +396,6 @@ impl Node {
         Ok(())
     }
 
-    pub async fn node_addr_known(&self, addr: iroh::EndpointAddr) -> Result<bool> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.actor_tx
-            .send(Command::NodeAddrKnown { addr, reply_tx })
-            .await
-            .map_err(|err| anyhow::anyhow!("send to actor error: {err}"))?;
-        Ok(reply_rx.await??)
-    }
-
     #[cfg(feature = "testing")]
     /// The node's iroh-blobs protocol handle, sharing its blob store. An
     /// in-process mailbox uses this so relayed blobs land in—and are served

--- a/crates/dashchat-node/src/node/actor.rs
+++ b/crates/dashchat-node/src/node/actor.rs
@@ -54,6 +54,10 @@ pub(crate) enum Command {
         addr: iroh::EndpointAddr,
         reply_tx: oneshot::Sender<Result<(), NodeActorError>>,
     },
+    NodeAddrKnown {
+        addr: iroh::EndpointAddr,
+        reply_tx: oneshot::Sender<Result<bool, NodeActorError>>,
+    },
     Shutdown {
         reply_tx: oneshot::Sender<()>,
     },
@@ -179,6 +183,10 @@ impl Actor {
                                 let result = self.handle_register_mailbox_addr(addr).await;
                                 let _ = reply_tx.send(result);
                             },
+                            Command::NodeAddrKnown { addr, reply_tx } => {
+                                let result = self.handle_node_addr_known(addr).await;
+                                let _ = reply_tx.send(result);
+                            },
                             Command::Shutdown { reply_tx } => {
                                 // Drop self and then break out of the processing loop which will
                                 // cause the actor task to complete.
@@ -283,8 +291,17 @@ impl Actor {
         &self,
         addr: iroh::EndpointAddr,
     ) -> Result<(), NodeActorError> {
-        self.inner.insert_node_addr(addr).await?;
+        if !self.inner.node_addr_known(&addr).await? {
+            self.inner.insert_node_addr(addr).await?;
+        }
         Ok(())
+    }
+
+    async fn handle_node_addr_known(
+        &self,
+        addr: iroh::EndpointAddr,
+    ) -> Result<bool, NodeActorError> {
+        Ok(self.inner.node_addr_known(&addr).await?)
     }
 
     async fn process_event(&mut self, event: StreamEvent<Payload>) -> Result<(), NodeActorError> {

--- a/crates/dashchat-node/src/node/actor.rs
+++ b/crates/dashchat-node/src/node/actor.rs
@@ -54,10 +54,6 @@ pub(crate) enum Command {
         addr: iroh::EndpointAddr,
         reply_tx: oneshot::Sender<Result<(), NodeActorError>>,
     },
-    NodeAddrKnown {
-        addr: iroh::EndpointAddr,
-        reply_tx: oneshot::Sender<Result<bool, NodeActorError>>,
-    },
     Shutdown {
         reply_tx: oneshot::Sender<()>,
     },
@@ -190,10 +186,6 @@ impl Actor {
                                 let result = self.handle_register_peer_addr(addr).await;
                                 let _ = reply_tx.send(result);
                             },
-                            Command::NodeAddrKnown { addr, reply_tx } => {
-                                let result = self.handle_node_addr_known(addr).await;
-                                let _ = reply_tx.send(result);
-                            },
                             Command::Shutdown { reply_tx } => {
                                 // Drop self and then break out of the processing loop which will
                                 // cause the actor task to complete.
@@ -318,13 +310,6 @@ impl Actor {
         }
         // else: in address book but not mailbox-discovered means it's node-discovered, so skip.
         Ok(())
-    }
-
-    async fn handle_node_addr_known(
-        &self,
-        addr: iroh::EndpointAddr,
-    ) -> Result<bool, NodeActorError> {
-        Ok(self.inner.node_addr_known(&addr).await?)
     }
 
     async fn process_event(&mut self, event: StreamEvent<Payload>) -> Result<(), NodeActorError> {

--- a/crates/dashchat-node/src/node/actor.rs
+++ b/crates/dashchat-node/src/node/actor.rs
@@ -50,7 +50,7 @@ pub(crate) enum Command {
         relay_url: RelayUrl,
         reply_tx: oneshot::Sender<Result<(), NodeActorError>>,
     },
-    RegisterMailboxAddr {
+    RegisterPeerAddr {
         addr: iroh::EndpointAddr,
         reply_tx: oneshot::Sender<Result<(), NodeActorError>>,
     },
@@ -127,11 +127,11 @@ pub struct Actor {
     /// Channel for forwarding all received events on to the application layer processor.
     events_tx: mpsc::Sender<ProcessorEvent>,
 
-    /// EndpointIds registered exclusively via mailbox `/peers/register` hints.
+    /// EndpointIds registered exclusively via mailbox `/peers/register`.
     /// Tracked separately from node-discovered addresses so re-registration after
-    /// a network change is allowed for hints while node-discovered entries are
-    /// never overwritten by mailbox-supplied data.
-    mailbox_addr_hints: HashSet<iroh::EndpointId>,
+    /// a network change is allowed, while trusted node-discovered entries are
+    /// never overwritten by unauthenticated mailbox-supplied data.
+    peer_registered_addrs: HashSet<iroh::EndpointId>,
 }
 
 impl Actor {
@@ -147,7 +147,7 @@ impl Actor {
                 processed: Default::default(),
                 groups_processor,
                 events_tx,
-                mailbox_addr_hints: Default::default(),
+                peer_registered_addrs: Default::default(),
             },
             events_rx,
         )
@@ -186,8 +186,8 @@ impl Actor {
                                 let _ = reply_tx.send(result);
 
                             },
-                            Command::RegisterMailboxAddr { addr, reply_tx } => {
-                                let result = self.handle_register_mailbox_addr(addr).await;
+                            Command::RegisterPeerAddr { addr, reply_tx } => {
+                                let result = self.handle_register_peer_addr(addr).await;
                                 let _ = reply_tx.send(result);
                             },
                             Command::NodeAddrKnown { addr, reply_tx } => {
@@ -294,28 +294,29 @@ impl Actor {
         Ok(())
     }
 
-    async fn handle_register_mailbox_addr(
+    async fn handle_register_peer_addr(
         &mut self,
         addr: iroh::EndpointAddr,
     ) -> Result<(), NodeActorError> {
         let id = addr.id;
-        if self.mailbox_addr_hints.contains(&id) {
+        if self.peer_registered_addrs.contains(&id) {
             // Previously mailbox-registered: allow re-registration so updated
             // addresses after a network change are picked up.
             //
             // KNOWN LIMITATION: a malicious client that registered this endpoint
             // before p2panda discovered it via mDNS/gossip can continue to inject
             // undialable addresses here (griefing). We cannot detect the upgrade
-            // from mailbox-hint to node-discovered without a p2panda discovery
-            // hook; the iroh QUIC handshake prevents data from flowing to the
-            // wrong peer, so the worst case is wasted dial attempts.
+            // from mailbox-discovered to node-discovered without a
+            // p2panda discovery hook;
+            // the iroh QUIC handshake prevents data from flowing to the wrong peer,
+            // so the worst case is wasted dial attempts.
             self.inner.insert_node_addr(addr).await?;
         } else if !self.inner.node_addr_known(&addr).await? {
-            // First time seen: register as a mailbox hint.
+            // First time seen: register as mailbox-discovered.
             self.inner.insert_node_addr(addr).await?;
-            self.mailbox_addr_hints.insert(id);
+            self.peer_registered_addrs.insert(id);
         }
-        // else: in address book but not a hint → node-discovered, skip.
+        // else: in address book but not mailbox-discovered means it's node-discovered, so skip.
         Ok(())
     }
 

--- a/crates/dashchat-node/src/node/actor.rs
+++ b/crates/dashchat-node/src/node/actor.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -126,6 +126,12 @@ pub struct Actor {
 
     /// Channel for forwarding all received events on to the application layer processor.
     events_tx: mpsc::Sender<ProcessorEvent>,
+
+    /// EndpointIds registered exclusively via mailbox `/peers/register` hints.
+    /// Tracked separately from node-discovered addresses so re-registration after
+    /// a network change is allowed for hints while node-discovered entries are
+    /// never overwritten by mailbox-supplied data.
+    mailbox_addr_hints: HashSet<iroh::EndpointId>,
 }
 
 impl Actor {
@@ -141,6 +147,7 @@ impl Actor {
                 processed: Default::default(),
                 groups_processor,
                 events_tx,
+                mailbox_addr_hints: Default::default(),
             },
             events_rx,
         )
@@ -288,12 +295,27 @@ impl Actor {
     }
 
     async fn handle_register_mailbox_addr(
-        &self,
+        &mut self,
         addr: iroh::EndpointAddr,
     ) -> Result<(), NodeActorError> {
-        if !self.inner.node_addr_known(&addr).await? {
+        let id = addr.id;
+        if self.mailbox_addr_hints.contains(&id) {
+            // Previously mailbox-registered: allow re-registration so updated
+            // addresses after a network change are picked up.
+            //
+            // KNOWN LIMITATION: a malicious client that registered this endpoint
+            // before p2panda discovered it via mDNS/gossip can continue to inject
+            // undialable addresses here (griefing). We cannot detect the upgrade
+            // from mailbox-hint to node-discovered without a p2panda discovery
+            // hook; the iroh QUIC handshake prevents data from flowing to the
+            // wrong peer, so the worst case is wasted dial attempts.
             self.inner.insert_node_addr(addr).await?;
+        } else if !self.inner.node_addr_known(&addr).await? {
+            // First time seen: register as a mailbox hint.
+            self.inner.insert_node_addr(addr).await?;
+            self.mailbox_addr_hints.insert(id);
         }
+        // else: in address book but not a hint → node-discovered, skip.
         Ok(())
     }
 

--- a/crates/dashchat-node/tests/mailbox_blob_sync.rs
+++ b/crates/dashchat-node/tests/mailbox_blob_sync.rs
@@ -212,3 +212,69 @@ async fn node_inserts_mailbox_addr_into_address_book() {
         .await
         .expect("inserting a mailbox addr into the address book should succeed");
 }
+
+/// The standalone mailbox server's blob fetch loop can reach a peer after that
+/// peer's `EndpointAddr` is registered via `BlobSync::add_peer_addr` (which is
+/// what `POST /peers/register` calls under the hood). Without the registration
+/// the downloader only knows the peer's EndpointId and cannot dial it.
+#[tokio::test(flavor = "multi_thread")]
+async fn blob_fetch_succeeds_after_peer_addr_registration() {
+    use dashchat_utils::FetchConfig;
+    use mailbox_server::BlobSync;
+
+    let poll = PollConfig::default();
+
+    // Sender: a standalone BlobSync endpoint that stores a blob.
+    let sender_dir = tempfile::tempdir().unwrap();
+    let sender = BlobSync::new(
+        iroh::SecretKey::generate(),
+        sender_dir.path().join("blobs"),
+        None,
+    )
+    .await
+    .unwrap();
+    let blob_data: Vec<u8> = b"peer-addr-registration-test".to_vec();
+    let tag = sender.blobs.add_bytes(blob_data.clone()).await.unwrap();
+    let hash = tag.hash;
+    let sender_id = sender.endpoint_id();
+    let sender_addr = sender.endpoint_addr();
+
+    // Standalone mailbox: its own endpoint, separate blob store.
+    let mb_dir = tempfile::tempdir().unwrap();
+    let mailbox = BlobSync::new(
+        iroh::SecretKey::generate(),
+        mb_dir.path().join("blobs"),
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Register the sender's dialing address. Without this the mailbox knows
+    // the sender only by EndpointId and the fetch will fail to connect.
+    mailbox.add_peer_addr(sender_addr);
+
+    // Enqueue the blob for download from the sender.
+    mailbox.fetch_pool().add_source(hash, sender_id).await;
+
+    let _fetch_handle = mailbox.spawn_fetch_loop(FetchConfig {
+        concurrency: 1,
+        pass_interval: Duration::from_millis(100),
+        attempt_timeout: Duration::from_secs(5),
+        retry_cooldown: Duration::from_millis(100),
+    });
+
+    poll.wait_for(|| async {
+        mailbox
+            .blobs
+            .has(hash)
+            .await
+            .unwrap_or(false)
+            .then_some(())
+            .ok_or("mailbox has not fetched the blob from the sender yet")
+    })
+    .await
+    .unwrap();
+
+    let fetched = mailbox.blobs.get_bytes(hash).await.unwrap();
+    assert_eq!(fetched.as_ref(), blob_data.as_slice());
+}

--- a/crates/dashchat-node/tests/mailbox_blob_sync.rs
+++ b/crates/dashchat-node/tests/mailbox_blob_sync.rs
@@ -190,27 +190,28 @@ async fn media_blob_relays_through_mailbox_when_sender_offline() {
     server.stop().await;
 }
 
-/// A node can add a mailbox's dialing address to its p2panda address book.
+/// A node running a local mailbox can add a peer's dialing address
+/// to its p2panda address book.
 ///
 /// This exercises the full client-side wiring added for mailbox dialability:
-/// `Node::insert_mailbox_addr` → the `RegisterMailboxAddr` actor command → the
+/// `Node::insert_peer_addr` → the `RegisterPeerAddr` actor command → the
 /// p2panda `Node::insert_node_addr` → `AddressBook::insert_node_info`. Without
-/// this path the iroh blob downloader can't reach a mailbox by its EndpointId.
+/// this path the iroh blob downloader can't reach a peer by its EndpointId.
 /// We feed it a real `EndpointAddr` (the host node's own) and assert the insert
 /// succeeds end-to-end.
 #[tokio::test(flavor = "multi_thread")]
-async fn node_inserts_mailbox_addr_into_address_book() {
+async fn node_inserts_peer_addr_into_address_book() {
     let config = NodeConfig::testing();
 
-    // A stand-in "mailbox" endpoint: any real, well-formed EndpointAddr works.
+    // A stand-in peer endpoint: any real, well-formed EndpointAddr works.
     let host = TestNode::new(config.clone(), "host").await;
-    let mailbox_addr = host.iroh_endpoint().await.unwrap().addr();
+    let peer_addr = host.iroh_endpoint().await.unwrap().addr();
 
     let client = TestNode::new(config.clone(), "client").await;
     client
-        .insert_mailbox_addr(mailbox_addr)
+        .insert_peer_addr(peer_addr)
         .await
-        .expect("inserting a mailbox addr into the address book should succeed");
+        .expect("inserting a peer addr into the address book should succeed");
 }
 
 /// The standalone mailbox server's blob fetch loop can reach a peer after that

--- a/crates/dashchat-node/tests/mailbox_blob_sync.rs
+++ b/crates/dashchat-node/tests/mailbox_blob_sync.rs
@@ -46,6 +46,7 @@ async fn media_blob_relays_through_mailbox_when_sender_offline() {
     // The relay shares no chat topic with Alice, so it discovers her address
     // lazily over mDNS rather than via an active gossip connection; retry the
     // blob fetch on a short interval so a pass lands once her address resolves.
+    let (peer_addr_tx, _peer_addr_rx) = tokio::sync::mpsc::unbounded_channel();
     let server = mailbox_local_server::spawn_local_mailbox_server(
         db_path,
         relay.blobs(),
@@ -57,6 +58,7 @@ async fn media_blob_relays_through_mailbox_when_sender_offline() {
             pass_interval: Duration::from_secs(2),
             retry_cooldown: Duration::from_secs(2),
         }),
+        peer_addr_tx,
     )
     .await
     .unwrap();

--- a/crates/dashchat-utils/src/endpoint.rs
+++ b/crates/dashchat-utils/src/endpoint.rs
@@ -1,0 +1,22 @@
+/// Wait until the iroh endpoint has connected to its relay, so that
+/// `iroh_endpoint().addr()` includes the relay URL. Without this a NAT'd
+/// peer we hand our address to (e.g. a cloud mailbox) may only learn our
+/// direct addresses and fail to dial us back. No-op when no relay is
+/// configured (tests, the push extension's no-p2p node), where `online()`
+/// would never resolve.
+pub async fn wait_endpoint_online(
+    has_relay: bool,
+    endpoint: &iroh::Endpoint,
+    timeout: std::time::Duration,
+) -> anyhow::Result<()> {
+    if !has_relay {
+        // No relay to wait for
+        return Ok(());
+    }
+    tokio::time::timeout(timeout, endpoint.online())
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!("iroh endpoint did not connect to relay within {timeout:?}")
+        })?;
+    Ok(())
+}

--- a/crates/dashchat-utils/src/lib.rs
+++ b/crates/dashchat-utils/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod blob_sync;
 mod derive_watch;
+pub mod endpoint;
 mod fetch_loop;
 mod retry_with_backoff;
 mod singleton_task_with_retries;

--- a/crates/mailbox-client/src/lib.rs
+++ b/crates/mailbox-client/src/lib.rs
@@ -4,6 +4,8 @@ pub mod store;
 pub mod sync_tracker;
 pub mod toy;
 
+pub use mailbox_server::RegisterPeerRequest;
+
 #[cfg(test)]
 pub mod testing;
 

--- a/crates/mailbox-local-server/src/lib.rs
+++ b/crates/mailbox-local-server/src/lib.rs
@@ -13,6 +13,7 @@ use iroh::EndpointId;
 use iroh_blobs::api::downloader::Downloader;
 use iroh_blobs::BlobsProtocol;
 use mailbox_server::{encode_mailbox_id, BlobSync, FetchConfig};
+use tokio::sync::mpsc::UnboundedSender;
 use mdns_sd::{ServiceDaemon, ServiceInfo};
 
 /// A running in-process mailbox server. Call [`LocalMailboxServer::stop`] to
@@ -49,10 +50,11 @@ pub async fn spawn_local_mailbox_server(
     downloader: Downloader,
     endpoint: iroh::Endpoint,
     fetch_config: Option<FetchConfig>,
+    peer_addr_tx: UnboundedSender<iroh::EndpointAddr>,
 ) -> anyhow::Result<LocalMailboxServer> {
     let port = free_port()?;
 
-    let mut blob_sync = BlobSync::shared(blobs, downloader, endpoint);
+    let mut blob_sync = BlobSync::shared(blobs, downloader, endpoint, peer_addr_tx);
     if let Some(fetch_config) = fetch_config {
         blob_sync = blob_sync.with_fetch_config(fetch_config);
     }

--- a/crates/mailbox-local-server/src/lib.rs
+++ b/crates/mailbox-local-server/src/lib.rs
@@ -13,8 +13,8 @@ use iroh::EndpointId;
 use iroh_blobs::api::downloader::Downloader;
 use iroh_blobs::BlobsProtocol;
 use mailbox_server::{encode_mailbox_id, BlobSync, FetchConfig};
-use tokio::sync::mpsc::UnboundedSender;
 use mdns_sd::{ServiceDaemon, ServiceInfo};
+use tokio::sync::mpsc::UnboundedSender;
 
 /// A running in-process mailbox server. Call [`LocalMailboxServer::stop`] to
 /// shut it down gracefully.

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -167,17 +167,12 @@ impl BlobSync {
         // so an unreachable relay can't block server startup indefinitely.
         // Skipped when no relay is configured (e.g. tests): with the `Minimal`
         // preset there is no default relay, so `online()` would never resolve.
-        if has_relay {
-            if let Err(e) = tokio::time::timeout(Duration::from_secs(10), endpoint.online()).await {
-                tracing::error!(
-                    ?e,
-                    "failed to connect to bind iroh endpoint after 10 seconds"
-                );
-                return Err(anyhow::anyhow!(
-                    "failed to connect to bind iroh endpoint after 10 seconds: {e}"
-                ));
-            }
-        }
+        dashchat_utils::endpoint::wait_endpoint_online(
+            has_relay,
+            &endpoint,
+            Duration::from_secs(10),
+        )
+        .await?;
 
         let db_path = root.join("blobs.db");
         let mut options = iroh_blobs::store::fs::options::Options::new(&root);

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -252,10 +252,16 @@ impl BlobSync {
     }
 
     /// Register a peer's dialing address so the blob downloader can reach it
-    /// by its EndpointId.
+    /// by its EndpointId. If an entry for this EndpointId already exists
+    /// (registered by this node's own discovery), the hint is dropped so
+    /// node-discovered addresses are never overwritten by client-supplied ones.
     pub fn add_peer_addr(&self, addr: iroh::EndpointAddr) {
         match &self.peer_addr_registry {
-            PeerAddrRegistry::Memory(lookup) => lookup.add_endpoint_info(addr),
+            PeerAddrRegistry::Memory(lookup) => {
+                if lookup.get_endpoint_info(addr.id).is_none() {
+                    lookup.add_endpoint_info(addr);
+                }
+            }
             PeerAddrRegistry::Channel(tx) => {
                 let _ = tx.send(addr);
             }

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -5,7 +5,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use dashchat_utils::{fetch_loop, FetchConfig, FetchPool, NETWORK_ID};
 use futures::StreamExt;
+use iroh::address_lookup::memory::MemoryLookup;
 use iroh::endpoint::presets;
+use tokio::sync::mpsc::UnboundedSender;
 use iroh::protocol::Router;
 use iroh_blobs::api::downloader::{Downloader, Shuffled};
 use tokio::sync::{Mutex, Notify};
@@ -106,6 +108,15 @@ impl FetchPool for BlobFetchPool {
 }
 
 #[derive(Clone)]
+enum PeerAddrRegistry {
+    /// Standalone server: lookup is wired directly into the iroh endpoint builder.
+    Memory(MemoryLookup),
+    /// Shared (in-process) server: iroh endpoint is p2panda's; addresses are
+    /// forwarded to the node's address book via an unbounded channel.
+    Channel(UnboundedSender<iroh::EndpointAddr>),
+}
+
+#[derive(Clone)]
 pub struct BlobSync {
     pub blobs: iroh_blobs::BlobsProtocol,
     pub(crate) fetch_pool: BlobFetchPool,
@@ -125,6 +136,7 @@ pub struct BlobSync {
     /// `None` when sharing an in-process node's endpoint, in which case the
     /// node keeps the router and blob store alive.
     _router: Option<Router>,
+    peer_addr_registry: PeerAddrRegistry,
 }
 
 impl BlobSync {
@@ -138,7 +150,10 @@ impl BlobSync {
         root: PathBuf,
         relay_url: Option<iroh::RelayUrl>,
     ) -> anyhow::Result<Self> {
-        let mut builder = iroh::Endpoint::builder(presets::Minimal).secret_key(secret_key);
+        let peer_addr_lookup = MemoryLookup::new();
+        let mut builder = iroh::Endpoint::builder(presets::Minimal)
+            .secret_key(secret_key)
+            .address_lookup(peer_addr_lookup.clone());
         let has_relay = relay_url.is_some();
         if let Some(relay_url) = relay_url {
             builder = builder.relay_mode(iroh::RelayMode::Custom(iroh::RelayMap::from_iter([
@@ -188,6 +203,7 @@ impl BlobSync {
             fetch_config: FetchConfig::default(),
             enable_gc: true,
             _router: Some(router),
+            peer_addr_registry: PeerAddrRegistry::Memory(peer_addr_lookup),
         })
     }
 
@@ -200,6 +216,7 @@ impl BlobSync {
         blobs: iroh_blobs::BlobsProtocol,
         downloader: Downloader,
         endpoint: iroh::Endpoint,
+        peer_addr_tx: UnboundedSender<iroh::EndpointAddr>,
     ) -> Self {
         Self {
             blobs,
@@ -209,6 +226,7 @@ impl BlobSync {
             fetch_config: FetchConfig::default(),
             enable_gc: false,
             _router: None,
+            peer_addr_registry: PeerAddrRegistry::Channel(peer_addr_tx),
         }
     }
 
@@ -231,6 +249,17 @@ impl BlobSync {
     /// served via `/health` so clients can reach this mailbox by its EndpointId.
     pub fn endpoint_addr(&self) -> iroh::EndpointAddr {
         self.endpoint.addr()
+    }
+
+    /// Register a peer's dialing address so the blob downloader can reach it
+    /// by its EndpointId.
+    pub fn add_peer_addr(&self, addr: iroh::EndpointAddr) {
+        match &self.peer_addr_registry {
+            PeerAddrRegistry::Memory(lookup) => lookup.add_endpoint_info(addr),
+            PeerAddrRegistry::Channel(tx) => {
+                let _ = tx.send(addr);
+            }
+        }
     }
 
     pub fn fetch_pool(&self) -> &BlobFetchPool {

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -7,9 +7,9 @@ use dashchat_utils::{fetch_loop, FetchConfig, FetchPool, NETWORK_ID};
 use futures::StreamExt;
 use iroh::address_lookup::memory::MemoryLookup;
 use iroh::endpoint::presets;
-use tokio::sync::mpsc::UnboundedSender;
 use iroh::protocol::Router;
 use iroh_blobs::api::downloader::{Downloader, Shuffled};
+use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::{Mutex, Notify};
 use tokio::task::JoinHandle;
 

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -252,16 +252,10 @@ impl BlobSync {
     }
 
     /// Register a peer's dialing address so the blob downloader can reach it
-    /// by its EndpointId. If an entry for this EndpointId already exists
-    /// (registered by this node's own discovery), the hint is dropped so
-    /// node-discovered addresses are never overwritten by client-supplied ones.
+    /// by its EndpointId.
     pub fn add_peer_addr(&self, addr: iroh::EndpointAddr) {
         match &self.peer_addr_registry {
-            PeerAddrRegistry::Memory(lookup) => {
-                if lookup.get_endpoint_info(addr.id).is_none() {
-                    lookup.add_endpoint_info(addr);
-                }
-            }
+            PeerAddrRegistry::Memory(lookup) => lookup.add_endpoint_info(addr),
             PeerAddrRegistry::Channel(tx) => {
                 let _ = tx.send(addr);
             }

--- a/crates/mailbox-server/src/lib.rs
+++ b/crates/mailbox-server/src/lib.rs
@@ -41,6 +41,7 @@ pub use dashchat_utils::FetchConfig;
 pub use get_blips::{
     get_blips_for_topics, GetBlipsForTopicResponse, GetBlipsRequest, GetBlipsResponse,
 };
+pub use register_peer::RegisterPeerRequest;
 pub use server_key::{load_or_create_secret_key, SERVER_KEY_TABLE};
 pub use store_blips::{store_blips, StoreBlipsRequest};
 pub use watermark::compute_initial_watermarks;

--- a/crates/mailbox-server/src/lib.rs
+++ b/crates/mailbox-server/src/lib.rs
@@ -19,6 +19,7 @@ mod blob_sync;
 mod cleanup;
 mod get_blips;
 mod notify_topics_subscribers;
+mod register_peer;
 mod server_key;
 mod store_blips;
 mod watermark;
@@ -204,6 +205,7 @@ pub fn create_app(
         .route("/health", get(health_check))
         .route("/blips/store", post(store_blips))
         .route("/blips/get", post(get_blips_for_topics))
+        .route("/peers/register", post(register_peer::register_peer))
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http())
         .layer(DefaultBodyLimit::max(MAX_PAYLOAD_SIZE))

--- a/crates/mailbox-server/src/register_peer.rs
+++ b/crates/mailbox-server/src/register_peer.rs
@@ -1,0 +1,17 @@
+use axum::{extract::State, http::StatusCode, Json};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+
+#[derive(Serialize, Deserialize)]
+pub struct RegisterPeerRequest {
+    pub addr: iroh::EndpointAddr,
+}
+
+pub async fn register_peer(
+    State(state): State<AppState>,
+    Json(payload): Json<RegisterPeerRequest>,
+) -> StatusCode {
+    state.blob_sync.add_peer_addr(payload.addr);
+    StatusCode::NO_CONTENT
+}

--- a/crates/mailbox-server/tests/integration.rs
+++ b/crates/mailbox-server/tests/integration.rs
@@ -1,4 +1,8 @@
-use mailbox_server::{encode_mailbox_id, test_utils::create_test_server, GetBlipsResponse};
+use mailbox_server::{
+    encode_mailbox_id,
+    test_utils::{create_test_server, test_blob_sync},
+    GetBlipsResponse,
+};
 use serde_json::json;
 
 #[tokio::test]
@@ -575,4 +579,17 @@ async fn test_no_missing_when_server_is_ahead() {
 
     // No missing since server is ahead
     assert!(topic_response.missing.is_empty());
+}
+
+#[tokio::test]
+async fn register_peer_returns_no_content() {
+    let (server, _temp_file) = create_test_server().await;
+    // Use a real BlobSync endpoint to obtain a well-formed EndpointAddr.
+    let peer = test_blob_sync().await;
+    let addr = peer.endpoint_addr();
+    server
+        .post("/peers/register")
+        .json(&serde_json::json!({ "addr": addr }))
+        .await
+        .assert_status_no_content();
 }

--- a/src-tauri/src/mailbox.rs
+++ b/src-tauri/src/mailbox.rs
@@ -201,6 +201,27 @@ async fn handle_browse_events(
                             "Failed to fetch local mailbox {mailbox_id} health for address book: {err}"
                         ),
                     }
+                    // Tell the mailbox our own dialing address so its blob fetch
+                    // pool can reach us as a source.
+                    // NOTE: on network changes, mDNS re-browse fires a new
+                    // ServiceResolved for each known mailbox, which re-runs this
+                    // path and re-registers the updated EndpointAddr. Cloud
+                    // mailboxes don't have this hook; re-registration there would
+                    // require a network-change callback from the node layer.
+                    match node.iroh_endpoint().await {
+                        Ok(ep) => {
+                            if let Err(err) =
+                                crate::setup::register_self_with_mailbox(&url, ep.addr()).await
+                            {
+                                log::warn!(
+                                    "Failed to register our addr with local mailbox {mailbox_id}: {err}"
+                                );
+                            }
+                        }
+                        Err(err) => log::warn!(
+                            "Could not get iroh endpoint to register with mailbox {mailbox_id}: {err}"
+                        ),
+                    }
                     log::info!(
                         "*** Registered local mailbox client via mdns: {mailbox_id} ({url}) ***",
                     );

--- a/src-tauri/src/mailbox.rs
+++ b/src-tauri/src/mailbox.rs
@@ -191,7 +191,7 @@ async fn handle_browse_events(
                     // relying solely on p2panda mDNS resolution timing.
                     match crate::setup::fetch_mailbox_health(&url).await {
                         Ok(health) => {
-                            if let Err(err) = node.insert_mailbox_addr(health.endpoint_addr).await {
+                            if let Err(err) = node.insert_peer_addr(health.endpoint_addr).await {
                                 log::warn!(
                                     "Failed to add local mailbox {mailbox_id} addr to address book: {err}"
                                 );

--- a/src-tauri/src/mailbox/server.rs
+++ b/src-tauri/src/mailbox/server.rs
@@ -34,6 +34,16 @@ pub async fn start_local_mailbox<R: Runtime>(handle: &AppHandle<R>) -> anyhow::R
     let path = FileSystem::new(handle)?.local_mailbox_db_path();
     let daemon: ServiceDaemon = handle.state::<ServiceDaemon>().inner().clone();
 
+    let (peer_addr_tx, mut peer_addr_rx) = tokio::sync::mpsc::unbounded_channel();
+    let node_for_peer_addrs = (*node).clone();
+    tokio::spawn(async move {
+        while let Some(addr) = peer_addr_rx.recv().await {
+            if let Err(err) = node_for_peer_addrs.insert_mailbox_addr(addr).await {
+                log::warn!("Failed to register peer addr: {err}");
+            }
+        }
+    });
+
     // The in-process mailbox shares the node's iroh endpoint and blob store, so
     // its EndpointId equals the node's device id and relayed blobs are served
     // from the same store on the same endpoint. The mDNS instance name therefore
@@ -44,6 +54,7 @@ pub async fn start_local_mailbox<R: Runtime>(handle: &AppHandle<R>) -> anyhow::R
         node.blob_downloader(),
         endpoint,
         None,
+        peer_addr_tx,
     )
     .await?;
 

--- a/src-tauri/src/mailbox/server.rs
+++ b/src-tauri/src/mailbox/server.rs
@@ -38,7 +38,7 @@ pub async fn start_local_mailbox<R: Runtime>(handle: &AppHandle<R>) -> anyhow::R
     let node_for_peer_addrs = (*node).clone();
     tokio::spawn(async move {
         while let Some(addr) = peer_addr_rx.recv().await {
-            if let Err(err) = node_for_peer_addrs.insert_mailbox_addr(addr).await {
+            if let Err(err) = node_for_peer_addrs.insert_peer_addr(addr).await {
                 log::warn!("Failed to register peer addr: {err}");
             }
         }

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -46,11 +46,36 @@ pub(crate) async fn register_cloud_mailbox(node: &Node) -> anyhow::Result<()> {
     if !node.mailboxes.is_tracked(&health.mailbox_id).await {
         let mailbox_client = mailbox_client::toy::ToyMailboxClient::new(
             health.mailbox_id,
-            mailbox_url,
+            mailbox_url.clone(),
             node.endpoint_id(),
         );
         node.mailboxes.register(mailbox_client).await;
     }
+    // Tell the mailbox our own dialing address so its blob fetch pool can reach
+    // us as a source (without this the mailbox knows our EndpointId from blip
+    // uploads but cannot dial us).
+    let our_addr = node.iroh_endpoint().await?.addr();
+    register_self_with_mailbox(&mailbox_url, our_addr).await?;
+    Ok(())
+}
+
+/// POST our current `EndpointAddr` to a mailbox's `/peers/register` endpoint so
+/// it can dial us when fetching blobs we published.
+pub(crate) async fn register_self_with_mailbox(
+    base_url: &str,
+    our_addr: iroh::EndpointAddr,
+) -> anyhow::Result<()> {
+    #[derive(serde::Serialize)]
+    struct Req {
+        addr: iroh::EndpointAddr,
+    }
+    let url = format!("{}/peers/register", base_url.trim_end_matches('/'));
+    mailbox_client::HTTP_CLIENT
+        .post(&url)
+        .json(&Req { addr: our_addr })
+        .send()
+        .await?
+        .error_for_status()?;
     Ok(())
 }
 

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -42,7 +42,7 @@ pub(crate) async fn register_cloud_mailbox(node: &Node) -> anyhow::Result<()> {
     // Add the mailbox's dialing address to the p2panda address book so the iroh
     // blob downloader can reach it by EndpointId; without this the mailbox is
     // known only by id and is not dialable.
-    node.insert_mailbox_addr(health.endpoint_addr).await?;
+    node.insert_peer_addr(health.endpoint_addr).await?;
     if !node.mailboxes.is_tracked(&health.mailbox_id).await {
         let mailbox_client = mailbox_client::toy::ToyMailboxClient::new(
             health.mailbox_id,
@@ -53,7 +53,11 @@ pub(crate) async fn register_cloud_mailbox(node: &Node) -> anyhow::Result<()> {
     }
     // Tell the mailbox our own dialing address so its blob fetch pool can reach
     // us as a source (without this the mailbox knows our EndpointId from blip
-    // uploads but cannot dial us).
+    // uploads but cannot dial us). Wait for the relay first so the address we
+    // send includes our relay URL; otherwise a NAT'd mailbox cannot dial us
+    // back. On failure we return Err so the retry wrapper runs us again.
+    node.wait_endpoint_online(std::time::Duration::from_secs(10))
+        .await?;
     let our_addr = node.iroh_endpoint().await?.addr();
     register_self_with_mailbox(&mailbox_url, our_addr).await?;
     Ok(())
@@ -65,14 +69,10 @@ pub(crate) async fn register_self_with_mailbox(
     base_url: &str,
     our_addr: iroh::EndpointAddr,
 ) -> anyhow::Result<()> {
-    #[derive(serde::Serialize)]
-    struct Req {
-        addr: iroh::EndpointAddr,
-    }
     let url = format!("{}/peers/register", base_url.trim_end_matches('/'));
     mailbox_client::HTTP_CLIENT
         .post(&url)
-        .json(&Req { addr: our_addr })
+        .json(&mailbox_client::RegisterPeerRequest { addr: our_addr })
         .send()
         .await?
         .error_for_status()?;

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -56,8 +56,12 @@ pub(crate) async fn register_cloud_mailbox(node: &Node) -> anyhow::Result<()> {
     // uploads but cannot dial us). Wait for the relay first so the address we
     // send includes our relay URL; otherwise a NAT'd mailbox cannot dial us
     // back. On failure we return Err so the retry wrapper runs us again.
-    node.wait_endpoint_online(std::time::Duration::from_secs(10))
-        .await?;
+    dashchat_utils::endpoint::wait_endpoint_online(
+        node.config.relay_url.is_some(),
+        &node.iroh_endpoint().await?,
+        std::time::Duration::from_secs(10),
+    )
+    .await?;
     let our_addr = node.iroh_endpoint().await?.addr();
     register_self_with_mailbox(&mailbox_url, our_addr).await?;
     Ok(())


### PR DESCRIPTION
Clients use a new `peers/register` endpoint to inform message servers of their iroh endpoint addresses, so that the server can fetch blobs from them during syncing. This endpoint is called at node startup and when local network address changes are detected.