### PR TITLE
E2E tests can disabled P2P syncing in a targetted way. 

### DIFF
--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -511,6 +511,17 @@ impl Node {
         Ok(self.endpoint.endpoint().await?)
     }
 
+    /// Tear down all p2p connectivity by closing the iroh endpoint. Afterwards
+    /// the node can neither dial nor accept peer connections, so no gossip sync
+    /// happens; local reads and writes against the op store keep working. This
+    /// is a one-way switch intended only for e2e tests that must observe
+    /// pre-sync UI state without racing a direct p2p connection between two
+    /// agents running on the same machine.
+    pub async fn disconnect_p2p(&self) -> Result<()> {
+        self.endpoint.endpoint().await?.close().await;
+        Ok(())
+    }
+
     /// Add (or refresh) a peer's dialing address (relay + direct addresses) in
     /// the p2panda address book so the iroh blob downloader can reach that peer
     /// by its EndpointId. Used for mailbox `/health` self-addresses and for peer

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -517,7 +517,8 @@ impl Node {
     /// is a one-way switch intended only for e2e tests that must observe
     /// pre-sync UI state without racing a direct p2p connection between two
     /// agents running on the same machine.
-    pub async fn disconnect_p2p(&self) -> Result<()> {
+    #[cfg(feature = "testing")]
+    pub async fn close_iroh_endpoint(&self) -> Result<()> {
         self.endpoint.endpoint().await?.close().await;
         Ok(())
     }

--- a/e2e-tests/setup/setup-agents.ts
+++ b/e2e-tests/setup/setup-agents.ts
@@ -166,7 +166,9 @@ export function makeAgent(b: WebdriverIO.Browser): Agent {
 		await b.execute(() => window.__test.enablePreviewFeatures());
 	};
 	agent.disableP2p = async () => {
-		await b.execute(() => window.__test.disableP2p());
+		await b.executeAsync((done: () => void) =>
+			window.__test.disableP2p().then(done, done),
+		);
 	};
 	agent.restart = async () => {
 		await b.reloadSession();

--- a/e2e-tests/setup/setup-agents.ts
+++ b/e2e-tests/setup/setup-agents.ts
@@ -80,6 +80,10 @@ export type Agent = WebdriverIO.Browser & {
 	setDarkMode(value: boolean): Promise<void>;
 	/** Enable preview features so gated UI (e.g. new-group) becomes visible. */
 	enablePreviewFeatures(): Promise<void>;
+	/** Close this agent's iroh endpoint so it can no longer sync over p2p.
+	 *  One-way for the life of the process; the agent still reads/writes
+	 *  locally and talks to a mailbox. */
+	disableP2p(): Promise<void>;
 };
 
 /** (Re)build every page object against `b`. Called on first setup and again
@@ -160,6 +164,9 @@ export function makeAgent(b: WebdriverIO.Browser): Agent {
 	};
 	agent.enablePreviewFeatures = async () => {
 		await b.execute(() => window.__test.enablePreviewFeatures());
+	};
+	agent.disableP2p = async () => {
+		await b.execute(() => window.__test.disableP2p());
 	};
 	agent.restart = async () => {
 		await b.reloadSession();

--- a/e2e-tests/specs/waiting-profile.spec.ts
+++ b/e2e-tests/specs/waiting-profile.spec.ts
@@ -27,6 +27,7 @@ describe('Waiting-for-profile placeholder', () => {
 	let agent1: Agent;
 	let agent2: Agent;
 	let waitingText: string;
+	let contactCode1: string;
 	let mailboxSuspended = false;
 
 	before(async function () {
@@ -42,9 +43,16 @@ describe('Waiting-for-profile placeholder', () => {
 			agent2.createProfilePage.createProfile('Bob', 'Test'),
 		]);
 		waitingText = await agent2.tr('waitingForProfile');
-		// Suspend the shared mailbox before any contact exchange so agent1's
-		// profile cannot sync to agent2 while we check the placeholder. Without
-		// this the placeholder window is only ~2s wide and races slow setups.
+		// Fetch agent1's contact code while its p2p is still up (generating the
+		// code sets up agent1's inbox gossip topic, which needs a live endpoint).
+		await navigateToAddContact(agent1);
+		contactCode1 = await agent1.addContactPage.getContactCode();
+		// Hold agent2 in the pre-sync state so the "waiting for profile"
+		// placeholder stays visible: suspend the shared mailbox AND cut agent1
+		// off from p2p. Without disabling p2p, the two agents sync agent1's
+		// profile directly over the iroh relay (mDNS is already off in e2e
+		// builds), bypassing the suspended mailbox and racing the assertions.
+		await agent1.disableP2p();
 		suspendMailbox();
 		mailboxSuspended = true;
 	});
@@ -61,11 +69,8 @@ describe('Waiting-for-profile placeholder', () => {
 	});
 
 	it('shows the placeholder on direct-chat after one-sided contact addition', async () => {
-		await navigateToAddContact(agent1);
-		const code1 = await agent1.addContactPage.getContactCode();
-
 		await navigateToAddContact(agent2);
-		await agent2.addContactPage.enterCode(code1);
+		await agent2.addContactPage.enterCode(contactCode1);
 		await agent2.directChatPage.ready();
 
 		await waitForTextContent(agent2, tid('direct-chat-peer-header'), waitingText);

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11,3 +11,6 @@ pub mod direct_chats;
 pub mod mailbox_state;
 pub mod media;
 pub mod settings;
+
+#[cfg(feature = "e2e-tests")]
+pub mod testing;

--- a/src-tauri/src/commands/testing.rs
+++ b/src-tauri/src/commands/testing.rs
@@ -6,6 +6,6 @@ use tauri::State;
 /// `e2e-tests` feature; used by specs that must observe pre-sync UI state
 /// without racing a direct p2p connection between two agents on one machine.
 #[tauri::command]
-pub async fn disable_p2p(node: State<'_, Node>) -> Result<(), String> {
-    node.disconnect_p2p().await.map_err(|e| e.to_string())
+pub async fn close_iroh_endpoint(node: State<'_, Node>) -> Result<(), String> {
+    node.close_iroh_endpoint().await.map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/testing.rs
+++ b/src-tauri/src/commands/testing.rs
@@ -1,0 +1,11 @@
+use dashchat_node::Node;
+use tauri::State;
+
+/// Close this node's iroh endpoint so it can no longer sync with peers over
+/// p2p. Local reads/writes keep working. Only registered under the
+/// `e2e-tests` feature; used by specs that must observe pre-sync UI state
+/// without racing a direct p2p connection between two agents on one machine.
+#[tauri::command]
+pub async fn disable_p2p(node: State<'_, Node>) -> Result<(), String> {
+    node.disconnect_p2p().await.map_err(|e| e.to_string())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -152,6 +152,8 @@ pub fn run() {
             commands::mailbox_state::mailbox_subscribe_sync_state,
             commands::mailbox_state::mailbox_subscribe_cloud_id,
             commands::media::save_blob_to_cache,
+            #[cfg(feature = "e2e-tests")]
+            commands::testing::disable_p2p,
         ])
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_notification::init())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -153,7 +153,7 @@ pub fn run() {
             commands::mailbox_state::mailbox_subscribe_cloud_id,
             commands::media::save_blob_to_cache,
             #[cfg(feature = "e2e-tests")]
-            commands::testing::disable_p2p,
+            commands::testing::close_iroh_endpoint,
         ])
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_notification::init())

--- a/ui/tests/setup-utils.ts
+++ b/ui/tests/setup-utils.ts
@@ -47,11 +47,11 @@ function hasText(selector: string, text: string): boolean {
 }
 
 /** Close this agent's iroh endpoint so it can no longer sync with peers over
- * p2p. Backed by the `disable_p2p` command (only registered under the
+ * p2p. Backed by the `close_iroh_endpoint` command (only registered under the
  * `e2e-tests` feature). One-way — the agent stays p2p-disconnected until it
  * restarts. */
 function disableP2p(): Promise<void> {
-	return invokeAfterSetup('disable_p2p');
+	return invokeAfterSetup('close_iroh_endpoint');
 }
 export interface TestFileSpec {
 	name: string;

--- a/ui/tests/setup-utils.ts
+++ b/ui/tests/setup-utils.ts
@@ -7,8 +7,9 @@
  *
  * Single-purpose DOM queries belong in `e2e-tests/helpers/pages/*`.
  */
-import type { m } from '../src/lib/paraglide/messages.js';
 import { invokeAfterSetup } from 'dash-chat-stores';
+
+import type { m } from '../src/lib/paraglide/messages.js';
 
 type Messages = typeof m;
 
@@ -51,7 +52,8 @@ function hasText(selector: string, text: string): boolean {
  * restarts. */
 function disableP2p(): Promise<void> {
 	return invokeAfterSetup('disable_p2p');
-}export interface TestFileSpec {
+}
+export interface TestFileSpec {
 	name: string;
 	mimeType: string;
 	/** Raw bytes. Omit and pass `size` for a large zero-filled file so a huge

--- a/ui/tests/setup-utils.ts
+++ b/ui/tests/setup-utils.ts
@@ -8,6 +8,7 @@
  * Single-purpose DOM queries belong in `e2e-tests/helpers/pages/*`.
  */
 import type { m } from '../src/lib/paraglide/messages.js';
+import { invokeAfterSetup } from 'dash-chat-stores';
 
 type Messages = typeof m;
 
@@ -44,7 +45,13 @@ function hasText(selector: string, text: string): boolean {
 	return document.querySelector(selector)?.textContent?.includes(text) ?? false;
 }
 
-export interface TestFileSpec {
+/** Close this agent's iroh endpoint so it can no longer sync with peers over
+ * p2p. Backed by the `disable_p2p` command (only registered under the
+ * `e2e-tests` feature). One-way — the agent stays p2p-disconnected until it
+ * restarts. */
+function disableP2p(): Promise<void> {
+	return invokeAfterSetup('disable_p2p');
+}export interface TestFileSpec {
 	name: string;
 	mimeType: string;
 	/** Raw bytes. Omit and pass `size` for a large zero-filled file so a huge
@@ -101,6 +108,7 @@ function dropFiles(specs: TestFileSpec[]) {
 export const testUtils = {
 	simulateUpdate,
 	hasText,
+	disableP2p,
 	pasteFiles,
 	dropFiles,
 	/** E2E override for the composer's recent-photos strip; left undefined unless


### PR DESCRIPTION
Disable it for the waiting-profile tests as the presence of p2p sync has made these tests (which turn off the mailbox to simulate a lack of connectivity) flaky.