### PR TITLE
Support running tests against deployment environment mailboxes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,6 +414,20 @@ cargo nextest run
 
 Run tests from workspace root. Tests use tokio async runtime.
 
+### Running Tests Against a Deployment Environment
+
+By default all tests use a local (in-memory or in-process) mailbox. Set `DASHCHAT_TEST_ENV=<env>` to run the same suites against a deployment environment's cloud mailbox instead (URL resolved from the repo-root `.env.<env>` file):
+
+```bash
+DASHCHAT_TEST_ENV=testing cargo nextest run   # Rust suite
+DASHCHAT_TEST_ENV=testing just test e2e       # E2E suite
+```
+
+- **Rust**: tests build their mailbox via `TestMailbox::from_env()` (`crates/dashchat-node/src/testing/mailbox.rs`) and register it with `TestNode::add_mailbox(&mb)`. Unset var → a fresh `MemMailbox`; set → a `ToyMailboxClient` for the environment's mailbox, registered the way the production app does it (id from `/health`, address book entry, `/peers/register`). Don't use `MemMailbox::new()` directly in new tests.
+- **E2E**: `wdio.conf.ts` skips spawning the local mailbox server and points the agents at the environment's mailbox. Specs that drive the mailbox server's lifecycle (suspend/kill) skip themselves via `isRemoteMailbox()`.
+
+Allowed environments are allowlisted (`ALLOWED_TEST_ENVS`, currently only `testing`) in both suites; any other value fails fast so tests can never hit staging/production.
+
 ### Development Testing
 Use `pnpm start` to run two instances locally that can communicate with each other over the p2panda network.
 

