### PR TITLE
Keep glib out of appimage build

### DIFF
--- a/scripts/assert-no-wayland-in-appimage.sh
+++ b/scripts/assert-no-wayland-in-appimage.sh
@@ -1,11 +1,23 @@
 #!/usr/bin/env bash
-# Guard: fail if libwayland-client leaked into the built AppImage.
+# Guard: fail if a host-coupled library leaked into the built AppImage.
 #
 # Backstop for install-ci-linuxdeploy-wrapper.sh. If a future tauri-bundler
 # changes the cached-tool path/filename or the skip-if-exists behaviour, the
-# shim silently stops applying and wayland leaks back in. This converts that
-# silent regression into a loud failure.
+# shim silently stops applying and the excluded libs leak back in. This
+# converts that silent regression into a loud failure. Covers both the wayland
+# client stack (blank-screen EGL mismatch) and glib (gvfs/gio module symbol
+# mismatch, e.g. "undefined symbol: g_task_set_static_name").
 set -euo pipefail
+
+# Libraries that must resolve from the host, never be bundled. Matched against
+# the basename of files under squashfs-root.
+FORBIDDEN_GLOBS=(
+  'libwayland-client.so*'
+  'libglib-2.0.so*'
+  'libgio-2.0.so*'
+  'libgobject-2.0.so*'
+  'libgmodule-2.0.so*'
+)
 
 # The bundle lands in the Cargo workspace target dir (repo-root `target/`), but
 # fall back to the per-crate `src-tauri/target/` in case the layout changes.
@@ -34,11 +46,15 @@ work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 ( cd "$work" && "$appimage" --appimage-extract >/dev/null )
 
-leaked="$(find "$work/squashfs-root" -name 'libwayland-client.so*')"
+leaked=""
+for glob in "${FORBIDDEN_GLOBS[@]}"; do
+  leaked+="$(find "$work/squashfs-root" -name "$glob")"$'\n'
+done
+leaked="$(printf '%s' "$leaked" | grep -v '^$' || true)"
 if [ -n "$leaked" ]; then
-  echo "assert-no-wayland: libwayland-client leaked into $(basename "$appimage"):" >&2
+  echo "assert-no-host-libs: forbidden libs leaked into $(basename "$appimage"):" >&2
   echo "$leaked" >&2
   exit 1
 fi
 
-echo "assert-no-wayland: OK, no libwayland-client bundled in $(basename "$appimage")"
+echo "assert-no-host-libs: OK, no host-coupled libs bundled in $(basename "$appimage")"

--- a/scripts/linuxdeploy-exclude-wayland.c
+++ b/scripts/linuxdeploy-exclude-wayland.c
@@ -1,6 +1,13 @@
 /*
  * linuxdeploy shim: exec the real linuxdeploy with extra --exclude-library
- * flags so the wayland client stack is never bundled into the AppImage.
+ * flags so host-coupled libraries are never bundled into the AppImage. Two
+ * stacks are excluded:
+ *   - the wayland client stack (prevents blank-screen EGL mismatch), and
+ *   - the glib/gio stack. GIO loads modules from the host (gvfs, gsettings
+ *     backends) that are built against the host's glib. AppRun puts bundled
+ *     libs first, so a runner-built (older) libglib gets paired with a newer
+ *     host gvfs module -> "undefined symbol: g_task_set_static_name". Letting
+ *     glib resolve from the host keeps it in lockstep with those modules.
  *
  * tauri-bundler invokes linuxdeploy with a hardcoded argument list and offers
  * no way to pass --exclude-library. It caches the tool at
@@ -38,6 +45,10 @@ int main(int argc, char **argv) {
       "--exclude-library=libwayland-egl.so*",
       "--exclude-library=libwayland-cursor.so*",
       "--exclude-library=libwayland-server.so*",
+      "--exclude-library=libglib-2.0.so*",
+      "--exclude-library=libgio-2.0.so*",
+      "--exclude-library=libgobject-2.0.so*",
+      "--exclude-library=libgmodule-2.0.so*",
   };
   const int n_excludes = (int)(sizeof(excludes) / sizeof(excludes[0]));
 


### PR DESCRIPTION
In the spirit of #415, I believe more libs need to be specially handled