--- a/crates/dashchat-node/src/chat/compat_tests.rs
+++ b/crates/dashchat-node/src/chat/compat_tests.rs
@@ -2,7 +2,6 @@
 mod tests {
     use dashchat_compat::{VersionConvert, VersionConvertError};
 
-    use mailbox_client::mem::MemMailbox;
     use maplit::btreeset;
     use p2panda_core::cbor::{decode_cbor, encode_cbor};
 
@@ -10,7 +9,7 @@ mod tests {
         ShareIntent,
         chat::*,
         compat::Capabilities,
-        testing::{PollConfig, TestNode, TestNodeConfig},
+        testing::{PollConfig, TestMailbox, TestNode, TestNodeConfig},
     };
 
     #[test]
@@ -102,14 +101,14 @@ mod tests {
         let bobbi_config = TestNodeConfig::default();
         alice_config.node_config.capabilities = Capabilities::zero();
 
-        let mailbox = MemMailbox::new();
+        let mailbox = TestMailbox::from_env();
         let alice = TestNode::new(alice_config, "alice")
             .await
-            .add_mailbox_client(mailbox.client())
+            .add_mailbox(&mailbox)
             .await;
         let bobbi = TestNode::new(bobbi_config, "bobbi")
             .await
-            .add_mailbox_client(mailbox.client())
+            .add_mailbox(&mailbox)
             .await;
 
         let ac = alice
@@ -137,14 +136,14 @@ mod tests {
         alice_config.node_config.capabilities = Capabilities::zero();
 
         let poll = PollConfig::default();
-        let mailbox = MemMailbox::new();
+        let mailbox = TestMailbox::from_env();
         let alice = TestNode::new(alice_config, "alice")
             .await
-            .add_mailbox_client(mailbox.client())
+            .add_mailbox(&mailbox)
             .await;
         let bobbi = TestNode::new(bobbi_config, "bobbi")
             .await
-            .add_mailbox_client(mailbox.client())
+            .add_mailbox(&mailbox)
             .await;
 
         println!("alice: {:?}", alice.device_id().to_hex());

--- a/crates/dashchat-node/src/mailbox.rs
+++ b/crates/dashchat-node/src/mailbox.rs
@@ -68,7 +68,7 @@ impl From<MailboxOperation> for Operation {
 mod tests {
 
     use crate::{testing::*, *};
-    use mailbox_client::{MailboxClient, MailboxItem as _, mem::MemMailbox};
+    use mailbox_client::MailboxItem as _;
 
     fn make_header(topic: TopicId) -> p2panda::operation::Header {
         use p2panda::operation::{Extensions, LogId};
@@ -149,7 +149,7 @@ mod tests {
             true,
         );
 
-        let mb = MemMailbox::new();
+        let mb = TestMailbox::from_env();
         let config = NodeConfig::testing();
         let poll = PollConfig::default();
 
@@ -163,8 +163,8 @@ mod tests {
         alice.send_message_raw(chat, "Hello".into()).await.unwrap();
 
         println!("=== adding mailboxes ===");
-        bobbi.add_mailbox_client(mb.client()).await;
-        alice.add_mailbox_client(mb.client()).await;
+        bobbi.add_mailbox(&mb).await;
+        alice.add_mailbox(&mb).await;
 
         bobbi.register_topic(chat).await.unwrap();
         println!("=== added mailboxes ===");
@@ -193,7 +193,7 @@ mod tests {
             true,
         );
 
-        let mb = MemMailbox::new();
+        let mb = TestMailbox::from_env();
         let config = NodeConfig::testing();
         let poll = PollConfig::default();
 
@@ -203,8 +203,8 @@ mod tests {
         let chat_id = alice.direct_chat_topic(bobbi.agent_id());
         alice.register_topic(chat_id).await.unwrap();
 
-        alice.add_mailbox_client(mb.client()).await;
-        bobbi.add_mailbox_client(mb.client()).await;
+        alice.add_mailbox(&mb).await;
+        bobbi.add_mailbox(&mb).await;
         bobbi.register_topic(chat_id).await.unwrap();
 
         alice
@@ -222,7 +222,7 @@ mod tests {
         .await
         .unwrap();
 
-        let mailbox_id = mb.client().id();
+        let mailbox_id = mb.id().await;
         let alice_device: crate::DeviceId = alice.device_id();
 
         // The mailbox should have recorded alice's seq 0 from both sides.

--- a/crates/dashchat-node/src/testing/mailbox.rs
+++ b/crates/dashchat-node/src/testing/mailbox.rs
@@ -1,0 +1,220 @@
+use std::path::PathBuf;
+
+use mailbox_client::{
+    FetchRequest, FetchResponse, MailboxClient, MailboxId, RegisterPeerRequest,
+    mem::{MemMailbox, MemMailboxClient},
+    toy::ToyMailboxClient,
+};
+
+use crate::mailbox::MailboxOperation;
+
+/// Env var naming the deployment environment whose cloud mailbox the test
+/// suite should run against (e.g. `DASHCHAT_TEST_ENV=testing`). When unset,
+/// tests use an in-memory mailbox.
+pub const TEST_ENV_VAR: &str = "DASHCHAT_TEST_ENV";
+
+/// Deployment environments the test suite is allowed to run against.
+pub const ALLOWED_TEST_ENVS: &[&str] = &["testing"];
+
+/// A mailbox for tests, built by [`TestMailbox::from_env`]: an in-memory
+/// mailbox by default, or the cloud mailbox of a deployment environment when
+/// [`TEST_ENV_VAR`] is set.
+#[derive(Clone)]
+pub enum TestMailbox {
+    Mem(MemMailbox<MailboxOperation>),
+    Env { name: String, url: String },
+}
+
+impl TestMailbox {
+    /// Builds a mailbox according to [`TEST_ENV_VAR`]: unset or empty → a
+    /// fresh [`MemMailbox`]; an allowlisted environment name → that
+    /// environment's cloud mailbox (URL resolved from the repo's
+    /// `.env.<name>` file). Panics on a non-allowlisted environment.
+    pub fn from_env() -> Self {
+        match std::env::var(TEST_ENV_VAR) {
+            Err(_) => Self::Mem(MemMailbox::new()),
+            Ok(name) if name.is_empty() => Self::Mem(MemMailbox::new()),
+            Ok(name) => {
+                assert!(
+                    ALLOWED_TEST_ENVS.contains(&name.as_str()),
+                    "{TEST_ENV_VAR}={name} is not an allowed test environment (allowed: {ALLOWED_TEST_ENVS:?})"
+                );
+                let url = env_file_mailbox_url(&name);
+                Self::Env { name, url }
+            }
+        }
+    }
+
+    /// The mailbox's id: the in-memory id, or the environment mailbox's
+    /// canonical id resolved from its `/health` endpoint.
+    pub async fn id(&self) -> MailboxId {
+        match self {
+            Self::Mem(mb) => mb.client().id(),
+            Self::Env { url, .. } => fetch_mailbox_health(url).await.unwrap().mailbox_id,
+        }
+    }
+
+    /// A standalone client with a throwaway sender identity. Prefer
+    /// [`crate::testing::TestNode::add_mailbox`], which attributes the client
+    /// to the node and registers addresses for blob transfer.
+    pub async fn client(&self) -> TestMailboxClient {
+        match self {
+            Self::Mem(mb) => TestMailboxClient::Mem(mb.client()),
+            Self::Env { url, .. } => {
+                let health = fetch_mailbox_health(url).await.unwrap();
+                TestMailboxClient::Toy(ToyMailboxClient::new(
+                    health.mailbox_id,
+                    url,
+                    iroh::SecretKey::generate().public(),
+                ))
+            }
+        }
+    }
+
+    /// Registers this mailbox on a node the way the production app does: for
+    /// an environment mailbox, resolve its id from `/health`, add its dialing
+    /// address to the node's address book, and register the node's own
+    /// address back so the mailbox's blob fetcher can dial it.
+    pub async fn register_on(&self, node: &crate::Node) {
+        match self {
+            Self::Mem(mb) => node.mailboxes.register(mb.client()).await,
+            Self::Env { url, .. } => {
+                let health = fetch_mailbox_health(url).await.unwrap();
+                node.insert_peer_addr(health.endpoint_addr).await.unwrap();
+                node.mailboxes
+                    .register(ToyMailboxClient::<MailboxOperation>::new(
+                        health.mailbox_id,
+                        url,
+                        node.endpoint_id(),
+                    ))
+                    .await;
+                register_self_with_mailbox(url, node.iroh_endpoint().await.unwrap().addr())
+                    .await
+                    .unwrap();
+            }
+        }
+    }
+}
+
+/// Client produced by [`TestMailbox::client`], delegating to the in-memory or
+/// HTTP client underneath.
+#[derive(Clone)]
+pub enum TestMailboxClient {
+    Mem(MemMailboxClient<MailboxOperation>),
+    Toy(ToyMailboxClient<MailboxOperation>),
+}
+
+#[async_trait::async_trait]
+impl MailboxClient<MailboxOperation> for TestMailboxClient {
+    fn id(&self) -> MailboxId {
+        match self {
+            Self::Mem(client) => client.id(),
+            Self::Toy(client) => client.id(),
+        }
+    }
+
+    fn url(&self) -> Option<String> {
+        match self {
+            Self::Mem(client) => client.url(),
+            Self::Toy(client) => client.url(),
+        }
+    }
+
+    async fn publish(&self, ops: Vec<MailboxOperation>) -> Result<(), anyhow::Error> {
+        match self {
+            Self::Mem(client) => client.publish(ops).await,
+            Self::Toy(client) => client.publish(ops).await,
+        }
+    }
+
+    async fn fetch(
+        &self,
+        request: FetchRequest<MailboxOperation>,
+    ) -> Result<FetchResponse<MailboxOperation>, anyhow::Error> {
+        match self {
+            Self::Mem(client) => client.fetch(request).await,
+            Self::Toy(client) => client.fetch(request).await,
+        }
+    }
+}
+
+/// Reads `MAILBOX_URL` from the repo-root `.env.<name>` file, resolving
+/// `${VAR}` references against values defined earlier in the same file.
+fn env_file_mailbox_url(name: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("../../.env.{name}"));
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+    let mut vars: Vec<(String, String)> = Vec::new();
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let mut value = value.trim().to_string();
+        for (k, v) in &vars {
+            value = value.replace(&format!("${{{k}}}"), v);
+        }
+        vars.push((key.trim().to_string(), value));
+    }
+    vars.into_iter()
+        .find(|(k, _)| k == "MAILBOX_URL")
+        .map(|(_, v)| v)
+        .unwrap_or_else(|| panic!("no MAILBOX_URL in {}", path.display()))
+}
+
+struct MailboxHealth {
+    mailbox_id: MailboxId,
+    endpoint_addr: iroh::EndpointAddr,
+}
+
+/// Fetch a mailbox server's `/health` response: its canonical MailboxId and
+/// its dialing address (mirrors `src-tauri/src/setup.rs`).
+async fn fetch_mailbox_health(base_url: &str) -> anyhow::Result<MailboxHealth> {
+    #[derive(serde::Deserialize)]
+    struct HealthResponse {
+        endpoint_id: String,
+        endpoint_addr: iroh::EndpointAddr,
+    }
+    let url = format!("{}/health", base_url.trim_end_matches('/'));
+    let resp = mailbox_client::HTTP_CLIENT
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<HealthResponse>()
+        .await?;
+    Ok(MailboxHealth {
+        mailbox_id: resp.endpoint_id,
+        endpoint_addr: resp.endpoint_addr,
+    })
+}
+
+/// POST the node's `EndpointAddr` to the mailbox's `/peers/register` endpoint
+/// so its blob fetch pool can dial the node as a source.
+async fn register_self_with_mailbox(
+    base_url: &str,
+    our_addr: iroh::EndpointAddr,
+) -> anyhow::Result<()> {
+    let url = format!("{}/peers/register", base_url.trim_end_matches('/'));
+    mailbox_client::HTTP_CLIENT
+        .post(&url)
+        .json(&RegisterPeerRequest { addr: our_addr })
+        .send()
+        .await?
+        .error_for_status()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_file_mailbox_url_interpolates_domain() {
+        let url = env_file_mailbox_url("testing");
+        assert_eq!(url, "https://0-19.mailbox.testing.darksoil.studio");
+    }
+}

--- a/crates/dashchat-node/src/testing/mod.rs
+++ b/crates/dashchat-node/src/testing/mod.rs
@@ -1,8 +1,10 @@
 mod behavior;
 mod introduce;
+mod mailbox;
 mod test_node;
 
 pub use introduce::*;
+pub use mailbox::*;
 pub use test_node::*;
 use tracing_subscriber::EnvFilter;
 

--- a/crates/dashchat-node/src/testing/test_node.rs
+++ b/crates/dashchat-node/src/testing/test_node.rs
@@ -15,7 +15,7 @@ use mailbox_client::MailboxClient;
 use crate::{
     AgentId, DeviceGroupPayload, NodeConfig, Notification, Payload, Profile,
     filesystem::Filesystem, mailbox::MailboxOperation, node::Node, stores::LocalStore,
-    testing::behavior::Behavior, topic::TopicId,
+    testing::TestMailbox, testing::behavior::Behavior, topic::TopicId,
 };
 
 #[derive(Clone, derive_more::Deref, derive_more::Debug)]
@@ -112,6 +112,11 @@ impl TestNode {
 
     pub async fn add_mailbox_client(&self, mailbox: impl MailboxClient<MailboxOperation>) -> Self {
         self.node.mailboxes.register(mailbox).await;
+        self.clone()
+    }
+
+    pub async fn add_mailbox(&self, mailbox: &TestMailbox) -> Self {
+        mailbox.register_on(&self.node).await;
         self.clone()
     }
 

--- a/crates/dashchat-node/tests/blob_sync.rs
+++ b/crates/dashchat-node/tests/blob_sync.rs
@@ -1,5 +1,4 @@
 use dashchat_node::{testing::*, *};
-use mailbox_client::mem::MemMailbox;
 use p2panda::network::MdnsDiscoveryMode;
 
 /// A chat message with a photo attachment created by one node should be
@@ -14,14 +13,14 @@ async fn media_blob_syncs_between_nodes() {
     let mut config = NodeConfig::testing();
     config.mdns_mode = MdnsDiscoveryMode::Active;
 
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = TestNode::new(config.clone(), "alice")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
     let bobbi = TestNode::new(config.clone(), "bobbi")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
 
     alice
@@ -102,14 +101,14 @@ async fn blob_fetch_pool_hydrates_stored_media_on_restart() {
     let mut config = NodeConfig::testing();
     config.mdns_mode = MdnsDiscoveryMode::Active;
 
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = TestNode::new(config.clone(), "alice")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
     let bobbi = TestNode::new(config.clone(), "bobbi")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
 
     alice

--- a/crates/dashchat-node/tests/bootstrap.rs
+++ b/crates/dashchat-node/tests/bootstrap.rs
@@ -1,5 +1,4 @@
 use dashchat_node::{testing::*, *};
-use mailbox_client::mem::MemMailbox;
 use p2panda::network::MdnsDiscoveryMode;
 
 const TRACING_FILTER: [&str; 1] = ["dashchat=debug"];
@@ -18,14 +17,14 @@ async fn test_mailbox_bootstrap() {
     let mut bobbi_config = NodeConfig::testing();
     bobbi_config.mdns_mode = MdnsDiscoveryMode::Disabled;
 
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = TestNode::new(alice_config, "alice")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
     let bobbi = TestNode::new(bobbi_config, "bobbi")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
 
     alice

--- a/crates/dashchat-node/tests/compat_upgrades.rs
+++ b/crates/dashchat-node/tests/compat_upgrades.rs
@@ -1,7 +1,6 @@
 use dashchat_node::ChatMessageContent;
 use dashchat_node::testing::{PollConfig, TestNode, TestNodeConfig};
 use dashchat_node::{ShareIntent, compat::Capabilities, node::NodeConfig};
-use mailbox_client::mem::MemMailbox;
 
 /// Capability upgrade in a direct chat:
 /// - Start with both nodes at zero capabilities, exchange messages (V0)
@@ -17,14 +16,14 @@ async fn direct_chat_capability_upgrade() {
     bobbi_config.node_config.capabilities = Capabilities::zero();
 
     let poll = PollConfig::default();
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = TestNode::new(alice_config, "alice")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
     let bobbi = TestNode::new(bobbi_config, "bobbi")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
 
     alice
@@ -67,7 +66,7 @@ async fn direct_chat_capability_upgrade() {
         alice_dir,
     )
     .await
-    .add_mailbox_client(mailbox.client())
+    .add_mailbox(&mailbox)
     .await;
 
     // Wait for bobbi to learn alice's updated capabilities via the mailbox.
@@ -149,7 +148,7 @@ async fn direct_chat_capability_upgrade() {
         bobbi_dir,
     )
     .await
-    .add_mailbox_client(mailbox.client())
+    .add_mailbox(&mailbox)
     .await;
 
     // Wait for alice to learn bobbi's updated capabilities.
@@ -223,18 +222,18 @@ async fn group_chat_capability_upgrade() {
     cammy_config.node_config.capabilities = Capabilities::zero();
 
     let poll = PollConfig::default();
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = TestNode::new(alice_config, "alice")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
     let bobbi = TestNode::new(bobbi_config, "bobbi")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
     let cammy = TestNode::new(cammy_config, "cammy")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
 
     println!(
@@ -347,7 +346,7 @@ async fn group_chat_capability_upgrade() {
         alice_dir,
     )
     .await
-    .add_mailbox_client(mailbox.client())
+    .add_mailbox(&mailbox)
     .await;
 
     println!("### {:3.1?} bobbi upgrading", start.elapsed());
@@ -362,7 +361,7 @@ async fn group_chat_capability_upgrade() {
         bobbi_dir,
     )
     .await
-    .add_mailbox_client(mailbox.client())
+    .add_mailbox(&mailbox)
     .await;
 
     println!(
@@ -455,7 +454,7 @@ async fn group_chat_capability_upgrade() {
         cammy_dir,
     )
     .await
-    .add_mailbox_client(mailbox.client())
+    .add_mailbox(&mailbox)
     .await;
 
     // Wait for bobbi to learn cammy's updated capabilities (bobbi knows cammy).
@@ -519,7 +518,7 @@ async fn group_chat_capability_upgrade() {
     danae_config.node_config.capabilities = Capabilities::zero();
     let danae = TestNode::new(danae_config, "danae")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
 
     danae

--- a/crates/dashchat-node/tests/contacts.rs
+++ b/crates/dashchat-node/tests/contacts.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use dashchat_node::{testing::*, *};
-use mailbox_client::mem::MemMailbox;
 
 const TRACING_FILTER: [&str; 5] = [
     "contacts=info",
@@ -16,14 +15,14 @@ const TRACING_FILTER: [&str; 5] = [
 async fn test_reject_contact_request() {
     dashchat_node::testing::setup_tracing(&TRACING_FILTER, true);
 
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = TestNode::new(NodeConfig::testing(), "alice")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
     let bobbi = TestNode::new(NodeConfig::testing(), "bobbi")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
 
     println!("nodes:");
@@ -77,18 +76,18 @@ async fn test_reject_multiple_contact_requests() {
 
     let start = tokio::time::Instant::now();
 
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = TestNode::new(NodeConfig::testing(), "alice")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
     let bobbi = TestNode::new(NodeConfig::testing(), "bobbi")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
     let carol = TestNode::new(NodeConfig::testing(), "carol")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
 
     println!("### {:3.1?} alice creating QR codes", start.elapsed());

--- a/crates/dashchat-node/tests/device_groups.rs
+++ b/crates/dashchat-node/tests/device_groups.rs
@@ -1,5 +1,4 @@
 use dashchat_node::{testing::*, *};
-use mailbox_client::mem::MemMailbox;
 
 const TRACING_FILTER: [&str; 4] = [
     "dashchat=debug",
@@ -13,14 +12,14 @@ const TRACING_FILTER: [&str; 4] = [
 async fn device_group_solo() {
     dashchat_node::testing::setup_tracing(&TRACING_FILTER, true);
 
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = TestNode::new(NodeConfig::testing(), "alice")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
     let alicia = TestNode::new(NodeConfig::testing(), "alicia")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
 
     println!("nodes:");

--- a/crates/dashchat-node/tests/group_chats.rs
+++ b/crates/dashchat-node/tests/group_chats.rs
@@ -3,8 +3,7 @@
 
 #![cfg(test)]
 
-use dashchat_node::{mailbox::MailboxOperation, testing::*, *};
-use mailbox_client::mem::MemMailbox;
+use dashchat_node::{testing::*, *};
 
 use maplit::{btreemap, btreeset};
 use p2panda::network::MdnsDiscoveryMode;
@@ -82,10 +81,10 @@ fn setup() {
     );
 }
 
-async fn make_node(mailbox: &MemMailbox<MailboxOperation>, name: &str) -> TestNode {
+async fn make_node(mailbox: &TestMailbox, name: &str) -> TestNode {
     let result = TestNode::new(NodeConfig::testing(), name)
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(mailbox)
         .await;
     println!("Node {}: {}", name, result.device_id());
     result
@@ -96,7 +95,7 @@ async fn test_direct_chat() {
     setup();
 
     let poll = PollConfig::default();
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = make_node(&mailbox, "alice").await;
     let bobbi = make_node(&mailbox, "bobbi").await;
 
@@ -197,7 +196,7 @@ async fn test_group_chat() {
     setup();
 
     let poll = PollConfig::default();
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = make_node(&mailbox, "alice").await;
     let bobbi = make_node(&mailbox, "bobbi").await;
     let cammy = make_node(&mailbox, "cammy").await;
@@ -352,7 +351,7 @@ async fn test_admin_removes_themself_when_they_are_the_only_member() {
     setup();
 
     let poll = PollConfig::default();
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = make_node(&mailbox, "alice").await;
 
     let chat_id = alice
@@ -374,7 +373,7 @@ async fn test_admin_removes_themself_there_is_another_admin() {
     setup();
 
     let poll = PollConfig::default();
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = make_node(&mailbox, "alice").await;
     let bobbi = make_node(&mailbox, "bobbi").await;
 
@@ -426,7 +425,7 @@ async fn test_admin_removes_themself_there_is_another_admin() {
 async fn test_admin_cant_remove_themself_when_they_are_the_only_admin() {
     setup();
 
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = make_node(&mailbox, "alice").await;
     let bobbi = make_node(&mailbox, "bobbi").await;
 
@@ -459,7 +458,7 @@ async fn test_non_admin_removes_themself() {
     setup();
 
     let poll = PollConfig::default();
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = make_node(&mailbox, "alice").await;
     let bobbi = make_node(&mailbox, "bobbi").await;
 
@@ -513,7 +512,7 @@ async fn test_admin_removes_non_admin() {
     setup();
 
     let poll = PollConfig::default();
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = make_node(&mailbox, "alice").await;
     let bobbi = make_node(&mailbox, "bobbi").await;
 
@@ -566,7 +565,7 @@ async fn test_non_admin_cannot_remove_admin() {
     setup();
 
     let poll = PollConfig::default();
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = make_node(&mailbox, "alice").await;
     let andi = make_node(&mailbox, "andi").await;
     let bobbi = make_node(&mailbox, "bobbi").await;

--- a/crates/dashchat-node/tests/inbox.rs
+++ b/crates/dashchat-node/tests/inbox.rs
@@ -1,5 +1,4 @@
 use dashchat_node::{testing::*, *};
-use mailbox_client::mem::MemMailbox;
 use p2panda::network::MdnsDiscoveryMode;
 
 const TRACING_FILTER: [&str; 5] = [
@@ -14,14 +13,14 @@ const TRACING_FILTER: [&str; 5] = [
 async fn test_inbox_2() {
     dashchat_node::testing::setup_tracing(&TRACING_FILTER, true);
 
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = TestNode::new(NodeConfig::testing(), "alice")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
     let bobbi = TestNode::new(NodeConfig::testing(), "bobbi")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
 
     println!("nodes:");

--- a/crates/dashchat-node/tests/mailboxes.rs
+++ b/crates/dashchat-node/tests/mailboxes.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
 use dashchat_node::{mailbox::MailboxOperation, testing::*, *};
-use mailbox_client::{MailboxClient, mem::MemMailbox, toy::ToyMailboxClient};
+use mailbox_client::{MailboxClient, toy::ToyMailboxClient};
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_mailbox_late_join_mem() {
+async fn test_mailbox_late_join_default() {
     dashchat_node::testing::setup_tracing(
         &[
             "dashchat=info",
@@ -16,8 +16,8 @@ async fn test_mailbox_late_join_mem() {
         true,
     );
 
-    let mb = MemMailbox::new();
-    mailbox_late_join(mb.client(), mb.client()).await;
+    let mb = TestMailbox::from_env();
+    mailbox_late_join(mb.client().await, mb.client().await).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -247,23 +247,23 @@ async fn test_multiple_mailboxes_group_pivot() {
         true,
     );
 
-    let mb1 = MemMailbox::new();
-    let mb2 = MemMailbox::new();
+    let mb1 = TestMailbox::from_env();
+    let mb2 = TestMailbox::from_env();
     let alice = TestNode::new(NodeConfig::testing(), "alice")
         .await
-        .add_mailbox_client(mb1.client())
+        .add_mailbox(&mb1)
         .await;
 
     let bobbi = TestNode::new(NodeConfig::testing(), "bobbi")
         .await
-        .add_mailbox_client(mb1.client())
+        .add_mailbox(&mb1)
         .await
-        .add_mailbox_client(mb2.client())
+        .add_mailbox(&mb2)
         .await;
 
     let carol = TestNode::new(NodeConfig::testing(), "carol")
         .await
-        .add_mailbox_client(mb2.client())
+        .add_mailbox(&mb2)
         .await;
 
     alice

--- a/crates/dashchat-node/tests/no_p2p.rs
+++ b/crates/dashchat-node/tests/no_p2p.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use dashchat_node::{mailbox::MailboxOperation, testing::*, *};
-use mailbox_client::mem::MemMailbox;
 use mailbox_client::toy::ToyMailboxClient;
 
 /// POST our dialing address to a mailbox's `/peers/register` endpoint so its
@@ -31,14 +30,14 @@ async fn no_p2p_cannot_sync_after_mailbox_removed() {
 
     let poll = PollConfig::default();
 
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = TestNode::new(NodeConfig::testing().no_p2p(), "alice")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
     let bobbi = TestNode::new(NodeConfig::testing().no_p2p(), "bobbi")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
 
     alice

--- a/crates/dashchat-node/tests/profiles.rs
+++ b/crates/dashchat-node/tests/profiles.rs
@@ -1,5 +1,3 @@
-use mailbox_client::mem::MemMailbox;
-
 use dashchat_node::{testing::*, *};
 
 const TRACING_FILTER: [&str; 4] = [
@@ -65,14 +63,14 @@ async fn test_profiles_sync_between_contacts() {
     dashchat_node::testing::setup_tracing(&TRACING_FILTER, true);
 
     println!("nodes:");
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = TestNode::new(NodeConfig::testing(), "alice--")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
     let bobbi = TestNode::new(NodeConfig::testing(), "--bobbi")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
 
     let poll = PollConfig::default();

--- a/crates/dashchat-node/tests/tombstones.rs
+++ b/crates/dashchat-node/tests/tombstones.rs
@@ -2,7 +2,6 @@
 //! must never be stored or synced.
 
 use dashchat_node::{testing::*, *};
-use mailbox_client::mem::MemMailbox;
 use p2panda::operation::LogId;
 
 fn setup_tracing() {
@@ -75,15 +74,15 @@ async fn tombstone_drops_payload_received_by_sync() {
 
     let poll = PollConfig::default();
     let config = NodeConfig::testing();
-    let mb = MemMailbox::new();
+    let mb = TestMailbox::from_env();
 
     let alice = TestNode::new(config.clone(), "alice")
         .await
-        .add_mailbox_client(mb.client())
+        .add_mailbox(&mb)
         .await;
     let bobbi = TestNode::new(config.clone(), "bobbi")
         .await
-        .add_mailbox_client(mb.client())
+        .add_mailbox(&mb)
         .await;
 
     alice
@@ -119,7 +118,7 @@ async fn tombstone_drops_payload_received_by_sync() {
     );
 
     // Reconnect bobbi: it syncs the op and drops the payload on arrival.
-    bobbi.add_mailbox_client(mb.client()).await;
+    bobbi.add_mailbox(&mb).await;
 
     poll.wait_for(|| async {
         match payload_present(&bobbi, *chat, alice.device_id(), secret_hash).await {

--- a/e2e-tests/setup/mailbox-control.ts
+++ b/e2e-tests/setup/mailbox-control.ts
@@ -26,14 +26,40 @@ const MAILBOX_INFO_PATH = path.join(
 );
 
 interface MailboxInfo {
-	pid: number;
-	port: number;
 	url: string;
-	dbPath: string;
+	/** Set when the suite runs against a remote environment mailbox (DASHCHAT_TEST_ENV). */
+	remote?: boolean;
+	pid?: number;
+	port?: number;
+	dbPath?: string;
 }
 
 function readInfo(): MailboxInfo {
 	return JSON.parse(readFileSync(MAILBOX_INFO_PATH, 'utf-8')) as MailboxInfo;
+}
+
+/**
+ * True when the suite runs against a remote environment mailbox, whose
+ * lifecycle specs cannot control. Specs using the helpers below should skip
+ * themselves when this returns true.
+ */
+export function isRemoteMailbox(): boolean {
+	return readInfo().remote === true;
+}
+
+function localInfo(): { pid: number; port: number; url: string; dbPath: string } {
+	const { remote, pid, port, url, dbPath } = readInfo();
+	if (
+		remote === true ||
+		pid === undefined ||
+		port === undefined ||
+		dbPath === undefined
+	) {
+		throw new Error(
+			'mailbox lifecycle control is unavailable against a remote environment mailbox (DASHCHAT_TEST_ENV)',
+		);
+	}
+	return { pid, port, url, dbPath };
 }
 
 function signalGroup(pid: number, sig: NodeJS.Signals): void {
@@ -44,18 +70,18 @@ function signalGroup(pid: number, sig: NodeJS.Signals): void {
 
 /** Suspend the mailbox server so all HTTP traffic to it hangs/times out. */
 export function suspendMailbox(): void {
-	signalGroup(readInfo().pid, 'SIGSTOP');
+	signalGroup(localInfo().pid, 'SIGSTOP');
 }
 
 /** Resume a previously-suspended mailbox server. */
 export function resumeMailbox(): void {
-	signalGroup(readInfo().pid, 'SIGCONT');
+	signalGroup(localInfo().pid, 'SIGCONT');
 }
 
 /** Kill the mailbox server outright so connections to it are refused. */
 export function killMailbox(): void {
 	try {
-		signalGroup(readInfo().pid, 'SIGKILL');
+		signalGroup(localInfo().pid, 'SIGKILL');
 	} catch {
 		/* already gone */
 	}
@@ -67,7 +93,7 @@ export function killMailbox(): void {
  * with the new pid.
  */
 export async function restartMailbox(): Promise<void> {
-	const info = readInfo();
+	const info = localInfo();
 	const server = spawnMailboxServer(info.port, info.dbPath);
 	server.unref();
 	writeFileSync(MAILBOX_INFO_PATH, JSON.stringify({ ...info, pid: server.pid }));

--- a/e2e-tests/setup/test-env.ts
+++ b/e2e-tests/setup/test-env.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const ALLOWED_TEST_ENVS = ['testing'];
+
+/**
+ * Mailbox URL for the deployment environment named by DASHCHAT_TEST_ENV,
+ * resolved from the repo-root `.env.<name>` file, or null when the var is
+ * unset — in which case the suite spawns its own local mailbox server.
+ * Throws on a non-allowlisted environment.
+ */
+export function testEnvMailboxUrl(): string | null {
+	const name = process.env.DASHCHAT_TEST_ENV;
+	if (name === undefined || name === '') return null;
+	if (!ALLOWED_TEST_ENVS.includes(name)) {
+		throw new Error(
+			`DASHCHAT_TEST_ENV=${name} is not an allowed test environment (allowed: ${ALLOWED_TEST_ENVS.join(', ')})`,
+		);
+	}
+	const file = path.resolve(__dirname, '..', '..', `.env.${name}`);
+	const vars = new Map<string, string>();
+	for (const line of readFileSync(file, 'utf-8').split('\n')) {
+		const trimmed = line.trim();
+		if (trimmed === '' || trimmed.startsWith('#')) continue;
+		const eq = trimmed.indexOf('=');
+		if (eq === -1) continue;
+		const key = trimmed.slice(0, eq).trim();
+		let value = trimmed.slice(eq + 1).trim();
+		for (const [k, v] of vars) {
+			value = value.split(`\${${k}}`).join(v);
+		}
+		vars.set(key, value);
+	}
+	const url = vars.get('MAILBOX_URL');
+	if (url === undefined) throw new Error(`no MAILBOX_URL in ${file}`);
+	return url;
+}

--- a/e2e-tests/specs/offline-transition-ux.spec.ts
+++ b/e2e-tests/specs/offline-transition-ux.spec.ts
@@ -11,6 +11,7 @@
  */
 import { exchangeContacts } from '../helpers/flows/exchange-contacts';
 import {
+	isRemoteMailbox,
 	killMailbox,
 	restartMailbox,
 	resumeMailbox,
@@ -44,6 +45,9 @@ describe('Offline UX', () => {
 
 	before(async function () {
 		this.timeout(120_000);
+		// The whole suite toggles the mailbox server's lifecycle, which is
+		// impossible against a remote environment mailbox.
+		if (isRemoteMailbox()) this.skip();
 		[agent1, agent2] = await Promise.all([
 			setupAgent('agent1'),
 			setupAgent('agent2'),

--- a/e2e-tests/specs/waiting-profile.spec.ts
+++ b/e2e-tests/specs/waiting-profile.spec.ts
@@ -1,5 +1,9 @@
 import { navigateToAddContact } from '../helpers/flows/exchange-contacts';
-import { resumeMailbox, suspendMailbox } from '../setup/mailbox-control';
+import {
+	isRemoteMailbox,
+	resumeMailbox,
+	suspendMailbox,
+} from '../setup/mailbox-control';
 import { type Agent, setupAgent } from '../setup/setup-agents';
 import { tid } from '../helpers/selectors';
 
@@ -25,7 +29,10 @@ describe('Waiting-for-profile placeholder', () => {
 	let waitingText: string;
 	let mailboxSuspended = false;
 
-	before(async () => {
+	before(async function () {
+		// The placeholder window only exists while the mailbox is suspended,
+		// which is impossible against a remote environment mailbox.
+		if (isRemoteMailbox()) this.skip();
 		[agent1, agent2] = await Promise.all([
 			setupAgent('agent1'),
 			setupAgent('agent2'),

--- a/e2e-tests/wdio.conf.ts
+++ b/e2e-tests/wdio.conf.ts
@@ -13,6 +13,7 @@ import {
 	killPortHolders,
 } from './setup/cleanup';
 import { spawnMailboxServer } from './setup/mailbox-server';
+import { testEnvMailboxUrl } from './setup/test-env';
 import { waitForPortFree, waitForPortListening } from './setup/wait-for-port';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -107,6 +108,25 @@ export const config: WebdriverIO.MultiremoteConfig = {
 		killLeftoverMailboxServers();
 		killPortHolders(ALL_PORTS);
 
+		const mailboxInfoPath = path.join(ROOT, '.dbs', 'e2e', 'mailbox-info.json');
+
+		// When DASHCHAT_TEST_ENV names a deployment environment, run against
+		// its cloud mailbox instead of spawning a local server. Specs that
+		// drive the mailbox's lifecycle skip themselves via isRemoteMailbox().
+		const remoteMailboxUrl = testEnvMailboxUrl();
+		if (remoteMailboxUrl !== null) {
+			process.env.MAILBOX_URL = remoteMailboxUrl;
+			mkdirSync(path.dirname(mailboxInfoPath), { recursive: true });
+			writeFileSync(
+				mailboxInfoPath,
+				JSON.stringify({ remote: true, url: remoteMailboxUrl }),
+			);
+			console.log(
+				`Using remote '${process.env.DASHCHAT_TEST_ENV}' mailbox at ${remoteMailboxUrl}`,
+			);
+			return;
+		}
+
 		// Start a local mailbox server so e2e tests don't hit the internet.
 		const mailboxPort = allocatePort();
 		const mailboxUrl = `http://localhost:${mailboxPort}`;
@@ -154,7 +174,6 @@ export const config: WebdriverIO.MultiremoteConfig = {
 
 		// Persist mailbox info so individual specs can suspend/resume it to
 		// drive the offline-UX state transitions.
-		const mailboxInfoPath = path.join(ROOT, '.dbs', 'e2e', 'mailbox-info.json');
 		writeFileSync(
 			mailboxInfoPath,
 			JSON.stringify({


### PR DESCRIPTION
## Summary

Add support for running the Rust and E2E test suites against cloud mailboxes in deployment environments (e.g., `testing`) instead of always using local in-memory or spawned mailbox servers. This enables testing against real infrastructure while keeping local development simple.

## Key Changes

- **New `TestMailbox` enum** (`crates/dashchat-node/src/testing/mailbox.rs`): Abstracts over in-memory and HTTP-based mailbox clients. `TestMailbox::from_env()` reads `DASHCHAT_TEST_ENV` to decide which to use; unset or empty → fresh `MemMailbox`, set to an allowlisted environment → cloud mailbox with URL resolved from `.env.<name>` file.

- **New `TestMailbox::register_on()` method**: Registers a mailbox on a node the way the production app does it — fetches the mailbox's canonical id from `/health`, adds its dialing address to the node's address book, and registers the node's own address back via `/peers/register` so the mailbox's blob fetcher can dial it.

- **Updated `TestNode::add_mailbox()`**: Now accepts `&TestMailbox` instead of a raw client, calls `register_on()` internally, and handles both in-memory and remote mailboxes transparently.

- **E2E test infrastructure** (`e2e-tests/setup/test-env.ts`): New helper to resolve mailbox URLs from `.env.<name>` files with variable interpolation. `wdio.conf.ts` now skips spawning a local mailbox server when `DASHCHAT_TEST_ENV` is set and writes `remote: true` to the mailbox info file.

- **E2E mailbox control guards** (`e2e-tests/setup/mailbox-control.ts`): Added `isRemoteMailbox()` check and `localInfo()` helper so specs that drive the mailbox server's lifecycle (suspend/kill/restart) can skip themselves when running against a remote environment.

- **Updated all test files**: Replaced direct `MemMailbox::new()` calls with `TestMailbox::from_env()` and changed `add_mailbox_client(mb.client())` to `add_mailbox(&mb)` throughout the Rust test suite. Updated E2E specs to skip lifecycle-dependent tests via `isRemoteMailbox()`.

- **Documentation** (CLAUDE.md): Added section explaining how to run tests against deployment environments, the allowlisted environments, and the differences between Rust and E2E test behavior.

## Implementation Details

- Environment names are allowlisted (`ALLOWED_TEST_ENVS = ["testing"]`) in both Rust and E2E suites to prevent accidental test runs against production.
- The `.env.<name>` file parser supports variable interpolation (e.g., `${DOMAIN}`) to avoid duplication.
- Remote mailbox registration mirrors the production app's flow: health check → address book → peer registration.
- E2E specs that depend on mailbox lifecycle control (suspend/kill/restart) detect remote mode and skip themselves; specs that only use the mailbox for message passing work unchanged.

https://claude.ai/code/session_01ArDyp5yF7wp1LHHi8W6Vpv