### PR TITLE
Reduce shared contact code length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2078,6 +2078,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serde_repr",
  "sqlx",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/dashchat-node/Cargo.toml
+++ b/crates/dashchat-node/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2024"
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1"
+serde_repr = "0.1"
 
 mailbox-client = { workspace = true }
 mailbox-server = { workspace = true }

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -48,9 +48,28 @@ pub enum ShareIntent {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct InboxTopic {
     // NOTE: order of these fields matters! expires_at, then topic.
-    /// Expiry date must be within the valid range expressible by DateTime::from_timestamp_nanos
+    /// Expiry date. Serialized as a whole number of hours since the Unix epoch
+    /// to keep the QR code short; sub-hour precision is not needed for expiry.
+    #[serde(with = "expires_at_hours")]
     pub expires_at: DateTime<Utc>,
     pub topic: Topic<kind::Inbox>,
+}
+
+/// Serialize a `DateTime<Utc>` as an `i64` count of whole hours since the Unix
+/// epoch. Truncates toward the epoch; used only for coarse expiry timestamps.
+mod expires_at_hours {
+    use chrono::{DateTime, Utc};
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(dt: &DateTime<Utc>, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_i64(dt.timestamp().div_euclid(3600))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<DateTime<Utc>, D::Error> {
+        let hours = i64::deserialize(d)?;
+        DateTime::from_timestamp(hours * 3600, 0)
+            .ok_or_else(|| serde::de::Error::custom("expires_at hours out of range"))
+    }
 }
 
 impl std::fmt::Display for QrCode {
@@ -109,7 +128,9 @@ mod tests {
             device_pubkey: DeviceId::from(pubkey),
             inbox_topic: Some(InboxTopic {
                 topic: Topic::inbox(),
-                expires_at: Utc::now() + chrono::Duration::seconds(3600),
+                // Hour-aligned so it survives the coarse (hours-since-epoch)
+                // serialization used to keep the QR code short.
+                expires_at: DateTime::from_timestamp(1_700_000_000 / 3600 * 3600, 0).unwrap(),
             }),
             agent_id,
             share_intent: ShareIntent::AddDevice,

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -72,12 +72,8 @@ mod expires_at_hours {
 
 impl std::fmt::Display for QrCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let bytes = encode_cbor(&(
-            &self.device_pubkey,
-            &self.inbox_topic,
-            &self.share_intent,
-        ))
-        .map_err(|_| std::fmt::Error)?;
+        let bytes = encode_cbor(&(&self.device_pubkey, &self.inbox_topic, &self.share_intent))
+            .map_err(|_| std::fmt::Error)?;
         write!(f, "{}", hex::encode(bytes))
     }
 }

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -65,7 +65,10 @@ mod expires_at_hours {
 
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<DateTime<Utc>, D::Error> {
         let hours = i64::deserialize(d)?;
-        DateTime::from_timestamp(hours * 3600, 0)
+        let secs = hours
+            .checked_mul(3600)
+            .ok_or_else(|| serde::de::Error::custom("expires_at hours out of range"))?;
+        DateTime::from_timestamp(secs, 0)
             .ok_or_else(|| serde::de::Error::custom("expires_at hours out of range"))
     }
 }

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::str::FromStr;
 
-use crate::{AgentId, DeviceId, Topic, topic::kind};
+use crate::{DeviceId, Topic, topic::kind};
 
 /// The content for a QR code or deep link.
 ///
@@ -27,8 +27,6 @@ use crate::{AgentId, DeviceId, Topic, topic::kind};
 pub struct QrCode {
     /// Pubkey of this node: allows adding this node to groups.
     pub device_pubkey: DeviceId,
-    /// Agent ID to add to spaces
-    pub agent_id: AgentId,
     /// Topic for receiving messages from this node during the lifetime of the QR code.
     /// The initiator will specify an InboxTopic, and the recipient will send back a QR
     /// code without an associated inbox, because after this exchange the two nodes
@@ -77,7 +75,6 @@ impl std::fmt::Display for QrCode {
         let bytes = encode_cbor(&(
             &self.device_pubkey,
             &self.inbox_topic,
-            &self.agent_id,
             &self.share_intent,
         ))
         .map_err(|_| std::fmt::Error)?;
@@ -89,11 +86,10 @@ impl FromStr for QrCode {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let bytes = hex::decode(s)?;
-        let (device_pubkey, inbox_topic, agent_id, share_intent) = decode_cbor(bytes.as_slice())?;
+        let (device_pubkey, inbox_topic, share_intent) = decode_cbor(bytes.as_slice())?;
         Ok(QrCode {
             device_pubkey,
             inbox_topic,
-            agent_id,
             share_intent,
         })
     }
@@ -116,14 +112,12 @@ impl TryFrom<String> for QrCode {
 mod tests {
 
     use p2panda::VerifyingKey;
-    use p2panda_spaces::ActorId;
 
     use super::*;
 
     #[test]
     fn test_contact_roundtrip() {
         let pubkey = VerifyingKey::from_bytes(&[11; 32]).unwrap();
-        let agent_id = AgentId::from(ActorId::from_bytes(&[22; 32]).unwrap());
         let contact = QrCode {
             device_pubkey: DeviceId::from(pubkey),
             inbox_topic: Some(InboxTopic {
@@ -132,7 +126,6 @@ mod tests {
                 // serialization used to keep the QR code short.
                 expires_at: DateTime::from_timestamp(1_700_000_000 / 3600 * 3600, 0).unwrap(),
             }),
-            agent_id,
             share_intent: ShareIntent::AddDevice,
         };
         let encoded = contact.to_string();

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use p2panda_core::cbor::{decode_cbor, encode_cbor};
 use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::str::FromStr;
 
 use crate::{AgentId, DeviceId, Topic, topic::kind};
@@ -37,10 +38,11 @@ pub struct QrCode {
     pub share_intent: ShareIntent,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
 pub enum ShareIntent {
-    AddDevice,
-    AddContact,
+    AddDevice = 0,
+    AddContact = 1,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -46,30 +46,28 @@ pub enum ShareIntent {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct InboxTopic {
     // NOTE: order of these fields matters! expires_at, then topic.
-    /// Expiry date. Serialized as a whole number of hours since the Unix epoch
-    /// to keep the QR code short; sub-hour precision is not needed for expiry.
-    #[serde(with = "expires_at_hours")]
+    /// Expiry date. Serialized as a whole number of minutes since the Unix epoch.
+    #[serde(with = "expires_at_minutes")]
     pub expires_at: DateTime<Utc>,
     pub topic: Topic<kind::Inbox>,
 }
 
-/// Serialize a `DateTime<Utc>` as an `i64` count of whole hours since the Unix
-/// epoch. Truncates toward the epoch; used only for coarse expiry timestamps.
-mod expires_at_hours {
+/// Serialize a `DateTime<Utc>` as a `u64` count of whole minutes since the Unix epoch.
+mod expires_at_minutes {
     use chrono::{DateTime, Utc};
     use serde::{Deserialize, Deserializer, Serializer};
 
     pub fn serialize<S: Serializer>(dt: &DateTime<Utc>, s: S) -> Result<S::Ok, S::Error> {
-        s.serialize_i64(dt.timestamp().div_euclid(3600))
+        s.serialize_u64(dt.timestamp().div_euclid(60) as u64)
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<DateTime<Utc>, D::Error> {
-        let hours = i64::deserialize(d)?;
-        let secs = hours
-            .checked_mul(3600)
-            .ok_or_else(|| serde::de::Error::custom("expires_at hours out of range"))?;
-        DateTime::from_timestamp(secs, 0)
-            .ok_or_else(|| serde::de::Error::custom("expires_at hours out of range"))
+        let minutes = u64::deserialize(d)?;
+        let secs = minutes
+            .checked_mul(60)
+            .ok_or_else(|| serde::de::Error::custom("expires_at minutes out of range"))?;
+        DateTime::from_timestamp(secs as i64, 0)
+            .ok_or_else(|| serde::de::Error::custom("expires_at minutes out of range"))
     }
 }
 
@@ -121,9 +119,8 @@ mod tests {
             device_pubkey: DeviceId::from(pubkey),
             inbox_topic: Some(InboxTopic {
                 topic: Topic::inbox(),
-                // Hour-aligned so it survives the coarse (hours-since-epoch)
-                // serialization used to keep the QR code short.
-                expires_at: DateTime::from_timestamp(1_700_000_000 / 3600 * 3600, 0).unwrap(),
+                // Minute-aligned so it survives the (minutes-since-epoch) serialization.
+                expires_at: DateTime::from_timestamp(1_700_000_000 / 60 * 60, 0).unwrap(),
             }),
             share_intent: ShareIntent::AddDevice,
         };

--- a/crates/dashchat-node/src/error.rs
+++ b/crates/dashchat-node/src/error.rs
@@ -33,9 +33,6 @@ pub enum AddContactError {
     #[error("Failed to create direct chat: {0}")]
     CreateDirectChat(String),
 
-    #[error("Failed to store contact info: {0}")]
-    StoreContact(String),
-
     #[error(transparent)]
     #[serde(untagged)]
     Common(#[from] Error),

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -34,7 +34,7 @@ use crate::contact::{InboxTopic, QrCode, ShareIntent};
 use crate::mailbox::MailboxOperation;
 use crate::payload::{AnnouncementsPayload, ChatPayload, InboxPayload, Payload, Profile};
 use crate::stores::{GroupStore, LocalStore, NodeKeys, OpStore};
-use crate::topic::{Topic, TopicId};
+use crate::topic::{Topic, TopicId, kind};
 use crate::{
     AgentId, AsBody, ChatId, ChatReaction, DeviceGroupId, DeviceGroupPayload, DeviceId,
     DirectChatId, MediaBundle, MediaMetaKind, MediaMetadata, OutgoingFile, OutgoingMedia,
@@ -1255,6 +1255,22 @@ impl Node {
             self.initialize_topic(*inbox_topic.topic)
                 .await
                 .map_err(|e| Error::InitializeTopic(e.to_string()))?;
+            // Mint a private reply inbox for this exchange and listen on it for
+            // the owner's ack. We do NOT persist the (possibly shared) advertised
+            // inbox we scanned — only the owner keeps camping on that — so other
+            // scanners of the same QR never share a return channel with us.
+            let reply_inbox = InboxTopic {
+                topic: Topic::inbox()
+                    .alias_named(&format!("reply_inbox({:?})", self.device_id().aliased())),
+                expires_at: Utc::now() + self.config.contact_code_expiry,
+            };
+            self.initialize_topic(*reply_inbox.topic)
+                .await
+                .map_err(|e| Error::InitializeTopic(e.to_string()))?;
+            self.local_store
+                .add_reply_inbox_topic(reply_inbox.clone())
+                .await
+                .map_err(|e| Error::AddActiveInbox(format!("{e}")))?;
             let code = self
                 .new_qr_code(ShareIntent::AddContact, false)
                 .await
@@ -1268,7 +1284,11 @@ impl Node {
             };
             self.publish(
                 inbox_topic.topic,
-                Payload::Inbox(InboxPayload::ContactRequest { code, profile }),
+                Payload::Inbox(InboxPayload::ContactRequest {
+                    code,
+                    profile,
+                    reply_topic: reply_inbox.topic.clone(),
+                }),
                 Some(&format!(
                     "add_contact/contact_request({:?})",
                     agent.aliased()
@@ -1286,6 +1306,34 @@ impl Node {
         }
 
         Ok(agent)
+    }
+
+    /// Reply to an incoming contact request by sending our profile to the
+    /// scanner's private reply topic, so the scanner learns it immediately over
+    /// the inbox rather than waiting for announcements sync. We subscribe to the
+    /// reply topic just long enough to publish to it.
+    pub(crate) async fn reply_to_contact_request(
+        &self,
+        reply_topic: Topic<kind::Inbox>,
+    ) -> Result<(), Error> {
+        let Some(profile) = self
+            .my_profile()
+            .await
+            .map_err(|e| Error::AuthorOperation(e.to_string()))?
+        else {
+            return Ok(());
+        };
+        self.initialize_topic(*reply_topic)
+            .await
+            .map_err(|e| Error::InitializeTopic(e.to_string()))?;
+        self.publish(
+            reply_topic,
+            Payload::Inbox(InboxPayload::ContactRequestAck { profile }),
+            Some("reply_to_contact_request"),
+        )
+        .await
+        .map_err(|e| Error::AuthorOperation(e.to_string()))?;
+        Ok(())
     }
 
     /// Reject a contact request from the given agent.
@@ -1348,6 +1396,16 @@ impl Node {
                     .topic
                     .clone()
                     .alias_named(&format!("inbox({:?})", self.device_id().aliased())),
+            )
+            .await?;
+        }
+
+        for topic in self.local_store.get_reply_inbox_topics().await?.iter() {
+            self.initialize_topic(
+                *topic
+                    .topic
+                    .clone()
+                    .alias_named(&format!("reply_inbox({:?})", self.device_id().aliased())),
             )
             .await?;
         }

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -1274,8 +1274,11 @@ impl Node {
         // inbox we scanned — only the owner keeps camping on that — so other
         // scanners of the same QR never share a return channel with us.
         let reply_inbox = InboxTopic {
-            topic: Topic::inbox()
-                .alias_named(&format!("reply_inbox({:?})", self.device_id().aliased())),
+            topic: Topic::inbox().alias_named(&format!(
+                "reply_inbox({:?},peer={})",
+                self.device_id().aliased(),
+                &hex::encode(&contact.device_pubkey.as_bytes()[..4])
+            )),
             expires_at: Utc::now() + self.config.contact_code_expiry,
         };
         self.initialize_topic(*reply_inbox.topic)
@@ -1540,13 +1543,17 @@ impl Node {
             .await?;
         }
 
-        for topic in self.local_store.get_reply_inbox_topics().await?.iter() {
-            self.initialize_topic(
-                *topic
-                    .topic
-                    .clone()
-                    .alias_named(&format!("reply_inbox({:?})", self.device_id().aliased())),
-            )
+        for (topic, peer_device) in self
+            .local_store
+            .get_reply_inbox_topics_with_author()
+            .await?
+            .iter()
+        {
+            self.initialize_topic(*topic.topic.clone().alias_named(&format!(
+                "reply_inbox({:?},peer={})",
+                self.device_id().aliased(),
+                &hex::encode(&peer_device.as_bytes()[..4])
+            )))
             .await?;
         }
 

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -439,6 +439,18 @@ impl Node {
             .map_err(|err| Error::GetActiveInboxes(format!("{err}")))
     }
 
+    /// Resolve the agent id we've recorded for a device pubkey, if any. Returns
+    /// `None` until the contact is established (e.g. while an outgoing contact
+    /// request is still pending its ack).
+    pub async fn agent_for_device(&self, device_pubkey: DeviceId) -> Result<Option<AgentId>, Error> {
+        let map = self
+            .local_store
+            .lookup_contacts([&device_pubkey])
+            .await
+            .map_err(|e| Error::AuthorOperation(e.to_string()))?;
+        Ok(map.get(&device_pubkey).copied())
+    }
+
     /// Create a new contact QR code with configured expiry time,
     /// subscribe to the inbox topic for it, and register the topic as active.
     pub async fn new_qr_code(
@@ -1291,6 +1303,22 @@ impl Node {
             }),
             Some(&format!(
                 "add_contact/contact_request({:?})",
+                contact.device_pubkey.aliased()
+            )),
+        )
+        .await
+        .map_err(|e| Error::AuthorOperation(e.to_string()))?;
+
+        // Record a pending request in our own device group so the UI can show a
+        // placeholder chat until the owner's ack arrives. Keyed on the owner's
+        // device pubkey, since we don't know their agent id yet.
+        self.publish(
+            self.device_group_topic(),
+            Payload::DeviceGroup(DeviceGroupPayload::PendingContactRequest {
+                device_pubkey: contact.device_pubkey,
+            }),
+            Some(&format!(
+                "add_contact/pending({:?})",
                 contact.device_pubkey.aliased()
             )),
         )

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -1386,22 +1386,11 @@ impl Node {
     /// `device_pubkey` (i.e. we scanned their code and are awaiting their ack).
     pub(crate) async fn has_outgoing_pending_request(
         &self,
-        device_pubkey: DeviceId,
+        device_id: DeviceId,
     ) -> anyhow::Result<bool> {
-        let found = self
-            .op_store
-            .get_interleaved_logs(self.device_group_topic().into(), vec![self.device_id()])
-            .await?
-            .into_iter()
-            .any(|(_, payload)| {
-                matches!(
-                    payload,
-                    Some(Payload::DeviceGroup(DeviceGroupPayload::PendingContactRequest {
-                        device_pubkey: dp,
-                    })) if dp == device_pubkey
-                )
-            });
-        Ok(found)
+        self.local_store
+            .has_pending_reply_inbox_for(device_id)
+            .await
     }
 
     /// Scan our advertised inbox logs for a pending [`InboxPayload::ContactRequest`]

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -434,7 +434,7 @@ impl Node {
 
     pub async fn get_active_inbox_topics(&self) -> Result<BTreeSet<InboxTopic>, Error> {
         self.local_store
-            .get_active_inbox_topics()
+            .get_advertised_inbox_topics()
             .await
             .map_err(|err| Error::GetActiveInboxes(format!("{err}")))
     }
@@ -1423,7 +1423,7 @@ impl Node {
         &self,
         agent_id: AgentId,
     ) -> anyhow::Result<Option<Topic<kind::Inbox>>> {
-        for inbox in self.local_store.get_active_inbox_topics().await? {
+        for inbox in self.local_store.get_advertised_inbox_topics().await? {
             let log_id = LogId::from_topic(*inbox.topic);
             for author in self.op_store.get_authors(log_id).await? {
                 for op in self.op_store.get_log(&author, &log_id, None).await? {
@@ -1530,7 +1530,7 @@ impl Node {
         )
         .await?;
 
-        for topic in self.local_store.get_active_inbox_topics().await?.iter() {
+        for topic in self.local_store.get_advertised_inbox_topics().await?.iter() {
             self.initialize_topic(
                 *topic
                     .topic

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -439,21 +439,6 @@ impl Node {
             .map_err(|err| Error::GetActiveInboxes(format!("{err}")))
     }
 
-    /// Resolve the agent id we've recorded for a device pubkey, if any. Returns
-    /// `None` until the contact is established (e.g. while an outgoing contact
-    /// request is still pending its ack).
-    pub async fn agent_for_device(
-        &self,
-        device_pubkey: DeviceId,
-    ) -> Result<Option<AgentId>, Error> {
-        let map = self
-            .local_store
-            .lookup_contacts([&device_pubkey])
-            .await
-            .map_err(|e| Error::AuthorOperation(e.to_string()))?;
-        Ok(map.get(&device_pubkey).copied())
-    }
-
     /// Create a new contact QR code with configured expiry time,
     /// subscribe to the inbox topic for it, and register the topic as active.
     pub async fn new_qr_code(

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -1161,6 +1161,37 @@ impl Node {
         Ok(())
     }
 
+    /// Register the shared, idempotent state for a contact identified by their
+    /// device pubkey and agent id: record the device -> agent mapping, register
+    /// them as a bootstrap peer, and subscribe to their announcements and our
+    /// direct-chat topic. Safe to call repeatedly, so both the initiating
+    /// `add_contact` path and the inbox request/ack handlers can call it.
+    pub(crate) async fn establish_contact(
+        &self,
+        device_pubkey: DeviceId,
+        agent_id: AgentId,
+    ) -> Result<(), Error> {
+        self.local_store
+            .save_agent_mapping(device_pubkey, agent_id)
+            .await
+            .map_err(|e| Error::AuthorOperation(e.to_string()))?;
+        // Register the contact as a bootstrap so p2panda discovery can reach it
+        // directly over the internet (relay + pkarr), rather than depending on a
+        // mutually-reachable mailbox to introduce the two nodes.
+        self.register_bootstrap_node(*device_pubkey)
+            .await
+            .map_err(|e| Error::RegisterBootstrap(e.to_string()))?;
+        // Subscribe to the contact's announcements to receive their group
+        // control messages, and to our shared direct-chat topic.
+        self.register_topic(Topic::announcements(agent_id))
+            .await
+            .map_err(|e| Error::InitializeTopic(e.to_string()))?;
+        self.register_topic(self.direct_chat_topic(agent_id))
+            .await
+            .map_err(|e| Error::InitializeTopic(e.to_string()))?;
+        Ok(())
+    }
+
     /// Store someone as a contact, and:
     /// - register their spaces keybundle so we can add them to spaces
     /// - subscribe to their inbox
@@ -1175,26 +1206,8 @@ impl Node {
             "adding contact",
         );
 
-        self.local_store
-            .save_contact(contact.clone())
-            .await
-            .map_err(|e| AddContactError::StoreContact(e.to_string()))?;
-
-        // Register the scanned contact as a bootstrap so p2panda discovery can
-        // reach it directly over the internet (relay + pkarr), rather than
-        // depending on a mutually-reachable mailbox to introduce the two nodes.
-        self.register_bootstrap_node(*contact.device_pubkey)
-            .await
-            .map_err(|e| Error::RegisterBootstrap(e.to_string()))?;
-
-        // SPACES: Register the member in the spaces manager
-
-        // Must subscribe to the new member's device group in order to receive their
-        // group control messages.
-        // TODO: is this idempotent? If not we must make sure to do this only once.
-        self.register_topic(Topic::announcements(contact.agent_id))
-            .await
-            .map_err(|e| Error::InitializeTopic(e.to_string()))?;
+        self.establish_contact(contact.device_pubkey, contact.agent_id)
+            .await?;
 
         // TODO: use all of this commented out stuff when spaces are possible again
         // // XXX: there should be a better way to wait for the device group to be created,
@@ -1238,11 +1251,6 @@ impl Node {
         // tokio::time::sleep(std::time::Duration::from_millis(3000)).await;
 
         let agent = contact.agent_id;
-        let direct_topic = self.direct_chat_topic(agent);
-        self.register_topic(direct_topic)
-            .await
-            .map_err(|e| Error::InitializeTopic(e.to_string()))?;
-
         self.publish(
             self.device_group_topic(),
             Payload::DeviceGroup(DeviceGroupPayload::AddContact(contact.clone())),

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -467,7 +467,6 @@ impl Node {
         Ok(QrCode {
             device_pubkey: self.device_id(),
             inbox_topic,
-            agent_id: self.node_keys.agent_id,
             share_intent,
         })
     }
@@ -1198,16 +1197,18 @@ impl Node {
     /// - store them in the contacts map
     /// - send an invitation to them to do the same
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all, fields(me = ?self.device_id().aliased())))]
-    pub async fn add_contact(&self, contact: QrCode) -> Result<AgentId, AddContactError> {
+    pub async fn add_contact(&self, contact: QrCode) -> Result<(), AddContactError> {
         tracing::debug!(
             device_pub_key = ?contact.device_pubkey.aliased(),
-            agent_id = ?contact.agent_id.aliased(),
             inbox_topic = ?contact.inbox_topic,
             "adding contact",
         );
 
-        self.establish_contact(contact.device_pubkey, contact.agent_id)
-            .await?;
+        let Some(inbox_topic) = contact.inbox_topic.clone() else {
+            return Err(AddContactError::CreateQrCode(
+                "contact code has no inbox to send a request to".to_string(),
+            ));
+        };
 
         // TODO: use all of this commented out stuff when spaces are possible again
         // // XXX: there should be a better way to wait for the device group to be created,
@@ -1250,71 +1251,67 @@ impl Node {
         // // XXX: need sleep a little more for all the messages to be processed
         // tokio::time::sleep(std::time::Duration::from_millis(3000)).await;
 
-        let agent = contact.agent_id;
+        self.initialize_topic(*inbox_topic.topic)
+            .await
+            .map_err(|e| Error::InitializeTopic(e.to_string()))?;
+        // Mint a private reply inbox for this exchange and listen on it for
+        // the owner's ack. We do NOT persist the (possibly shared) advertised
+        // inbox we scanned — only the owner keeps camping on that — so other
+        // scanners of the same QR never share a return channel with us.
+        let reply_inbox = InboxTopic {
+            topic: Topic::inbox()
+                .alias_named(&format!("reply_inbox({:?})", self.device_id().aliased())),
+            expires_at: Utc::now() + self.config.contact_code_expiry,
+        };
+        self.initialize_topic(*reply_inbox.topic)
+            .await
+            .map_err(|e| Error::InitializeTopic(e.to_string()))?;
+        self.local_store
+            .add_reply_inbox_topic(reply_inbox.clone())
+            .await
+            .map_err(|e| Error::AddActiveInbox(format!("{e}")))?;
+        let code = self
+            .new_qr_code(ShareIntent::AddContact, false)
+            .await
+            .map_err(|e| AddContactError::CreateQrCode(e.to_string()))?;
+        let Some(profile) = self
+            .my_profile()
+            .await
+            .map_err(|e| Error::AuthorOperation(e.to_string()))?
+        else {
+            return Err(AddContactError::ProfileNotCreated);
+        };
         self.publish(
-            self.device_group_topic(),
-            Payload::DeviceGroup(DeviceGroupPayload::AddContact { agent_id: agent }),
-            Some(&format!("add_contact/add_contact({:?})", agent.aliased())),
+            inbox_topic.topic,
+            Payload::Inbox(InboxPayload::ContactRequest {
+                code,
+                profile,
+                agent_id: self.agent_id(),
+                reply_topic: reply_inbox.topic.clone(),
+            }),
+            Some(&format!(
+                "add_contact/contact_request({:?})",
+                contact.device_pubkey.aliased()
+            )),
         )
         .await
         .map_err(|e| Error::AuthorOperation(e.to_string()))?;
 
-        if let Some(inbox_topic) = contact.inbox_topic.clone() {
-            self.initialize_topic(*inbox_topic.topic)
-                .await
-                .map_err(|e| Error::InitializeTopic(e.to_string()))?;
-            // Mint a private reply inbox for this exchange and listen on it for
-            // the owner's ack. We do NOT persist the (possibly shared) advertised
-            // inbox we scanned — only the owner keeps camping on that — so other
-            // scanners of the same QR never share a return channel with us.
-            let reply_inbox = InboxTopic {
-                topic: Topic::inbox()
-                    .alias_named(&format!("reply_inbox({:?})", self.device_id().aliased())),
-                expires_at: Utc::now() + self.config.contact_code_expiry,
-            };
-            self.initialize_topic(*reply_inbox.topic)
-                .await
-                .map_err(|e| Error::InitializeTopic(e.to_string()))?;
-            self.local_store
-                .add_reply_inbox_topic(reply_inbox.clone())
-                .await
-                .map_err(|e| Error::AddActiveInbox(format!("{e}")))?;
-            let code = self
-                .new_qr_code(ShareIntent::AddContact, false)
-                .await
-                .map_err(|e| AddContactError::CreateQrCode(e.to_string()))?;
-            let Some(profile) = self
-                .my_profile()
-                .await
-                .map_err(|e| Error::AuthorOperation(e.to_string()))?
-            else {
-                return Err(AddContactError::ProfileNotCreated);
-            };
-            self.publish(
-                inbox_topic.topic,
-                Payload::Inbox(InboxPayload::ContactRequest {
-                    code,
-                    profile,
-                    agent_id: self.agent_id(),
-                    reply_topic: reply_inbox.topic.clone(),
-                }),
-                Some(&format!(
-                    "add_contact/contact_request({:?})",
-                    agent.aliased()
-                )),
-            )
-            .await
-            .map_err(|e| Error::AuthorOperation(e.to_string()))?;
-        }
+        Ok(())
+    }
 
-        // Only the initiator of contactship should create the direct chat space
-        if contact.share_intent == ShareIntent::AddContact && contact.inbox_topic.is_none() {
-            self.create_direct_chat_space(agent)
-                .await
-                .map_err(|e| AddContactError::CreateDirectChat(e.to_string()))?;
-        }
-
-        Ok(agent)
+    /// Record a mutual contact by publishing the contact marker into our own
+    /// device group. Contact establishment (mapping, topics, bootstrap) is done
+    /// separately via [`Self::establish_contact`].
+    pub(crate) async fn publish_add_contact(&self, agent_id: AgentId) -> Result<(), Error> {
+        self.publish(
+            self.device_group_topic(),
+            Payload::DeviceGroup(DeviceGroupPayload::AddContact { agent_id }),
+            Some(&format!("add_contact({:?})", agent_id.aliased())),
+        )
+        .await
+        .map_err(|e| Error::AuthorOperation(e.to_string()))?;
+        Ok(())
     }
 
     /// Accept a contact request that was received over our advertised inbox.
@@ -1324,13 +1321,7 @@ impl Node {
     /// agent_id.
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all, fields(me = ?self.device_id().aliased())))]
     pub async fn accept_contact(&self, agent_id: AgentId) -> Result<(), AddContactError> {
-        self.publish(
-            self.device_group_topic(),
-            Payload::DeviceGroup(DeviceGroupPayload::AddContact { agent_id }),
-            Some(&format!("accept_contact/add_contact({:?})", agent_id.aliased())),
-        )
-        .await
-        .map_err(|e| Error::AuthorOperation(e.to_string()))?;
+        self.publish_add_contact(agent_id).await?;
 
         self.create_direct_chat_space(agent_id)
             .await

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -1253,7 +1253,7 @@ impl Node {
         let agent = contact.agent_id;
         self.publish(
             self.device_group_topic(),
-            Payload::DeviceGroup(DeviceGroupPayload::AddContact(contact.clone())),
+            Payload::DeviceGroup(DeviceGroupPayload::AddContact { agent_id: agent }),
             Some(&format!("add_contact/add_contact({:?})", agent.aliased())),
         )
         .await

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -442,7 +442,10 @@ impl Node {
     /// Resolve the agent id we've recorded for a device pubkey, if any. Returns
     /// `None` until the contact is established (e.g. while an outgoing contact
     /// request is still pending its ack).
-    pub async fn agent_for_device(&self, device_pubkey: DeviceId) -> Result<Option<AgentId>, Error> {
+    pub async fn agent_for_device(
+        &self,
+        device_pubkey: DeviceId,
+    ) -> Result<Option<AgentId>, Error> {
         let map = self
             .local_store
             .lookup_contacts([&device_pubkey])

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -1328,7 +1328,10 @@ impl Node {
             .map_err(|e| Error::InitializeTopic(e.to_string()))?;
         self.publish(
             reply_topic,
-            Payload::Inbox(InboxPayload::ContactRequestAck { profile }),
+            Payload::Inbox(InboxPayload::ContactRequestAck {
+                profile,
+                agent_id: self.agent_id(),
+            }),
             Some("reply_to_contact_request"),
         )
         .await

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -1394,6 +1394,28 @@ impl Node {
         Ok(())
     }
 
+    /// Returns true if we have an outgoing contact request recorded for
+    /// `device_pubkey` (i.e. we scanned their code and are awaiting their ack).
+    pub(crate) async fn has_outgoing_pending_request(
+        &self,
+        device_pubkey: DeviceId,
+    ) -> anyhow::Result<bool> {
+        let found = self
+            .op_store
+            .get_interleaved_logs(self.device_group_topic().into(), vec![self.device_id()])
+            .await?
+            .into_iter()
+            .any(|(_, payload)| {
+                matches!(
+                    payload,
+                    Some(Payload::DeviceGroup(DeviceGroupPayload::PendingContactRequest {
+                        device_pubkey: dp,
+                    })) if dp == device_pubkey
+                )
+            });
+        Ok(found)
+    }
+
     /// Scan our advertised inbox logs for a pending [`InboxPayload::ContactRequest`]
     /// from `agent_id` and return its private reply topic, so [`Self::accept_contact`]
     /// can send our acceptance there. Returns `None` if no matching request is stored.

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -1287,6 +1287,7 @@ impl Node {
                 Payload::Inbox(InboxPayload::ContactRequest {
                     code,
                     profile,
+                    agent_id: self.agent_id(),
                     reply_topic: reply_inbox.topic.clone(),
                 }),
                 Some(&format!(

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -1317,6 +1317,28 @@ impl Node {
         Ok(agent)
     }
 
+    /// Accept a contact request that was received over our advertised inbox.
+    /// Contact establishment (mapping, topics, bootstrap) already happened when
+    /// the request was processed; accepting publishes the contact marker and
+    /// creates the shared direct-chat space, keyed only on the requester's
+    /// agent_id.
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all, fields(me = ?self.device_id().aliased())))]
+    pub async fn accept_contact(&self, agent_id: AgentId) -> Result<(), AddContactError> {
+        self.publish(
+            self.device_group_topic(),
+            Payload::DeviceGroup(DeviceGroupPayload::AddContact { agent_id }),
+            Some(&format!("accept_contact/add_contact({:?})", agent_id.aliased())),
+        )
+        .await
+        .map_err(|e| Error::AuthorOperation(e.to_string()))?;
+
+        self.create_direct_chat_space(agent_id)
+            .await
+            .map_err(|e| AddContactError::CreateDirectChat(e.to_string()))?;
+
+        Ok(())
+    }
+
     /// Reply to an incoming contact request by sending our profile to the
     /// scanner's private reply topic, so the scanner learns it immediately over
     /// the inbox rather than waiting for announcements sync. We subscribe to the

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -1346,12 +1346,45 @@ impl Node {
     }
 
     /// Accept a contact request that was received over our advertised inbox.
-    /// Contact establishment (mapping, topics, bootstrap) already happened when
-    /// the request was processed; accepting publishes the contact marker and
-    /// creates the shared direct-chat space, keyed only on the requester's
-    /// agent_id.
+    /// On receipt we only recorded the requester's identity + profile locally;
+    /// accepting now performs the network establishment we deliberately deferred
+    /// — registering the requester as a bootstrap node and subscribing to their
+    /// topics — replies with our profile (which also signals acceptance so the
+    /// requester can complete their side), publishes the contact marker, and
+    /// creates the shared direct-chat space.
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all, fields(me = ?self.device_id().aliased())))]
     pub async fn accept_contact(&self, agent_id: AgentId) -> Result<(), AddContactError> {
+        // The requester's device was mapped to their agent_id when the request
+        // arrived; recover it to establish their network presence.
+        let device_pubkey = self
+            .local_store
+            .lookup_contact_by_agent_id(agent_id)
+            .await
+            .map_err(|e| Error::AuthorOperation(e.to_string()))?
+            .ok_or_else(|| {
+                AddContactError::CreateDirectChat(format!(
+                    "no pending contact request found for agent {:?}",
+                    agent_id.aliased()
+                ))
+            })?;
+        self.establish_contact(device_pubkey, agent_id).await?;
+
+        // Reply to the requester with our profile over their private reply
+        // topic. This is the point at which we first disclose our profile and
+        // signals that we accepted, letting them complete the exchange.
+        if let Some(reply_topic) = self
+            .find_contact_request_reply_topic(agent_id)
+            .await
+            .map_err(|e| Error::AuthorOperation(e.to_string()))?
+        {
+            self.reply_to_contact_request(reply_topic).await?;
+        } else {
+            tracing::warn!(
+                agent_id = ?agent_id.aliased(),
+                "accepted contact but found no request to reply to"
+            );
+        }
+
         self.publish_add_contact(agent_id).await?;
 
         self.create_direct_chat_space(agent_id)
@@ -1359,6 +1392,35 @@ impl Node {
             .map_err(|e| AddContactError::CreateDirectChat(e.to_string()))?;
 
         Ok(())
+    }
+
+    /// Scan our advertised inbox logs for a pending [`InboxPayload::ContactRequest`]
+    /// from `agent_id` and return its private reply topic, so [`Self::accept_contact`]
+    /// can send our acceptance there. Returns `None` if no matching request is stored.
+    async fn find_contact_request_reply_topic(
+        &self,
+        agent_id: AgentId,
+    ) -> anyhow::Result<Option<Topic<kind::Inbox>>> {
+        for inbox in self.local_store.get_active_inbox_topics().await? {
+            let log_id = LogId::from_topic(*inbox.topic);
+            for author in self.op_store.get_authors(log_id).await? {
+                for op in self.op_store.get_log(&author, &log_id, None).await? {
+                    let Some(body) = op.body else { continue };
+                    let Ok(Payload::Inbox(InboxPayload::ContactRequest {
+                        agent_id: req_agent,
+                        reply_topic,
+                        ..
+                    })) = Payload::try_from_body(&body)
+                    else {
+                        continue;
+                    };
+                    if req_agent == agent_id {
+                        return Ok(Some(reply_topic));
+                    }
+                }
+            }
+        }
+        Ok(None)
     }
 
     /// Reply to an incoming contact request by sending our profile to the

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -1282,7 +1282,7 @@ impl Node {
             .await
             .map_err(|e| Error::InitializeTopic(e.to_string()))?;
         self.local_store
-            .add_reply_inbox_topic(reply_inbox.clone())
+            .add_reply_inbox_topic(reply_inbox.clone(), contact.device_pubkey)
             .await
             .map_err(|e| Error::AddActiveInbox(format!("{e}")))?;
         let code = self

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -444,32 +444,27 @@ impl Node {
                 }
                 match invitation {
                     InboxPayload::ContactRequest {
-                        reply_topic,
-                        agent_id,
-                        profile,
-                        ..
+                        agent_id, profile, ..
                     } => {
-                        // Only the advertised inbox owner answers, and only for a
-                        // freshly-received request (not a local replay), by
-                        // sending its profile to the scanner's private reply
-                        // topic. Spawned so we don't await publishing (which needs
-                        // this same processor) and deadlock.
+                        // A request arrived on our advertised inbox. Persist the
+                        // requester's identity + profile locally so the UI can
+                        // render the pending request, but perform no network
+                        // side-effects (bootstrap registration, topic
+                        // subscriptions) and disclose nothing about us until the
+                        // user explicitly accepts (see `accept_contact`). This
+                        // keeps an unsolicited request — e.g. anyone scanning a
+                        // shared QR — from amplifying our resources or handing our
+                        // profile to every scanner. The request is signed by the
+                        // scanner's device key (author), so we map that device to
+                        // the requester's agent_id directly rather than trusting
+                        // the embedded QR code's agent_id.
                         if owned_topic && !matches!(source, Source::LocalStore) {
-                            // The request is signed by the scanner's device key
-                            // (author), so establish the contact directly from
-                            // the request rather than relying on the embedded QR
-                            // code's agent_id.
-                            self.establish_contact(author, *agent_id).await?;
+                            self.local_store
+                                .save_agent_mapping(author, *agent_id)
+                                .await?;
                             self.local_store
                                 .save_profile(*agent_id, profile.clone())
                                 .await?;
-                            let node = self.clone();
-                            let reply_topic = *reply_topic;
-                            tokio::spawn(async move {
-                                if let Err(err) = node.reply_to_contact_request(reply_topic).await {
-                                    tracing::warn!(?err, "failed to reply to contact request");
-                                }
-                            });
                         }
                     }
                     InboxPayload::ContactRequestAck { profile, agent_id } => {

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -428,17 +428,49 @@ impl Node {
             }
 
             Payload::Inbox(invitation) => {
-                let active_topics = self.local_store.get_active_inbox_topics().await?;
-                if !active_topics
+                let topic_id = TopicId::from(topic);
+                let owned = self.local_store.get_active_inbox_topics().await?;
+                let owned_topic = owned.iter().any(|it| *it.topic == topic_id);
+                let is_reply = self
+                    .local_store
+                    .get_reply_inbox_topics()
+                    .await?
                     .iter()
-                    .any(|it| *it.topic == TopicId::from(topic))
-                {
-                    // not for me, ignore
+                    .any(|it| *it.topic == topic_id);
+                if !owned_topic && !is_reply {
+                    // not for me (e.g. another scanner's request on a shared
+                    // advertised inbox we only transiently synced): ignore.
                     return Ok(());
                 }
                 match invitation {
-                    InboxPayload::ContactRequest { .. } => {
-                        // Nothing to do.
+                    InboxPayload::ContactRequest { reply_topic, .. } => {
+                        // Only the advertised inbox owner answers, and only for a
+                        // freshly-received request (not a local replay), by
+                        // sending its profile to the scanner's private reply
+                        // topic. Spawned so we don't await publishing (which needs
+                        // this same processor) and deadlock.
+                        if owned_topic && !matches!(source, Source::LocalStore) {
+                            let node = self.clone();
+                            let reply_topic = *reply_topic;
+                            tokio::spawn(async move {
+                                if let Err(err) = node.reply_to_contact_request(reply_topic).await {
+                                    tracing::warn!(?err, "failed to reply to contact request");
+                                }
+                            });
+                        }
+                    }
+                    InboxPayload::ContactRequestAck { profile } => {
+                        // The scanner learns the owner's profile over its private
+                        // reply topic.
+                        if is_reply {
+                            if let Some(agent_id) =
+                                self.local_store.lookup_contact_by_device_id(author).await?
+                            {
+                                self.local_store
+                                    .save_profile(agent_id, profile.clone())
+                                    .await?;
+                            }
+                        }
                     }
                 }
             }

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -429,15 +429,16 @@ impl Node {
 
             Payload::Inbox(invitation) => {
                 let topic_id = TopicId::from(topic);
-                let owned = self.local_store.get_active_inbox_topics().await?;
-                let owned_topic = owned.iter().any(|it| *it.topic == topic_id);
+                let all_advertised_topics = self.local_store.get_advertised_inbox_topics().await?;
+                let is_advertised_topic =
+                    all_advertised_topics.iter().any(|it| *it.topic == topic_id);
                 let is_reply = self
                     .local_store
                     .get_reply_inbox_topics()
                     .await?
                     .iter()
                     .any(|it| *it.topic == topic_id);
-                if !owned_topic && !is_reply {
+                if !is_advertised_topic && !is_reply {
                     // not for me (e.g. another scanner's request on a shared
                     // advertised inbox we only transiently synced): ignore.
                     return Ok(());
@@ -458,7 +459,7 @@ impl Node {
                         // scanner's device key (author), so we map that device to
                         // the requester's agent_id directly rather than trusting
                         // the embedded QR code's agent_id.
-                        if owned_topic && !matches!(source, Source::LocalStore) {
+                        if is_advertised_topic && !matches!(source, Source::LocalStore) {
                             self.local_store
                                 .save_agent_mapping(author, *agent_id)
                                 .await?;

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -440,7 +440,7 @@ impl Node {
                     .any(|it| *it.topic == topic_id);
                 if !is_advertised_topic && !is_reply {
                     // not for me (e.g. another scanner's request on a shared
-                    // advertised inbox we only transiently synced): ignore.
+                    // advertised inbox we only synced as an intermediary): ignore.
                     return Ok(());
                 }
                 match invitation {

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -456,12 +456,10 @@ impl Node {
                         // this same processor) and deadlock.
                         if owned_topic && !matches!(source, Source::LocalStore) {
                             // The request is signed by the scanner's device key
-                            // (author), so record the device_pubkey -> agent_id
-                            // mapping directly rather than relying on one taken
-                            // from the embedded QR code.
-                            self.local_store
-                                .save_agent_mapping(author, *agent_id)
-                                .await?;
+                            // (author), so establish the contact directly from
+                            // the request rather than relying on the embedded QR
+                            // code's agent_id.
+                            self.establish_contact(author, *agent_id).await?;
                             self.local_store
                                 .save_profile(*agent_id, profile.clone())
                                 .await?;
@@ -477,13 +475,10 @@ impl Node {
                     InboxPayload::ContactRequestAck { profile, agent_id } => {
                         // The scanner learns the owner's agent_id and profile
                         // over its private reply topic. The op is signed by the
-                        // owner's device key (author), so record the
-                        // device_pubkey -> agent_id mapping directly rather than
-                        // relying on one previously taken from the QR code.
-                        if is_reply {
-                            self.local_store
-                                .save_agent_mapping(author, *agent_id)
-                                .await?;
+                        // owner's device key (author), so establish the contact
+                        // directly rather than relying on the QR code's agent_id.
+                        if is_reply && !matches!(source, Source::LocalStore) {
+                            self.establish_contact(author, *agent_id).await?;
                             self.local_store
                                 .save_profile(*agent_id, profile.clone())
                                 .await?;

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -465,6 +465,25 @@ impl Node {
                             self.local_store
                                 .save_profile(*agent_id, profile.clone())
                                 .await?;
+
+                            // Mutual add: if we also sent this peer a contact
+                            // request, their incoming request is an implicit
+                            // acceptance — complete the exchange automatically
+                            // rather than waiting for a manual tap. Spawned so we
+                            // don't await publishing (which needs this same
+                            // processor) and deadlock.
+                            if self.has_outgoing_pending_request(author).await? {
+                                let node = self.clone();
+                                let agent_id = *agent_id;
+                                tokio::spawn(async move {
+                                    if let Err(err) = node.accept_contact(agent_id).await {
+                                        tracing::warn!(
+                                            ?err,
+                                            "failed to auto-accept mutual contact request"
+                                        );
+                                    }
+                                });
+                            }
                         }
                     }
                     InboxPayload::ContactRequestAck { profile, agent_id } => {

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -488,13 +488,26 @@ impl Node {
                         }
                     }
                     InboxPayload::ContactRequestAck { profile, agent_id } => {
-                        // The scanner learns the owner's agent_id and profile
-                        // over its private reply topic. The op is signed by the
-                        // owner's device key (author), so establish the contact
-                        // directly rather than relying on the QR code's agent_id.
-                        // The scanner initiated contact, so record it immediately
-                        // (spawned, since publishing needs this same processor).
+                        // The op must arrive on our private reply topic and be
+                        // signed by the device whose QR we scanned. Verifying
+                        // Verifying author == expected_ack_author prevents a
+                        // third party that transiently synced the advertised
+                        // inbox (and thus learned the reply topic embedded in
+                        // our ContactRequest) from injecting a spoofed ack with
+                        // an attacker-chosen agent_id/profile.
                         if is_reply && !matches!(source, Source::LocalStore) {
+                            let expected = self
+                                .local_store
+                                .get_reply_inbox_expected_ack_author(topic_id)
+                                .await?;
+                            if expected.as_ref() != Some(&author) {
+                                tracing::warn!(
+                                    ?author,
+                                    ?expected,
+                                    "ContactRequestAck author does not match expected; ignoring"
+                                );
+                                return Ok(());
+                            }
                             self.establish_contact(author, *agent_id).await?;
                             self.local_store
                                 .save_profile(*agent_id, profile.clone())

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -491,9 +491,7 @@ impl Node {
                         // The op must arrive on our private reply topic and be
                         // signed by the device whose QR we scanned. Verifying
                         // Verifying author == expected_ack_author prevents a
-                        // third party that transiently synced the advertised
-                        // inbox (and thus learned the reply topic embedded in
-                        // our ContactRequest) from injecting a spoofed ack with
+                        // third party from injecting a spoofed ack with
                         // an attacker-chosen agent_id/profile.
                         if is_reply && !matches!(source, Source::LocalStore) {
                             let expected = self

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -477,11 +477,20 @@ impl Node {
                         // over its private reply topic. The op is signed by the
                         // owner's device key (author), so establish the contact
                         // directly rather than relying on the QR code's agent_id.
+                        // The scanner initiated contact, so record it immediately
+                        // (spawned, since publishing needs this same processor).
                         if is_reply && !matches!(source, Source::LocalStore) {
                             self.establish_contact(author, *agent_id).await?;
                             self.local_store
                                 .save_profile(*agent_id, profile.clone())
                                 .await?;
+                            let node = self.clone();
+                            let agent_id = *agent_id;
+                            tokio::spawn(async move {
+                                if let Err(err) = node.publish_add_contact(agent_id).await {
+                                    tracing::warn!(?err, "failed to record accepted contact");
+                                }
+                            });
                         }
                     }
                 }

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -443,13 +443,28 @@ impl Node {
                     return Ok(());
                 }
                 match invitation {
-                    InboxPayload::ContactRequest { reply_topic, .. } => {
+                    InboxPayload::ContactRequest {
+                        reply_topic,
+                        agent_id,
+                        profile,
+                        ..
+                    } => {
                         // Only the advertised inbox owner answers, and only for a
                         // freshly-received request (not a local replay), by
                         // sending its profile to the scanner's private reply
                         // topic. Spawned so we don't await publishing (which needs
                         // this same processor) and deadlock.
                         if owned_topic && !matches!(source, Source::LocalStore) {
+                            // The request is signed by the scanner's device key
+                            // (author), so record the device_pubkey -> agent_id
+                            // mapping directly rather than relying on one taken
+                            // from the embedded QR code.
+                            self.local_store
+                                .save_agent_mapping(author, *agent_id)
+                                .await?;
+                            self.local_store
+                                .save_profile(*agent_id, profile.clone())
+                                .await?;
                             let node = self.clone();
                             let reply_topic = *reply_topic;
                             tokio::spawn(async move {

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -459,17 +459,19 @@ impl Node {
                             });
                         }
                     }
-                    InboxPayload::ContactRequestAck { profile } => {
-                        // The scanner learns the owner's profile over its private
-                        // reply topic.
+                    InboxPayload::ContactRequestAck { profile, agent_id } => {
+                        // The scanner learns the owner's agent_id and profile
+                        // over its private reply topic. The op is signed by the
+                        // owner's device key (author), so record the
+                        // device_pubkey -> agent_id mapping directly rather than
+                        // relying on one previously taken from the QR code.
                         if is_reply {
-                            if let Some(agent_id) =
-                                self.local_store.lookup_contact_by_device_id(author).await?
-                            {
-                                self.local_store
-                                    .save_profile(agent_id, profile.clone())
-                                    .await?;
-                            }
+                            self.local_store
+                                .save_agent_mapping(author, *agent_id)
+                                .await?;
+                            self.local_store
+                                .save_profile(*agent_id, profile.clone())
+                                .await?;
                         }
                     }
                 }

--- a/crates/dashchat-node/src/payload.rs
+++ b/crates/dashchat-node/src/payload.rs
@@ -47,9 +47,12 @@ pub enum InboxPayload {
     /// private inbox the sender created for this exchange; the recipient sends
     /// its `ContactRequestAck` there rather than on the (possibly shared)
     /// advertised inbox, so other scanners of the same QR code never see it.
+    /// `agent_id` is the sender's agent id; the recipient records it against the
+    /// op author (device_pubkey)
     ContactRequest {
         code: QrCode,
         profile: Profile,
+        agent_id: AgentId,
         reply_topic: Topic<kind::Inbox>,
     },
     /// Sent by the inbox owner back to the scanner over the scanner's private

--- a/crates/dashchat-node/src/payload.rs
+++ b/crates/dashchat-node/src/payload.rs
@@ -129,7 +129,7 @@ pub struct ReadMessagesPayload {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload")]
 pub enum DeviceGroupPayload {
-    AddContact(QrCode),
+    AddContact { agent_id: AgentId },
     RejectContactRequest(AgentId),
     ReadMessages(ReadMessagesPayload),
 }

--- a/crates/dashchat-node/src/payload.rs
+++ b/crates/dashchat-node/src/payload.rs
@@ -10,6 +10,7 @@ use std::collections::BTreeMap;
 use crate::chat::ChatId;
 use crate::compat::Capabilities;
 use crate::contact::QrCode;
+use crate::topic::{Topic, kind};
 use crate::{AgentId, AsBody, Cbor, ChatMessageContent, ChatReaction, DeviceId};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -42,8 +43,19 @@ pub enum AnnouncementsPayload {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload")]
 pub enum InboxPayload {
-    /// Invites the recipient to add the sender as a contact.
-    ContactRequest { code: QrCode, profile: Profile },
+    /// Invites the recipient to add the sender as a contact. `reply_topic` is a
+    /// private inbox the sender created for this exchange; the recipient sends
+    /// its `ContactRequestAck` there rather than on the (possibly shared)
+    /// advertised inbox, so other scanners of the same QR code never see it.
+    ContactRequest {
+        code: QrCode,
+        profile: Profile,
+        reply_topic: Topic<kind::Inbox>,
+    },
+    /// Sent by the inbox owner back to the scanner over the scanner's private
+    /// reply topic, carrying the owner's profile so the scanner learns it
+    /// immediately rather than waiting for announcements sync.
+    ContactRequestAck { profile: Profile },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/dashchat-node/src/payload.rs
+++ b/crates/dashchat-node/src/payload.rs
@@ -54,8 +54,10 @@ pub enum InboxPayload {
     },
     /// Sent by the inbox owner back to the scanner over the scanner's private
     /// reply topic, carrying the owner's profile so the scanner learns it
-    /// immediately rather than waiting for announcements sync.
-    ContactRequestAck { profile: Profile },
+    /// immediately rather than waiting for announcements sync. `agent_id` is the
+    /// owner's agent id; the scanner records it against the op author
+    /// (device_pubkey), a step toward dropping `agent_id` from the QR code.
+    ContactRequestAck { profile: Profile, agent_id: AgentId },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/dashchat-node/src/payload.rs
+++ b/crates/dashchat-node/src/payload.rs
@@ -129,7 +129,18 @@ pub struct ReadMessagesPayload {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload")]
 pub enum DeviceGroupPayload {
-    AddContact { agent_id: AgentId },
+    AddContact {
+        agent_id: AgentId,
+    },
+    /// Recorded by the scanner the moment it sends a contact request, before it
+    /// knows the owner's agent id (the QR code no longer carries it). Keyed on
+    /// the owner's device pubkey — the only identity the scanner has at that
+    /// point — so the UI can show a "waiting for profile" placeholder chat.
+    /// Superseded by the `AddContact` marker once the owner's ack arrives and
+    /// the device -> agent mapping is known.
+    PendingContactRequest {
+        device_pubkey: DeviceId,
+    },
     RejectContactRequest(AgentId),
     ReadMessages(ReadMessagesPayload),
 }

--- a/crates/dashchat-node/src/stores/local_store.rs
+++ b/crates/dashchat-node/src/stores/local_store.rs
@@ -326,7 +326,7 @@ impl LocalStore {
     }
 
     /// Inbox topics this node created and advertises via its QR code.
-    pub async fn get_active_inbox_topics(&self) -> anyhow::Result<BTreeSet<InboxTopic>> {
+    pub async fn get_advertised_inbox_topics(&self) -> anyhow::Result<BTreeSet<InboxTopic>> {
         self.get_inbox_topics(InboxRole::Advertised).await
     }
 
@@ -700,13 +700,13 @@ mod tests {
             store.add_active_inbox_topic(t.clone()).await.unwrap();
         }
 
-        let loaded_topics = store.get_active_inbox_topics().await.unwrap();
+        let loaded_topics = store.get_advertised_inbox_topics().await.unwrap();
         assert_eq!(loaded_topics, topics);
 
         store.prune_expired_active_inbox_topics(now).await.unwrap();
         topics.pop_first().unwrap();
 
-        let loaded_topics = store.get_active_inbox_topics().await.unwrap();
+        let loaded_topics = store.get_advertised_inbox_topics().await.unwrap();
         assert_eq!(loaded_topics, topics);
 
         store
@@ -715,7 +715,7 @@ mod tests {
             .unwrap();
         topics.pop_first().unwrap();
 
-        let loaded_topics = store.get_active_inbox_topics().await.unwrap();
+        let loaded_topics = store.get_advertised_inbox_topics().await.unwrap();
         assert_eq!(loaded_topics, topics);
     }
 }

--- a/crates/dashchat-node/src/stores/local_store.rs
+++ b/crates/dashchat-node/src/stores/local_store.rs
@@ -404,6 +404,17 @@ impl LocalStore {
         Ok(())
     }
 
+    pub async fn has_pending_reply_inbox_for(&self, device_id: DeviceId) -> anyhow::Result<bool> {
+        let row: Option<(i64,)> = sqlx::query_as(
+            "SELECT 1 FROM active_inboxes WHERE expected_ack_author = ? AND role = ?",
+        )
+        .bind(device_id)
+        .bind(InboxRole::Reply)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.is_some())
+    }
+
     pub async fn get_reply_inbox_expected_ack_author(
         &self,
         topic: TopicId,

--- a/crates/dashchat-node/src/stores/local_store.rs
+++ b/crates/dashchat-node/src/stores/local_store.rs
@@ -339,6 +339,29 @@ impl LocalStore {
         self.get_inbox_topics(InboxRole::Reply).await
     }
 
+    pub async fn get_reply_inbox_topics_with_author(
+        &self,
+    ) -> anyhow::Result<Vec<(InboxTopic, DeviceId)>> {
+        let rows: Vec<(Topic, i64, DeviceId)> = sqlx::query_as(
+            "SELECT topic_id, expires_at_nanos, expected_ack_author FROM active_inboxes WHERE role = ?",
+        )
+        .bind(InboxRole::Reply)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|(topic, nanos, author)| {
+                (
+                    InboxTopic {
+                        expires_at: DateTime::from_timestamp_nanos(nanos),
+                        topic: topic.upcast::<kind::Inbox>(),
+                    },
+                    author,
+                )
+            })
+            .collect())
+    }
+
     async fn get_inbox_topics(&self, role: InboxRole) -> anyhow::Result<BTreeSet<InboxTopic>> {
         let rows: Vec<(Topic, i64)> =
             sqlx::query_as("SELECT topic_id, expires_at_nanos FROM active_inboxes WHERE role = ?")

--- a/crates/dashchat-node/src/stores/local_store.rs
+++ b/crates/dashchat-node/src/stores/local_store.rs
@@ -52,7 +52,8 @@ const MIGRATIONS: &[&str] = &[
     "CREATE TABLE IF NOT EXISTS active_inboxes (
         topic_id BLOB NOT NULL PRIMARY KEY,
         expires_at_nanos INTEGER NOT NULL,
-        role INTEGER NOT NULL DEFAULT 0
+        role INTEGER NOT NULL DEFAULT 0,
+        expected_ack_author BLOB NULL
     )",
     "CREATE TABLE IF NOT EXISTS group_chats (
         chat_id BLOB NOT NULL PRIMARY KEY
@@ -358,8 +359,40 @@ impl LocalStore {
             .await
     }
 
-    pub async fn add_reply_inbox_topic(&self, inbox_topic: InboxTopic) -> anyhow::Result<()> {
-        self.add_inbox_topic(inbox_topic, InboxRole::Reply).await
+    pub async fn add_reply_inbox_topic(
+        &self,
+        inbox_topic: InboxTopic,
+        expected_ack_author: DeviceId,
+    ) -> anyhow::Result<()> {
+        let nanos = inbox_topic
+            .expires_at
+            .timestamp_nanos_opt()
+            .unwrap_or(0)
+            .max(0);
+        sqlx::query(
+            "INSERT OR REPLACE INTO active_inboxes (topic_id, expires_at_nanos, role, expected_ack_author) VALUES (?, ?, ?, ?)",
+        )
+        .bind(inbox_topic.topic.to_vec())
+        .bind(nanos)
+        .bind(InboxRole::Reply)
+        .bind(expected_ack_author)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn get_reply_inbox_expected_ack_author(
+        &self,
+        topic: TopicId,
+    ) -> anyhow::Result<Option<DeviceId>> {
+        let row: Option<(DeviceId,)> = sqlx::query_as(
+            "SELECT expected_ack_author FROM active_inboxes WHERE topic_id = ? AND role = ?",
+        )
+        .bind(topic.as_bytes().to_vec())
+        .bind(InboxRole::Reply)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|(id,)| id))
     }
 
     async fn add_inbox_topic(

--- a/crates/dashchat-node/src/stores/local_store.rs
+++ b/crates/dashchat-node/src/stores/local_store.rs
@@ -214,11 +214,6 @@ impl LocalStore {
         Ok(q.fetch_all(&self.pool).await?.into_iter().collect())
     }
 
-    pub async fn save_contact(&self, contact: QrCode) -> anyhow::Result<()> {
-        self.save_agent_mapping(contact.device_pubkey, contact.agent_id)
-            .await
-    }
-
     pub async fn save_agent_mapping(
         &self,
         device_id: DeviceId,

--- a/crates/dashchat-node/src/stores/local_store.rs
+++ b/crates/dashchat-node/src/stores/local_store.rs
@@ -21,6 +21,17 @@ use crate::{
 const PRIVATE_KEY_KEY: &str = "private_key";
 const AGENT_ID_KEY: &str = "agent_id";
 
+/// Distinguishes the two roles an inbox topic can play for this node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::Type)]
+#[repr(i64)]
+enum InboxRole {
+    /// An inbox we advertise in our QR code and receive contact requests on.
+    Advertised = 0,
+    /// A private inbox we minted while scanning someone's QR, used only to
+    /// receive their `ContactRequestAck`.
+    Reply = 1,
+}
+
 const MIGRATIONS: &[&str] = &[
     "CREATE TABLE IF NOT EXISTS identity (
         key TEXT PRIMARY KEY,
@@ -40,7 +51,8 @@ const MIGRATIONS: &[&str] = &[
     )",
     "CREATE TABLE IF NOT EXISTS active_inboxes (
         topic_id BLOB NOT NULL PRIMARY KEY,
-        expires_at_nanos INTEGER NOT NULL
+        expires_at_nanos INTEGER NOT NULL,
+        role INTEGER NOT NULL DEFAULT 0
     )",
     "CREATE TABLE IF NOT EXISTS group_chats (
         chat_id BLOB NOT NULL PRIMARY KEY
@@ -318,9 +330,23 @@ impl LocalStore {
         Ok(AgentId::from(crate::ActorId::from_bytes(&arr)?))
     }
 
+    /// Inbox topics this node created and advertises via its QR code.
     pub async fn get_active_inbox_topics(&self) -> anyhow::Result<BTreeSet<InboxTopic>> {
+        self.get_inbox_topics(InboxRole::Advertised).await
+    }
+
+    /// Reply inbox topics this node created for a specific contact exchange and
+    /// is awaiting a `ContactRequestAck` on. Kept separate from advertised
+    /// inboxes so the frontend's contact-request scan only looks at inboxes
+    /// meant to receive requests, not our own private reply channels.
+    pub async fn get_reply_inbox_topics(&self) -> anyhow::Result<BTreeSet<InboxTopic>> {
+        self.get_inbox_topics(InboxRole::Reply).await
+    }
+
+    async fn get_inbox_topics(&self, role: InboxRole) -> anyhow::Result<BTreeSet<InboxTopic>> {
         let rows: Vec<(Topic, i64)> =
-            sqlx::query_as("SELECT topic_id, expires_at_nanos FROM active_inboxes")
+            sqlx::query_as("SELECT topic_id, expires_at_nanos FROM active_inboxes WHERE role = ?")
+                .bind(role)
                 .fetch_all(&self.pool)
                 .await?;
         Ok(rows
@@ -333,16 +359,30 @@ impl LocalStore {
     }
 
     pub async fn add_active_inbox_topic(&self, inbox_topic: InboxTopic) -> anyhow::Result<()> {
+        self.add_inbox_topic(inbox_topic, InboxRole::Advertised)
+            .await
+    }
+
+    pub async fn add_reply_inbox_topic(&self, inbox_topic: InboxTopic) -> anyhow::Result<()> {
+        self.add_inbox_topic(inbox_topic, InboxRole::Reply).await
+    }
+
+    async fn add_inbox_topic(
+        &self,
+        inbox_topic: InboxTopic,
+        role: InboxRole,
+    ) -> anyhow::Result<()> {
         let nanos = inbox_topic
             .expires_at
             .timestamp_nanos_opt()
             .unwrap_or(0)
             .max(0);
         sqlx::query(
-            "INSERT OR REPLACE INTO active_inboxes (topic_id, expires_at_nanos) VALUES (?, ?)",
+            "INSERT OR REPLACE INTO active_inboxes (topic_id, expires_at_nanos, role) VALUES (?, ?, ?)",
         )
         .bind(inbox_topic.topic.to_vec())
         .bind(nanos)
+        .bind(role)
         .execute(&self.pool)
         .await?;
         Ok(())

--- a/crates/dashchat-node/src/testing/behavior.rs
+++ b/crates/dashchat-node/src/testing/behavior.rs
@@ -35,26 +35,26 @@ impl Behavior {
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all, fields(me = ?self.node.device_id().aliased())))]
-    pub async fn accept_next_contact(&self) -> anyhow::Result<QrCode> {
+    pub async fn accept_next_contact(&self) -> anyhow::Result<AgentId> {
         let mut watcher = self.watcher.lock().await;
-        let qr = watcher
+        let agent_id = watcher
             .watch_mapped(Duration::from_secs(30), |n: &Notification| {
                 tracing::debug!(
                     hash = ?n.header.hash(),
                     "checking for contact invitation"
                 );
-                let Some(Payload::Inbox(InboxPayload::ContactRequest { code, .. })) = &n.payload
+                let Some(Payload::Inbox(InboxPayload::ContactRequest { agent_id, .. })) = &n.payload
                 else {
                     return None;
                 };
-                Some(code.clone())
+                Some(*agent_id)
             })
             .await
             .context("no contact invitation found")?;
 
-        self.node.add_contact(qr.clone()).await?;
+        self.node.accept_contact(agent_id).await?;
 
-        Ok(qr)
+        Ok(agent_id)
     }
 
     // NOTE: we technically want to wait for the *last* capabilities announcement.

--- a/crates/dashchat-node/src/testing/behavior.rs
+++ b/crates/dashchat-node/src/testing/behavior.rs
@@ -35,13 +35,17 @@ impl Behavior {
         // ack (it learns our agent_id only then), so wait for it to land before
         // returning a fully-established mutual contact.
         let me = self.node.agent_id();
-        let deadline = std::time::Instant::now() + Duration::from_secs(15);
-        while !other.get_contacts().await?.contains(&me) {
-            if std::time::Instant::now() >= deadline {
-                anyhow::bail!("scanner did not record the contact in time");
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
+        PollConfig::seconds(15)
+            .wait_for(|| async {
+                if other.get_contacts().await?.contains(&me) {
+                    Ok(())
+                } else {
+                    Err(anyhow::anyhow!(
+                        "scanner did not record the contact in time"
+                    ))
+                }
+            })
+            .await?;
         Ok(())
     }
 

--- a/crates/dashchat-node/src/testing/behavior.rs
+++ b/crates/dashchat-node/src/testing/behavior.rs
@@ -54,7 +54,8 @@ impl Behavior {
                     hash = ?n.header.hash(),
                     "checking for contact invitation"
                 );
-                let Some(Payload::Inbox(InboxPayload::ContactRequest { agent_id, .. })) = &n.payload
+                let Some(Payload::Inbox(InboxPayload::ContactRequest { agent_id, .. })) =
+                    &n.payload
                 else {
                     return None;
                 };

--- a/crates/dashchat-node/src/testing/behavior.rs
+++ b/crates/dashchat-node/src/testing/behavior.rs
@@ -31,6 +31,17 @@ impl Behavior {
         other.add_contact(qr).await?;
         self.accept_next_contact().await?;
         self.await_first_capabilities(other.device_id()).await?;
+        // The scanner records the contact asynchronously when it receives our
+        // ack (it learns our agent_id only then), so wait for it to land before
+        // returning a fully-established mutual contact.
+        let me = self.node.agent_id();
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        while !other.get_contacts().await?.contains(&me) {
+            if std::time::Instant::now() >= deadline {
+                anyhow::bail!("scanner did not record the contact in time");
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
         Ok(())
     }
 

--- a/crates/dashchat-node/src/testing/test_node.rs
+++ b/crates/dashchat-node/src/testing/test_node.rs
@@ -136,7 +136,9 @@ impl TestNode {
             .await?
             .into_iter()
             .filter_map(|(_, payload)| match payload {
-                Some(Payload::DeviceGroup(DeviceGroupPayload::AddContact(qr))) => Some(qr.agent_id),
+                Some(Payload::DeviceGroup(DeviceGroupPayload::AddContact { agent_id })) => {
+                    Some(agent_id)
+                }
                 _ => None,
             })
             .collect();

--- a/crates/dashchat-node/tests/contacts.rs
+++ b/crates/dashchat-node/tests/contacts.rs
@@ -164,14 +164,14 @@ async fn test_reject_multiple_contact_requests() {
 async fn test_inbox_two_way_flow() {
     dashchat_node::testing::setup_tracing(&TRACING_FILTER, true);
 
-    let mailbox = MemMailbox::new();
+    let mailbox = TestMailbox::from_env();
     let alice = TestNode::new(NodeConfig::testing(), "alice")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
     let bobbi = TestNode::new(NodeConfig::testing(), "bobbi")
         .await
-        .add_mailbox_client(mailbox.client())
+        .add_mailbox(&mailbox)
         .await;
 
     #[cfg(feature = "p2p")]

--- a/crates/dashchat-node/tests/contacts.rs
+++ b/crates/dashchat-node/tests/contacts.rs
@@ -154,3 +154,50 @@ async fn test_reject_multiple_contact_requests() {
     assert!(rejected.contains(&received_agents[0]));
     assert!(!rejected.contains(&received_agents[1]));
 }
+
+/// Two-way inbox flow: when the scanner sends a contact request, the inbox
+/// owner replies over the same inbox with a `ContactRequestAck` carrying its
+/// profile, and the scanner receives it on the inbox it scanned.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_inbox_two_way_flow() {
+    dashchat_node::testing::setup_tracing(&TRACING_FILTER, true);
+
+    let mailbox = MemMailbox::new();
+    let alice = TestNode::new(NodeConfig::testing(), "alice")
+        .await
+        .add_mailbox_client(mailbox.client())
+        .await;
+    let bobbi = TestNode::new(NodeConfig::testing(), "bobbi")
+        .await
+        .add_mailbox_client(mailbox.client())
+        .await;
+
+    #[cfg(feature = "p2p")]
+    introduce_and_wait([&alice, &bobbi]).await;
+
+    // Alice generates a QR code with an inbox and Bobbi scans it, sending his
+    // contact request to Alice's inbox.
+    let qr = alice
+        .new_qr_code(ShareIntent::AddContact, true)
+        .await
+        .unwrap();
+    bobbi.add_contact(qr).await.unwrap();
+
+    // Bobbi should receive Alice's reply over the same inbox, carrying her
+    // profile — proving the inbox channel is bidirectional.
+    let acked_profile = bobbi
+        .watcher
+        .lock()
+        .await
+        .watch_mapped(Duration::from_secs(30), |n: &Notification| {
+            let Some(Payload::Inbox(InboxPayload::ContactRequestAck { profile })) = &n.payload
+            else {
+                return None;
+            };
+            Some(profile.clone())
+        })
+        .await
+        .expect("Bobbi should receive Alice's contact request ack");
+
+    assert_eq!(acked_profile.name, "alice");
+}

--- a/crates/dashchat-node/tests/contacts.rs
+++ b/crates/dashchat-node/tests/contacts.rs
@@ -185,6 +185,25 @@ async fn test_inbox_two_way_flow() {
         .unwrap();
     bobbi.add_contact(qr).await.unwrap();
 
+    // Alice waits for Bobbi's contact request and explicitly accepts it. Since
+    // an owner no longer discloses its profile until it accepts, the ack (and
+    // thus the reply over the same inbox) is only sent on acceptance.
+    let requester = alice
+        .watcher
+        .lock()
+        .await
+        .watch_mapped(Duration::from_secs(30), |n: &Notification| {
+            let Some(Payload::Inbox(InboxPayload::ContactRequest { agent_id, .. })) = &n.payload
+            else {
+                return None;
+            };
+            Some(*agent_id)
+        })
+        .await
+        .expect("Alice should receive Bobbi's contact request");
+    assert_eq!(requester, bobbi.agent_id());
+    alice.accept_contact(requester).await.unwrap();
+
     // Bobbi should receive Alice's reply over the same inbox, carrying her
     // profile — proving the inbox channel is bidirectional.
     let acked_profile = bobbi

--- a/crates/dashchat-node/tests/contacts.rs
+++ b/crates/dashchat-node/tests/contacts.rs
@@ -122,7 +122,8 @@ async fn test_reject_multiple_contact_requests() {
             .lock()
             .await
             .watch_mapped(Duration::from_secs(30), |n: &Notification| {
-                let Some(Payload::Inbox(InboxPayload::ContactRequest { agent_id, .. })) = &n.payload
+                let Some(Payload::Inbox(InboxPayload::ContactRequest { agent_id, .. })) =
+                    &n.payload
                 else {
                     return None;
                 };

--- a/crates/dashchat-node/tests/contacts.rs
+++ b/crates/dashchat-node/tests/contacts.rs
@@ -190,7 +190,7 @@ async fn test_inbox_two_way_flow() {
         .lock()
         .await
         .watch_mapped(Duration::from_secs(30), |n: &Notification| {
-            let Some(Payload::Inbox(InboxPayload::ContactRequestAck { profile })) = &n.payload
+            let Some(Payload::Inbox(InboxPayload::ContactRequestAck { profile, .. })) = &n.payload
             else {
                 return None;
             };

--- a/crates/dashchat-node/tests/contacts.rs
+++ b/crates/dashchat-node/tests/contacts.rs
@@ -39,21 +39,22 @@ async fn test_reject_contact_request() {
     bobbi.add_contact(qr).await.unwrap();
 
     // Wait for Alice to receive the contact request
-    let received_qr = alice
+    let received_agent_id = alice
         .watcher
         .lock()
         .await
         .watch_mapped(Duration::from_secs(30), |n: &Notification| {
-            let Some(Payload::Inbox(InboxPayload::ContactRequest { code, .. })) = &n.payload else {
+            let Some(Payload::Inbox(InboxPayload::ContactRequest { agent_id, .. })) = &n.payload
+            else {
                 return None;
             };
-            Some(code.clone())
+            Some(*agent_id)
         })
         .await
         .expect("Alice should receive Bobbi's contact request");
 
     // Verify the contact request came from Bobbi
-    assert_eq!(received_qr.agent_id, bobbi.agent_id());
+    assert_eq!(received_agent_id, bobbi.agent_id());
 
     // Alice rejects the contact request instead of accepting it
     alice
@@ -121,11 +122,11 @@ async fn test_reject_multiple_contact_requests() {
             .lock()
             .await
             .watch_mapped(Duration::from_secs(30), |n: &Notification| {
-                let Some(Payload::Inbox(InboxPayload::ContactRequest { code, .. })) = &n.payload
+                let Some(Payload::Inbox(InboxPayload::ContactRequest { agent_id, .. })) = &n.payload
                 else {
                     return None;
                 };
-                Some(code.agent_id)
+                Some(*agent_id)
             })
             .await
             .expect("Alice should receive contact request");

--- a/e2e-tests/helpers/components/composer.ts
+++ b/e2e-tests/helpers/components/composer.ts
@@ -84,6 +84,7 @@ export class Composer extends TestHelper {
 		contents = 'hello from e2e',
 		mimeType = 'text/plain',
 	): Promise<void> {
+		await this.messageInput.waitForExist();
 		await this.agent.execute(
 			(n: string, c: string, m: string) => {
 				const bytes = Array.from(new TextEncoder().encode(c));
@@ -98,6 +99,7 @@ export class Composer extends TestHelper {
 
 	/** Attach a zero-filled file of exactly `sizeBytes` to test the size cap. */
 	async attachFileOfSize(sizeBytes: number, name = 'big.bin'): Promise<void> {
+		await this.messageInput.waitForExist();
 		await this.agent.execute(
 			(size: number, n: string) => {
 				window.__test.pasteFiles([
@@ -112,6 +114,7 @@ export class Composer extends TestHelper {
 
 	/** Paste a single synthesized PNG named `${label}.png` into the composer. */
 	async pastePhotos(label: string): Promise<void> {
+		await this.messageInput.waitForExist();
 		await this.agent.execute(
 			(pngBytes: number[], name: string) => {
 				window.__test.pasteFiles([
@@ -126,6 +129,7 @@ export class Composer extends TestHelper {
 
 	/** Drop a single synthesized PNG named `${label}.png` onto the window. */
 	async dropPhotos(label: string): Promise<void> {
+		await this.messageInput.waitForExist();
 		await this.agent.execute(
 			(pngBytes: number[], name: string) => {
 				window.__test.dropFiles([

--- a/e2e-tests/helpers/pages/direct-chats/direct-chat-page.ts
+++ b/e2e-tests/helpers/pages/direct-chats/direct-chat-page.ts
@@ -3,6 +3,7 @@ import { ConnectionStatusIndicator } from '../../components/connection-status-in
 import { Messages } from '../../components/messages';
 import { ReverseScrollPage } from '../../components/reverse-scroll-page';
 import { tid } from '../../selectors';
+import { SYNC_TIMEOUT } from '../../timeouts';
 import { TestHelper } from '../test-helper';
 
 export type MessageStatus = 'sending' | 'local' | 'cloud';
@@ -37,6 +38,9 @@ export class DirectChatPage extends TestHelper {
 	}
 
 	async sendMessage(text: string) {
+		// The composer only mounts once the chat leaves the pending state, which
+		// depends on the peer's profile syncing peer-to-peer through the mailbox.
+		await this.composer.messageInput.waitForExist({ timeout: SYNC_TIMEOUT });
 		await this.typeInto(tid('message-input-textarea'), text);
 		await this.agent.pause(50);
 		await this.agent.execute((sel: string) => {

--- a/e2e-tests/helpers/pages/direct-chats/direct-chat-page.ts
+++ b/e2e-tests/helpers/pages/direct-chats/direct-chat-page.ts
@@ -85,7 +85,11 @@ export class DirectChatPage extends TestHelper {
 					if (!wrapper.textContent?.includes(t)) continue;
 					const el = wrapper.querySelector(statusSel) as HTMLElement | null;
 					const status = el?.dataset.status;
-					if (status === 'sending' || status === 'local' || status === 'cloud') {
+					if (
+						status === 'sending' ||
+						status === 'local' ||
+						status === 'cloud'
+					) {
 						return status;
 					}
 					return null;

--- a/packages/stores/src/chats/chat-key.ts
+++ b/packages/stores/src/chats/chat-key.ts
@@ -1,0 +1,33 @@
+import { AgentId, DeviceId } from '../p2panda/types';
+
+const PENDING_PREFIX = 'pending-device:';
+
+/**
+ * The id used to address a direct chat in routes and summaries. Normally an
+ * established contact's `AgentId`, but for an outgoing contact request whose
+ * ack hasn't arrived yet we only know the owner's `DeviceId`, so the key is
+ * tagged `pending-device:<device_pubkey>` to make it unmistakable that it is a
+ * device pubkey, not an agent id.
+ */
+export type ChatKey = string;
+
+export function pendingChatKey(devicePubkey: DeviceId): ChatKey {
+	return `${PENDING_PREFIX}${devicePubkey}`;
+}
+
+export function isPendingChatKey(key: ChatKey): boolean {
+	return key.startsWith(PENDING_PREFIX);
+}
+
+/**
+ * Extract the device pubkey from a pending chat key, or `undefined` if the key
+ * is a regular agent-keyed chat.
+ */
+export function pendingChatKeyDevice(key: ChatKey): DeviceId | undefined {
+	return isPendingChatKey(key) ? key.slice(PENDING_PREFIX.length) : undefined;
+}
+
+/** Narrow a chat key to an `AgentId`, or `undefined` for a pending key. */
+export function chatKeyAgentId(key: ChatKey): AgentId | undefined {
+	return isPendingChatKey(key) ? undefined : key;
+}

--- a/packages/stores/src/chats/chats-store.ts
+++ b/packages/stores/src/chats/chats-store.ts
@@ -16,6 +16,7 @@ import { LogsStore } from '../p2panda/logs-store';
 import { AgentId, VerifyingKey } from '../p2panda/types';
 import { ChatId, ChatSummary, Payload } from '../types';
 import { memo } from '../utils/memo';
+import { pendingChatKey } from './chat-key';
 import { type IChatsClient } from './chats-client';
 
 export class ChatsStore {
@@ -84,12 +85,13 @@ export class ChatsStore {
 	});
 
 	allChatsSummaries = reactive(async () => {
-		const [direct, groups, pending] = await Promise.all([
+		const [direct, groups, pending, outgoing] = await Promise.all([
 			this.allDirectChatSummaries(),
 			this.allGroupChatSummaries(),
 			this.allPendingRequestSummaries(),
+			this.allOutgoingPendingSummaries(),
 		]);
-		const summaries = [...direct, ...groups, ...pending];
+		const summaries = [...direct, ...groups, ...pending, ...outgoing];
 		summaries.sort((a, b) => b.lastEvent.timestamp - a.lastEvent.timestamp);
 		return summaries;
 	});
@@ -126,6 +128,23 @@ export class ChatsStore {
 					timestamp: pendingRequest.timestamp,
 				},
 				unreadMessages: 1,
+			}));
+		},
+	);
+
+	private allOutgoingPendingSummaries = reactive(
+		async (): Promise<ChatSummary[]> => {
+			const pending = await this.contactsStore.outgoingPendingRequests();
+			return pending.map(request => ({
+				type: 'DirectChat',
+				chatId: pendingChatKey(request.devicePubkey),
+				name: '',
+				avatar: undefined,
+				lastEvent: {
+					kind: 'contact_request',
+					timestamp: request.timestamp,
+				},
+				unreadMessages: 0,
 			}));
 		},
 	);

--- a/packages/stores/src/chats/chats-store.ts
+++ b/packages/stores/src/chats/chats-store.ts
@@ -114,12 +114,11 @@ export class ChatsStore {
 			const pendingRequests = await this.contactsStore.contactRequests();
 			const unique = pendingRequests.filter(
 				(request, index, self) =>
-					self.findIndex(r => r.code.agent_id === request.code.agent_id) ===
-					index,
+					self.findIndex(r => r.agentId === request.agentId) === index,
 			);
 			return unique.map(pendingRequest => ({
 				type: 'DirectChat',
-				chatId: pendingRequest.code.agent_id,
+				chatId: pendingRequest.agentId,
 				name: fullName(pendingRequest.profile),
 				avatar: pendingRequest.profile.avatar,
 				lastEvent: {

--- a/packages/stores/src/chats/chats-store.ts
+++ b/packages/stores/src/chats/chats-store.ts
@@ -140,6 +140,7 @@ export class ChatsStore {
 				chatId: pendingChatKey(request.devicePubkey),
 				name: '',
 				avatar: undefined,
+				waitingForProfile: true as const,
 				lastEvent: {
 					kind: 'contact_request',
 					timestamp: request.timestamp,

--- a/packages/stores/src/contacts/contact-code.ts
+++ b/packages/stores/src/contacts/contact-code.ts
@@ -7,7 +7,6 @@ import { ContactCode } from '../types';
 export function encodeContactCode(contactCode: ContactCode): string {
 	const bin = encode([
 		contactCode.device_pubkey,
-		contactCode.agent_id,
 		contactCode.inbox_topic,
 		contactCode.share_intent,
 	]);
@@ -16,10 +15,9 @@ export function encodeContactCode(contactCode: ContactCode): string {
 
 export function decodeContactCode(contactCodeString: string): ContactCode {
 	const bin = toByteArray(contactCodeString);
-	const [device_pubkey, agent_id, inbox_topic, share_intent] = decode(bin);
+	const [device_pubkey, inbox_topic, share_intent] = decode(bin);
 	return {
 		device_pubkey,
-		agent_id,
 		inbox_topic,
 		share_intent,
 	};

--- a/packages/stores/src/contacts/contact-code.ts
+++ b/packages/stores/src/contacts/contact-code.ts
@@ -4,10 +4,24 @@ import { decode, encode } from 'cbor-web';
 
 import { ContactCode } from '../types';
 
+function hexToBytes(hex: string): Uint8Array {
+	return Uint8Array.from(hex.match(/.{1,2}/g)!.map(byte => parseInt(byte, 16)));
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+	return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+}
+
+// The hex string keys (device_pubkey, inbox_topic.topic) are converted to raw
+// bytes before CBOR encoding so each 32-byte key costs 32 bytes rather than a
+// 64-char text string, roughly halving the encoded contact code.
 export function encodeContactCode(contactCode: ContactCode): string {
+	const inboxTopic = contactCode.inbox_topic
+		? [contactCode.inbox_topic.expires_at, hexToBytes(contactCode.inbox_topic.topic)]
+		: null;
 	const bin = encode([
-		contactCode.device_pubkey,
-		contactCode.inbox_topic,
+		hexToBytes(contactCode.device_pubkey),
+		inboxTopic,
 		contactCode.share_intent,
 	]);
 	return fromByteArray(bin);
@@ -17,8 +31,10 @@ export function decodeContactCode(contactCodeString: string): ContactCode {
 	const bin = toByteArray(contactCodeString);
 	const [device_pubkey, inbox_topic, share_intent] = decode(bin);
 	return {
-		device_pubkey,
-		inbox_topic,
+		device_pubkey: bytesToHex(device_pubkey),
+		inbox_topic: inbox_topic
+			? { expires_at: inbox_topic[0], topic: bytesToHex(inbox_topic[1]) }
+			: undefined,
 		share_intent,
 	};
 }

--- a/packages/stores/src/contacts/contact-code.ts
+++ b/packages/stores/src/contacts/contact-code.ts
@@ -5,7 +5,9 @@ import { decode, encode } from 'cbor-web';
 import { ContactCode } from '../types';
 
 function hexToBytes(hex: string): Uint8Array {
-	return Uint8Array.from((hex.match(/.{1,2}/g) ?? []).map(byte => parseInt(byte, 16)));
+	return Uint8Array.from(
+		(hex.match(/.{1,2}/g) ?? []).map(byte => parseInt(byte, 16)),
+	);
 }
 
 function bytesToHex(bytes: Uint8Array): string {

--- a/packages/stores/src/contacts/contact-code.ts
+++ b/packages/stores/src/contacts/contact-code.ts
@@ -5,7 +5,7 @@ import { decode, encode } from 'cbor-web';
 import { ContactCode } from '../types';
 
 function hexToBytes(hex: string): Uint8Array {
-	return Uint8Array.from(hex.match(/.{1,2}/g)!.map(byte => parseInt(byte, 16)));
+	return Uint8Array.from((hex.match(/.{1,2}/g) ?? []).map(byte => parseInt(byte, 16)));
 }
 
 function bytesToHex(bytes: Uint8Array): string {

--- a/packages/stores/src/contacts/contact-code.ts
+++ b/packages/stores/src/contacts/contact-code.ts
@@ -17,7 +17,10 @@ function bytesToHex(bytes: Uint8Array): string {
 // 64-char text string, roughly halving the encoded contact code.
 export function encodeContactCode(contactCode: ContactCode): string {
 	const inboxTopic = contactCode.inbox_topic
-		? [contactCode.inbox_topic.expires_at, hexToBytes(contactCode.inbox_topic.topic)]
+		? [
+				contactCode.inbox_topic.expires_at,
+				hexToBytes(contactCode.inbox_topic.topic),
+			]
 		: null;
 	const bin = encode([
 		hexToBytes(contactCode.device_pubkey),

--- a/packages/stores/src/contacts/contacts-client.ts
+++ b/packages/stores/src/contacts/contacts-client.ts
@@ -36,6 +36,9 @@ export interface IContactsClient {
 	// Add contact
 	addContact(code: ContactCode): Promise<void>;
 
+	// Accept an incoming contact request
+	acceptContact(agentId: AgentId): Promise<void>;
+
 	// Reject contact request
 	rejectContactRequest(agentId: AgentId): Promise<void>;
 
@@ -90,6 +93,18 @@ export class ContactsClient implements IContactsClient {
 				op =>
 					op.body?.payload.type === 'AddContact' &&
 					op.body.payload.payload.agent_id === contactCode.agent_id,
+			),
+		]);
+	}
+
+	async acceptContact(agentId: AgentId): Promise<void> {
+		await Promise.all([
+			invokeAfterSetup('accept_contact', { agentId }),
+			waitForOperation(
+				this.logsClient,
+				op =>
+					op.body?.payload.type === 'AddContact' &&
+					op.body.payload.payload.agent_id === agentId,
 			),
 		]);
 	}

--- a/packages/stores/src/contacts/contacts-client.ts
+++ b/packages/stores/src/contacts/contacts-client.ts
@@ -21,6 +21,10 @@ export interface IContactsClient {
 
 	myDeviceId(): Promise<DeviceId>;
 
+	// Resolve the agent id recorded for a device pubkey, if the contact is
+	// established. Undefined while an outgoing request is still pending.
+	agentForDevice(devicePubkey: DeviceId): Promise<AgentId | undefined>;
+
 	// Sets the profile for this user
 	setProfile(profile: Profile): Promise<void>;
 
@@ -69,6 +73,14 @@ export class ContactsClient implements IContactsClient {
 
 	myDeviceId(): Promise<DeviceId> {
 		return invokeAfterSetup('my_device_id');
+	}
+
+	async agentForDevice(devicePubkey: DeviceId): Promise<AgentId | undefined> {
+		return (
+			(await invokeAfterSetup<AgentId | null>('agent_for_device', {
+				devicePubkey,
+			})) ?? undefined
+		);
 	}
 
 	async setProfile(profile: Profile): Promise<void> {

--- a/packages/stores/src/contacts/contacts-client.ts
+++ b/packages/stores/src/contacts/contacts-client.ts
@@ -86,15 +86,7 @@ export class ContactsClient implements IContactsClient {
 	}
 
 	async addContact(contactCode: ContactCode): Promise<void> {
-		await Promise.all([
-			invokeAfterSetup('add_contact', { contactCode }),
-			waitForOperation(
-				this.logsClient,
-				op =>
-					op.body?.payload.type === 'AddContact' &&
-					op.body.payload.payload.agent_id === contactCode.agent_id,
-			),
-		]);
+		await invokeAfterSetup('add_contact', { contactCode });
 	}
 
 	async acceptContact(agentId: AgentId): Promise<void> {

--- a/packages/stores/src/contacts/contacts-store.ts
+++ b/packages/stores/src/contacts/contacts-store.ts
@@ -100,15 +100,13 @@ export class ContactsStore {
 		}
 
 		const devices = Object.keys(latestByDevice);
-		const contacts = await this.contactsAgentIds();
 		const resolved = await Promise.all(
 			devices.map(device => this.client.agentForDevice(device)),
 		);
 
 		const pending: OutgoingContactRequest[] = [];
 		for (let i = 0; i < devices.length; i++) {
-			const agentId = resolved[i];
-			if (agentId !== undefined && contacts.includes(agentId)) continue;
+			if (resolved[i] !== undefined) continue;
 			pending.push({
 				devicePubkey: devices[i],
 				timestamp: latestByDevice[devices[i]],

--- a/packages/stores/src/contacts/contacts-store.ts
+++ b/packages/stores/src/contacts/contacts-store.ts
@@ -3,7 +3,7 @@ import { reactive, relay } from 'signalium';
 import { DevicesStore } from '../devices/devices-store';
 import { LogsStore } from '../p2panda/logs-store';
 import { SimplifiedOperation } from '../p2panda/simplified-types';
-import { AgentId, TopicId } from '../p2panda/types';
+import { AgentId, DeviceId, TopicId } from '../p2panda/types';
 import { personalTopicFor } from '../topics';
 import { AnnouncementPayload, ContactCode, Payload } from '../types';
 import { IContactsClient, Profile } from './contacts-client';
@@ -14,6 +14,16 @@ export interface ContactRequest {
 	agentId: AgentId;
 	timestamp: number;
 	topicId: TopicId;
+}
+
+/**
+ * An outgoing contact request we've sent by scanning a QR code, before the
+ * owner's ack has arrived. Keyed on the owner's device pubkey, since we don't
+ * yet know their agent id or profile.
+ */
+export interface OutgoingContactRequest {
+	devicePubkey: DeviceId;
+	timestamp: number;
 }
 
 export class ContactsStore {
@@ -66,6 +76,45 @@ export class ContactsStore {
 		}
 
 		return Array.from(contacts);
+	});
+
+	/**
+	 * Outgoing contact requests we've sent but whose ack hasn't arrived yet.
+	 * A pending marker is dropped once its device pubkey resolves to an
+	 * established contact (the ack was processed and the `AddContact` marker
+	 * created a real chat that supersedes the placeholder).
+	 */
+	outgoingPendingRequests = reactive(async () => {
+		const myDeviceGroupTopic = await this.devicesStore.myDeviceGroupTopic();
+
+		const latestByDevice: Record<DeviceId, number> = {};
+		for (const [_, ops] of Object.entries(myDeviceGroupTopic)) {
+			for (const op of ops) {
+				if (op.body?.payload?.type !== 'PendingContactRequest') continue;
+				const { device_pubkey } = op.body.payload.payload;
+				const existing = latestByDevice[device_pubkey];
+				if (existing === undefined || op.header.timestamp > existing) {
+					latestByDevice[device_pubkey] = op.header.timestamp;
+				}
+			}
+		}
+
+		const devices = Object.keys(latestByDevice);
+		const contacts = await this.contactsAgentIds();
+		const resolved = await Promise.all(
+			devices.map(device => this.client.agentForDevice(device)),
+		);
+
+		const pending: OutgoingContactRequest[] = [];
+		for (let i = 0; i < devices.length; i++) {
+			const agentId = resolved[i];
+			if (agentId !== undefined && contacts.includes(agentId)) continue;
+			pending.push({
+				devicePubkey: devices[i],
+				timestamp: latestByDevice[devices[i]],
+			});
+		}
+		return pending;
 	});
 
 	contactAddedTimestamp = reactive(async (agentId: AgentId) => {

--- a/packages/stores/src/contacts/contacts-store.ts
+++ b/packages/stores/src/contacts/contacts-store.ts
@@ -11,6 +11,7 @@ import { IContactsClient, Profile } from './contacts-client';
 export interface ContactRequest {
 	profile: Profile;
 	code: ContactCode;
+	agentId: AgentId;
 	timestamp: number;
 	topicId: TopicId;
 }
@@ -125,9 +126,9 @@ export class ContactsStore {
 				for (const operation of operations) {
 					if (operation.body?.type !== 'Inbox') continue;
 					if (operation.body.payload.type !== 'ContactRequest') continue;
-					const { code, profile } = operation.body.payload.payload;
-					if (!code?.agent_id) continue;
-					const agentId = code.agent_id;
+					const { code, profile, agent_id } = operation.body.payload.payload;
+					if (!agent_id) continue;
+					const agentId = agent_id;
 
 					// We have already accepted this contact request
 					if (contacts.includes(agentId)) continue;
@@ -143,6 +144,7 @@ export class ContactsStore {
 					contactRequests.push({
 						code,
 						profile,
+						agentId,
 						topicId,
 						timestamp: operation.header.timestamp,
 					});
@@ -170,8 +172,8 @@ export class ContactsStore {
 				for (const operation of operations) {
 					if (operation.body?.type !== 'Inbox') continue;
 					if (operation.body.payload.type !== 'ContactRequest') continue;
-					const { code, profile } = operation.body.payload.payload;
-					if (code?.agent_id !== agentId) continue;
+					const { profile, agent_id } = operation.body.payload.payload;
+					if (agent_id !== agentId) continue;
 					const ts = operation.header.timestamp;
 					if (!latest || ts > latest.timestamp) {
 						latest = { timestamp: ts, profile };

--- a/packages/stores/src/direct-chats/direct-chat-store.ts
+++ b/packages/stores/src/direct-chats/direct-chat-store.ts
@@ -1,6 +1,6 @@
 import { reactive } from 'signalium';
 
-import { isPendingChatKey } from '../chats/chat-key';
+import { isPendingChatKey, pendingChatKeyDevice } from '../chats/chat-key';
 import { fullName } from '../contacts/contacts-client';
 import { ContactsStore } from '../contacts/contacts-store';
 import { LogsStore } from '../p2panda/logs-store';
@@ -42,6 +42,12 @@ export class DirectChatStore implements MessagesStore {
 	get isPending(): boolean {
 		return isPendingChatKey(this.peer);
 	}
+
+	resolvedPendingAgent = reactive(async () => {
+		const device = pendingChatKeyDevice(this.peer);
+		if (device === undefined) return undefined;
+		return await this.contactsStore.client.agentForDevice(device);
+	});
 
 	chatId = reactive(async () => {
 		if (this.isPending) return '';

--- a/packages/stores/src/direct-chats/direct-chat-store.ts
+++ b/packages/stores/src/direct-chats/direct-chat-store.ts
@@ -48,7 +48,7 @@ export class DirectChatStore implements MessagesStore {
 
 	contactRequest = reactive(async () => {
 		const contactRequests = await this.contactsStore.contactRequests();
-		return contactRequests.find(cr => cr.code.agent_id === this.peer);
+		return contactRequests.find(cr => cr.agentId === this.peer);
 	});
 
 	messages = reactive(async () => {

--- a/packages/stores/src/direct-chats/direct-chat-store.ts
+++ b/packages/stores/src/direct-chats/direct-chat-store.ts
@@ -1,5 +1,6 @@
 import { reactive } from 'signalium';
 
+import { isPendingChatKey } from '../chats/chat-key';
 import { fullName } from '../contacts/contacts-client';
 import { ContactsStore } from '../contacts/contacts-store';
 import { LogsStore } from '../p2panda/logs-store';
@@ -38,9 +39,17 @@ export class DirectChatStore implements MessagesStore {
 		public peer: AgentId,
 	) {}
 
-	chatId = reactive(async () => await this.client.chatId(this.peer));
+	get isPending(): boolean {
+		return isPendingChatKey(this.peer);
+	}
+
+	chatId = reactive(async () => {
+		if (this.isPending) return '';
+		return await this.client.chatId(this.peer);
+	});
 
 	peerProfile = reactive(async () => {
+		if (this.isPending) return undefined;
 		const request = await this.contactRequest();
 		if (request) return request.profile;
 		return await this.contactsStore.profiles(this.peer);
@@ -52,6 +61,7 @@ export class DirectChatStore implements MessagesStore {
 	});
 
 	messages = reactive(async () => {
+		if (this.isPending) return {} as Record<Hash, Message>;
 		const chatId = await this.chatId();
 		const logs = await this.logsStore.logsForAllAuthors(chatId);
 

--- a/packages/stores/src/direct-chats/direct-chat-store.ts
+++ b/packages/stores/src/direct-chats/direct-chat-store.ts
@@ -46,6 +46,10 @@ export class DirectChatStore implements MessagesStore {
 	resolvedPendingAgent = reactive(async () => {
 		const device = pendingChatKeyDevice(this.peer);
 		if (device === undefined) return undefined;
+		// Depend on the reactive contacts list so this re-runs once the contact
+		// is established (the device→agent mapping is saved around the same time
+		// the AddContact marker is published).
+		await this.contactsStore.contactsAgentIds();
 		return await this.contactsStore.client.agentForDevice(device);
 	});
 

--- a/packages/stores/src/index.ts
+++ b/packages/stores/src/index.ts
@@ -23,6 +23,7 @@ export * from './group-chats/group-chat-client.js';
 
 export * from './chats/chats-store.js';
 export * from './chats/chats-client.js';
+export * from './chats/chat-key.js';
 
 export * from './settings/settings-client.js';
 export * from './settings/settings-store.js';

--- a/packages/stores/src/mock/contacts-client.ts
+++ b/packages/stores/src/mock/contacts-client.ts
@@ -2,6 +2,7 @@ import type { IContactsClient, Profile } from '../contacts/contacts-client';
 import type { AgentId, DeviceId, TopicId } from '../p2panda/types';
 import { personalTopicFor } from '../topics';
 import type { ContactCode, InboxTopic } from '../types';
+import { ShareIntent } from '../types';
 import type { LocalStorageLogsClient } from './client';
 
 export class MockContactsClient implements IContactsClient {
@@ -35,7 +36,7 @@ export class MockContactsClient implements IContactsClient {
 			inbox_topic: this.inboxTopics[0]
 				? { topic: this.inboxTopics[0], expires_at: Date.now() + 86400000 }
 				: undefined,
-			share_intent: 'AddContact',
+			share_intent: ShareIntent.AddContact,
 		};
 	}
 

--- a/packages/stores/src/mock/contacts-client.ts
+++ b/packages/stores/src/mock/contacts-client.ts
@@ -22,6 +22,10 @@ export class MockContactsClient implements IContactsClient {
 		return this.deviceId;
 	}
 
+	async agentForDevice(_devicePubkey: DeviceId): Promise<AgentId | undefined> {
+		return undefined;
+	}
+
 	async setProfile(profile: Profile): Promise<void> {
 		await this.logsClient.create(personalTopicFor(this.agentId), {
 			type: 'Announcements',

--- a/packages/stores/src/mock/contacts-client.ts
+++ b/packages/stores/src/mock/contacts-client.ts
@@ -32,7 +32,6 @@ export class MockContactsClient implements IContactsClient {
 	async createContactCode(): Promise<ContactCode> {
 		return {
 			device_pubkey: this.deviceId,
-			agent_id: this.agentId,
 			inbox_topic: this.inboxTopics[0]
 				? { topic: this.inboxTopics[0], expires_at: Date.now() + 86400000 }
 				: undefined,
@@ -44,10 +43,12 @@ export class MockContactsClient implements IContactsClient {
 		return this.inboxTopics;
 	}
 
-	async addContact(contactCode: ContactCode): Promise<void> {
+	async addContact(_contactCode: ContactCode): Promise<void> {}
+
+	async acceptContact(agentId: AgentId): Promise<void> {
 		await this.logsClient.create(this.deviceGroupTopicId, {
 			type: 'DeviceGroupPayload',
-			payload: { type: 'AddContact', payload: contactCode },
+			payload: { type: 'AddContact', payload: { agent_id: agentId } },
 		});
 	}
 

--- a/packages/stores/src/mock/seed-demo-data.ts
+++ b/packages/stores/src/mock/seed-demo-data.ts
@@ -1,4 +1,5 @@
 import { personalTopicFor } from '../topics';
+import { ShareIntent } from '../types';
 import { LocalStorageLogsClient, hash } from './client';
 
 export const DEMO_IDS = {
@@ -109,7 +110,7 @@ export function seedDemoData(logsClient: LocalStorageLogsClient) {
 						device_pubkey: contact.deviceId,
 						agent_id: contact.agentId,
 						inbox_topic: undefined,
-						share_intent: 'AddContact' as const,
+						share_intent: ShareIntent.AddContact,
 					},
 				},
 			},
@@ -224,7 +225,7 @@ export function seedDemoData(logsClient: LocalStorageLogsClient) {
 						device_pubkey: EVE.deviceId,
 						agent_id: EVE.agentId,
 						inbox_topic: undefined,
-						share_intent: 'AddContact' as const,
+						share_intent: ShareIntent.AddContact,
 					},
 					profile: {
 						name: EVE.name,

--- a/packages/stores/src/mock/seed-demo-data.ts
+++ b/packages/stores/src/mock/seed-demo-data.ts
@@ -107,10 +107,7 @@ export function seedDemoData(logsClient: LocalStorageLogsClient) {
 				payload: {
 					type: 'AddContact',
 					payload: {
-						device_pubkey: contact.deviceId,
 						agent_id: contact.agentId,
-						inbox_topic: undefined,
-						share_intent: ShareIntent.AddContact,
 					},
 				},
 			},
@@ -223,10 +220,11 @@ export function seedDemoData(logsClient: LocalStorageLogsClient) {
 				payload: {
 					code: {
 						device_pubkey: EVE.deviceId,
-						agent_id: EVE.agentId,
 						inbox_topic: undefined,
 						share_intent: ShareIntent.AddContact,
 					},
+					agent_id: EVE.agentId,
+					reply_topic: DEMO_IDS.INBOX_TOPIC,
 					profile: {
 						name: EVE.name,
 						surname: EVE.surname,

--- a/packages/stores/src/types.ts
+++ b/packages/stores/src/types.ts
@@ -165,8 +165,6 @@ export const ShareIntent = {
 export interface ContactCode {
 	/// Pubkey of this node: allows adding this node to groups.
 	device_pubkey: DeviceId;
-	/// Agent ID to add to spaces
-	agent_id: AgentId;
 	inbox_topic: InboxTopic | undefined;
 	/// The intent of the QR code: whether to add this node as a contact or a device.
 	share_intent: ShareIntent;
@@ -178,7 +176,7 @@ export interface ReadMessagesPayload {
 }
 
 export type DeviceGroupPayload =
-	| { type: 'AddContact'; payload: ContactCode }
+	| { type: 'AddContact'; payload: { agent_id: AgentId } }
 	| { type: 'RejectContactRequest'; payload: AgentId }
 	| { type: 'ReadMessages'; payload: ReadMessagesPayload };
 

--- a/packages/stores/src/types.ts
+++ b/packages/stores/src/types.ts
@@ -177,6 +177,7 @@ export interface ReadMessagesPayload {
 
 export type DeviceGroupPayload =
 	| { type: 'AddContact'; payload: { agent_id: AgentId } }
+	| { type: 'PendingContactRequest'; payload: { device_pubkey: DeviceId } }
 	| { type: 'RejectContactRequest'; payload: AgentId }
 	| { type: 'ReadMessages'; payload: ReadMessagesPayload };
 

--- a/packages/stores/src/types.ts
+++ b/packages/stores/src/types.ts
@@ -280,4 +280,5 @@ export interface ChatSummary {
 	name: string;
 	avatar: string | undefined;
 	lastEvent: ChatSummaryLastEvent;
+	waitingForProfile?: true;
 }

--- a/packages/stores/src/types.ts
+++ b/packages/stores/src/types.ts
@@ -187,6 +187,8 @@ export type InboxPayload = {
 	payload: {
 		code: ContactCode;
 		profile: Profile;
+		agent_id: AgentId;
+		reply_topic: TopicId;
 	};
 };
 

--- a/packages/stores/src/types.ts
+++ b/packages/stores/src/types.ts
@@ -155,7 +155,12 @@ export interface InboxTopic {
 	topic: TopicId;
 }
 
-export type ShareIntent = 'AddDevice' | 'AddContact';
+/** Numeric discriminant matching `dashchat_node::ShareIntent` (serde_repr u8). */
+export type ShareIntent = 0 | 1;
+export const ShareIntent = {
+	AddDevice: 0,
+	AddContact: 1,
+} as const;
 
 export interface ContactCode {
 	/// Pubkey of this node: allows adding this node to groups.

--- a/src-tauri/src/app_node.rs
+++ b/src-tauri/src/app_node.rs
@@ -120,6 +120,12 @@ impl AppNode {
         };
         if no_p2p {
             config.no_p2p().no_blob_sync()
+        } else if std::env::var_os("DASHCHAT_NO_P2P").is_some() {
+            // Dev/testing escape hatch: force all communication through mailbox
+            // servers so peers can't sync directly over p2p. Keeps blob sync so
+            // media still flows over the mailbox.
+            log::warn!("DASHCHAT_NO_P2P set: disabling peer-to-peer connectivity");
+            config.no_p2p()
         } else {
             config
         }

--- a/src-tauri/src/commands/contacts.rs
+++ b/src-tauri/src/commands/contacts.rs
@@ -29,7 +29,10 @@ pub async fn agent_for_device(
     app_node: State<'_, AppNode>,
 ) -> Result<Option<AgentId>, Error> {
     let node = app_node.get().await?;
-    Ok(node.agent_for_device(device_pubkey).await?)
+    Ok(node
+        .lookup_contact(device_pubkey)
+        .await
+        .map_err(|e| dashchat_node::Error::AuthorOperation(e.to_string()))?)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/contacts.rs
+++ b/src-tauri/src/commands/contacts.rs
@@ -24,6 +24,15 @@ pub async fn my_device_id(app_node: State<'_, AppNode>) -> Result<DeviceId, Stri
 }
 
 #[tauri::command]
+pub async fn agent_for_device(
+    device_pubkey: DeviceId,
+    app_node: State<'_, AppNode>,
+) -> Result<Option<AgentId>, Error> {
+    let node = app_node.get().await?;
+    Ok(node.agent_for_device(device_pubkey).await?)
+}
+
+#[tauri::command]
 pub async fn add_contact(contact_code: QrCode, app_node: State<'_, AppNode>) -> Result<(), Error> {
     let node = app_node.get().await?;
     node.add_contact(contact_code).await?;

--- a/src-tauri/src/commands/contacts.rs
+++ b/src-tauri/src/commands/contacts.rs
@@ -31,10 +31,7 @@ pub async fn add_contact(contact_code: QrCode, app_node: State<'_, AppNode>) -> 
 }
 
 #[tauri::command]
-pub async fn accept_contact(
-    agent_id: AgentId,
-    app_node: State<'_, AppNode>,
-) -> Result<(), Error> {
+pub async fn accept_contact(agent_id: AgentId, app_node: State<'_, AppNode>) -> Result<(), Error> {
     let node = app_node.get().await?;
     node.accept_contact(agent_id).await?;
     Ok(())

--- a/src-tauri/src/commands/contacts.rs
+++ b/src-tauri/src/commands/contacts.rs
@@ -31,6 +31,16 @@ pub async fn add_contact(contact_code: QrCode, app_node: State<'_, AppNode>) -> 
 }
 
 #[tauri::command]
+pub async fn accept_contact(
+    agent_id: AgentId,
+    app_node: State<'_, AppNode>,
+) -> Result<(), Error> {
+    let node = app_node.get().await?;
+    node.accept_contact(agent_id).await?;
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn active_inbox_topics(
     app_node: State<'_, AppNode>,
 ) -> Result<BTreeSet<Topic<Inbox>>, Error> {

--- a/src-tauri/src/commands/contacts.rs
+++ b/src-tauri/src/commands/contacts.rs
@@ -34,6 +34,9 @@ pub async fn agent_for_device(
 
 #[tauri::command]
 pub async fn add_contact(contact_code: QrCode, app_node: State<'_, AppNode>) -> Result<(), Error> {
+    if contact_code.share_intent == ShareIntent::AddDevice {
+        return Err(Error::AddDeviceNotSupported);
+    }
     let node = app_node.get().await?;
     node.add_contact(contact_code).await?;
     Ok(())

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -8,6 +8,9 @@ pub enum Error {
     #[error("NodeNotReady")]
     NodeNotReady,
 
+    #[error("Device linking is not yet supported")]
+    AddDeviceNotSupported,
+
     #[error(transparent)]
     #[serde(untagged)]
     Node(#[from] dashchat_node::Error),

--- a/src-tauri/src/filesystem.rs
+++ b/src-tauri/src/filesystem.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use tauri::{AppHandle, Manager, Runtime};
 
-const DATABASE_VERSION: &str = "0.5";
+const DATABASE_VERSION: &str = "0.6";
 
 /// When `DATA_DIR` is set, isolate the XDG directories under it so concurrently
 /// running desktop instances don't share WebKitGTK's SQLite databases (which

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -127,6 +127,7 @@ pub fn run() {
             commands::devices::my_device_group_topic,
             commands::contacts::my_device_id,
             commands::contacts::my_agent_id,
+            commands::contacts::agent_for_device,
             commands::contacts::create_contact_code,
             commands::contacts::add_contact,
             commands::contacts::accept_contact,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -129,6 +129,7 @@ pub fn run() {
             commands::contacts::my_agent_id,
             commands::contacts::create_contact_code,
             commands::contacts::add_contact,
+            commands::contacts::accept_contact,
             commands::contacts::active_inbox_topics,
             commands::contacts::reject_contact_request,
             commands::direct_chats::direct_chat_id,

--- a/src-tauri/src/notifications/mod.rs
+++ b/src-tauri/src/notifications/mod.rs
@@ -157,14 +157,16 @@ pub async fn build_notification_data(
         Payload::Chat(dashchat_node::ChatPayload::Message(content)) => {
             Some(chat_message_notification(node, topic, sender_device_id, content, id).await)
         }
-        Payload::Inbox(dashchat_node::InboxPayload::ContactRequest { code, profile, .. }) => {
+        Payload::Inbox(dashchat_node::InboxPayload::ContactRequest {
+            agent_id, profile, ..
+        }) => {
             Some(NotificationData {
                 id,
                 title: Some(sonix_i18n::t!("newContactRequest")),
                 body: Some(profile.name.clone()),
                 icon: Some("ic_stat_icon".to_string()),
                 group: Some(topic.to_hex()),
-                route: Some(format!("/direct-chats/{}", code.agent_id.to_hex())),
+                route: Some(format!("/direct-chats/{}", agent_id.to_hex())),
                 ..Default::default()
             })
         }

--- a/src-tauri/src/notifications/mod.rs
+++ b/src-tauri/src/notifications/mod.rs
@@ -159,17 +159,15 @@ pub async fn build_notification_data(
         }
         Payload::Inbox(dashchat_node::InboxPayload::ContactRequest {
             agent_id, profile, ..
-        }) => {
-            Some(NotificationData {
-                id,
-                title: Some(sonix_i18n::t!("newContactRequest")),
-                body: Some(profile.name.clone()),
-                icon: Some("ic_stat_icon".to_string()),
-                group: Some(topic.to_hex()),
-                route: Some(format!("/direct-chats/{}", agent_id.to_hex())),
-                ..Default::default()
-            })
-        }
+        }) => Some(NotificationData {
+            id,
+            title: Some(sonix_i18n::t!("newContactRequest")),
+            body: Some(profile.name.clone()),
+            icon: Some("ic_stat_icon".to_string()),
+            group: Some(topic.to_hex()),
+            route: Some(format!("/direct-chats/{}", agent_id.to_hex())),
+            ..Default::default()
+        }),
         _ => None,
     }
 }

--- a/src-tauri/src/notifications/mod.rs
+++ b/src-tauri/src/notifications/mod.rs
@@ -157,7 +157,7 @@ pub async fn build_notification_data(
         Payload::Chat(dashchat_node::ChatPayload::Message(content)) => {
             Some(chat_message_notification(node, topic, sender_device_id, content, id).await)
         }
-        Payload::Inbox(dashchat_node::InboxPayload::ContactRequest { code, profile }) => {
+        Payload::Inbox(dashchat_node::InboxPayload::ContactRequest { code, profile, .. }) => {
             Some(NotificationData {
                 id,
                 title: Some(sonix_i18n::t!("newContactRequest")),

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -71,6 +71,7 @@
 	"shareQrCodeSubtitle": "Scan this QR code to chat with me on Dash Chat.",
 	"contactAdded": "{{name}} was added to your contacts.",
 	"contactAccepted": "Contact added.",
+	"contactRequestSent": "Contact request sent.",
 	"contactRequestRejected": "Contact request was rejected.",
 	"someone": "Someone",
 	"groupCreated": "Group created.",

--- a/ui/src/lib/components/chats/ChatSummary.svelte
+++ b/ui/src/lib/components/chats/ChatSummary.svelte
@@ -35,8 +35,8 @@
 </script>
 
 <TitleTruncatedListItem
-	title={summary.name || m.waitingForProfile()}
-	titleWrapClass={summary.name ? '' : 'quiet'}
+	title={summary.waitingForProfile ? m.waitingForProfile() : summary.name}
+	titleWrapClass={summary.waitingForProfile ? 'quiet' : ''}
 	link
 	class={active ? 'active' : ''}
 	linkProps={{ href: chatHref(summary) }}

--- a/ui/src/lib/components/layout/AddContactPanel.svelte
+++ b/ui/src/lib/components/layout/AddContactPanel.svelte
@@ -5,6 +5,7 @@
 		decodeContactCode,
 		encodeContactCode,
 		fullName,
+		pendingChatKey,
 		type ContactsStore,
 		type SettingsStore,
 	} from 'dash-chat-stores';
@@ -99,7 +100,7 @@
 			await contactsStore.client.addContact(contactCode);
 			showToast(m.contactAccepted());
 
-			goto('/');
+			goto(`/direct-chats/${pendingChatKey(contactCode.device_pubkey)}`);
 		} catch (e) {
 			console.error(e);
 			const error = e as AddContactError;

--- a/ui/src/lib/components/layout/AddContactPanel.svelte
+++ b/ui/src/lib/components/layout/AddContactPanel.svelte
@@ -99,7 +99,7 @@
 			await contactsStore.client.addContact(contactCode);
 			showToast(m.contactAccepted());
 
-			goto(`/direct-chats/${contactCode.agent_id}`);
+			goto('/');
 		} catch (e) {
 			console.error(e);
 			const error = e as AddContactError;

--- a/ui/src/lib/components/layout/AddContactPanel.svelte
+++ b/ui/src/lib/components/layout/AddContactPanel.svelte
@@ -98,7 +98,7 @@
 			// }
 
 			await contactsStore.client.addContact(contactCode);
-			showToast(m.contactAccepted());
+			showToast(m.contactRequestSent());
 
 			const knownAgent = await contactsStore.client.agentForDevice(
 				contactCode.device_pubkey,

--- a/ui/src/lib/components/layout/AddContactPanel.svelte
+++ b/ui/src/lib/components/layout/AddContactPanel.svelte
@@ -100,7 +100,12 @@
 			await contactsStore.client.addContact(contactCode);
 			showToast(m.contactAccepted());
 
-			goto(`/direct-chats/${pendingChatKey(contactCode.device_pubkey)}`);
+			const knownAgent = await contactsStore.client.agentForDevice(
+				contactCode.device_pubkey,
+			);
+			goto(
+				`/direct-chats/${knownAgent ?? pendingChatKey(contactCode.device_pubkey)}`,
+			);
 		} catch (e) {
 			console.error(e);
 			const error = e as AddContactError;

--- a/ui/src/routes/direct-chats/[agentId]/+page.svelte
+++ b/ui/src/routes/direct-chats/[agentId]/+page.svelte
@@ -64,6 +64,8 @@
 	const store = chatsStore.directChats(agentId);
 	setContext('messages-store', store);
 
+	const isPendingChat = store.isPending;
+
 	const readTracker = createReadMessagesTracker(store);
 	const readMessageOnObserve = readTracker.observe;
 
@@ -692,6 +694,19 @@
 									<wa-icon src={wrapPathInSvg(mdiChevronDown)}></wa-icon>
 								</button>
 							</div>
+						</div>
+					{:else if isPendingChat}
+						<div class="pb-safe bg-page-surface">
+							<div
+								class="mx-4 border-t border-gray-300 dark:border-gray-600"
+								style="margin: 0 auto"
+							></div>
+							<p
+								class="px-6 py-4 text-center text-sm text-gray-600 dark:text-gray-400"
+								data-testid="direct-chat-pending-note"
+							>
+								{m.waitingForProfile()}
+							</p>
 						</div>
 					{:else if contactRequest}
 						<div class="pb-safe bg-page-surface">

--- a/ui/src/routes/direct-chats/[agentId]/+page.svelte
+++ b/ui/src/routes/direct-chats/[agentId]/+page.svelte
@@ -101,9 +101,7 @@
 
 	async function rejectContactRequest(contactRequest: ContactRequest) {
 		try {
-			await contactsStore.client.rejectContactRequest(
-				contactRequest.agentId,
-			);
+			await contactsStore.client.rejectContactRequest(contactRequest.agentId);
 			// Defer navigation so the rejection operation propagates before the home page renders
 			setTimeout(() => {
 				showToast(m.contactRequestRejected());

--- a/ui/src/routes/direct-chats/[agentId]/+page.svelte
+++ b/ui/src/routes/direct-chats/[agentId]/+page.svelte
@@ -77,7 +77,7 @@
 
 	async function acceptContactRequest(contactRequest: ContactRequest) {
 		try {
-			await contactsStore.client.addContact(contactRequest.code);
+			await contactsStore.client.acceptContact(contactRequest.agentId);
 			showToast(m.contactAccepted());
 		} catch (e) {
 			console.error(e);
@@ -102,7 +102,7 @@
 	async function rejectContactRequest(contactRequest: ContactRequest) {
 		try {
 			await contactsStore.client.rejectContactRequest(
-				contactRequest.code.agent_id,
+				contactRequest.agentId,
 			);
 			// Defer navigation so the rejection operation propagates before the home page renders
 			setTimeout(() => {

--- a/ui/src/routes/direct-chats/[agentId]/+page.svelte
+++ b/ui/src/routes/direct-chats/[agentId]/+page.svelte
@@ -2,7 +2,7 @@
 	import '@awesome.me/webawesome/dist/components/icon/icon.js';
 	import { m } from '$lib/paraglide/messages.js';
 
-	import { useReactivePromise } from '$lib/stores/use-signal';
+	import { useReactivePromise, useReactiveValue } from '$lib/stores/use-signal';
 	import { getContext, setContext, onMount, tick } from 'svelte';
 	import { goto } from '$app/navigation';
 	import {
@@ -65,6 +65,13 @@
 	setContext('messages-store', store);
 
 	const isPendingChat = store.isPending;
+
+	const resolvedAgent = useReactiveValue(store.resolvedPendingAgent);
+	$effect(() => {
+		if (!isPendingChat) return;
+		const agent = $resolvedAgent;
+		if (agent) goto(`/direct-chats/${agent}`, { replaceState: true });
+	});
 
 	const readTracker = createReadMessagesTracker(store);
 	const readMessageOnObserve = readTracker.observe;
@@ -382,187 +389,205 @@
 						{/if}
 					{/snippet}
 
-					{#await $readMessageHashes then readHashes}
-						{#await $messagesSets then messagesSetsInDays}
-							{@const unreadDivider = getUnreadDividerInfo(
-								messagesSetsInDays,
-								readHashes,
-								myDeviceId,
-							)}
+					{#if isPendingChat}
+						<div class="column" style={`padding-bottom: ${bottomBarHeight}px`}>
 							<div
-								class="column"
-								style={`padding-bottom: ${bottomBarHeight}px`}
+								class="column min-w-0"
+								style="align-items: center"
+								data-testid="direct-chat-peer-header"
 							>
-								<div
-									class="column min-w-0"
-									style="align-items: center"
-									data-testid="direct-chat-peer-header"
-								>
-									{#if profile}
-										<Link
-											class="column my-6 gap-2 items-center max-w-full px-4"
-											onclick={() => (showPeerProfile = true)}
-										>
-											<Avatar
-												image={profile.avatar}
-												initials={profile.name.slice(0, 2)}
-												size={80}
-											/>
-											<div class="flex items-center gap-1 max-w-full">
-												<span
-													class="text-xl font-semibold break-words text-center min-w-0"
-													>{fullName(profile)}</span
-												>
-												<wa-icon
-													class="small-icon quiet shrink-0"
-													src={wrapPathInSvg(mdiChevronRight)}
-												></wa-icon>
-											</div>
-										</Link>
-									{:else}
-										<div class="column my-6 gap-2 items-center">
-											<Avatar waitingForProfile size={80} />
-											<span class="quiet text-xl">
-												{m.waitingForProfile()}
-											</span>
-										</div>
-									{/if}
-								</div>
-								<div class="row justify-center mb-4">
-									<div class="outline-card" style="border-radius: 0.75rem;">
-										<div
-											class="flex flex-col gap-1 items-center p-3 text-center"
-										>
-											{#if contactRequest}
-												<div class="flex items-center gap-2 text-amber-600">
-													<wa-icon
-														class="small-icon"
-														src={wrapPathInSvg(mdiAlert)}
-													></wa-icon>
-													<span class="font-semibold"
-														>{m.reviewCarefully()}</span
-													>
-												</div>
-											{/if}
-											<div
-												class="flex flex-col gap-1 text-sm text-gray-700 dark:text-gray-300"
-											>
-												<div
-													class="flex items-center justify-center gap-2"
-													role="button"
-													tabindex="0"
-													onclick={() => (profileNamesSheetOpen = true)}
-													onkeydown={onActivate(
-														() => (profileNamesSheetOpen = true),
-													)}
-												>
-													<wa-icon
-														class="small-icon"
-														src={wrapPathInSvg(mdiAccountQuestion)}
-													></wa-icon>
-													<span
-														><u>{m.profileNames()}</u>{m.areNotVerified()}</span
-													>
-												</div>
-												<div class="flex items-center justify-center gap-2">
-													<wa-icon
-														class="small-icon"
-														src={wrapPathInSvg(mdiAccountGroup)}
-													></wa-icon>
-													<span>{m.noGroupsInCommon()}</span>
-												</div>
-											</div>
-											{#if contactRequest}
-												<div class="row pt-1 justify-center">
-													<Button
-														rounded
-														tonal
-														small
-														onClick={() => (showSecurityTips = true)}
-													>
-														{m.securityTips()}
-													</Button>
-												</div>
-											{/if}
-										</div>
-									</div>
-								</div>
-
-								<ProfileNamesSheet
-									opened={profileNamesSheetOpen}
-									onClose={() => (profileNamesSheetOpen = false)}
-								/>
-
-								<div
-									class="column m-2 gap-1"
-									data-testid="direct-chat-messages"
-								>
-									{#each messagesSetsInDays as messageSetInDay}
-										<div use:navbarSticky class="self-center z-10">
-											<DayTag class="quiet" day={messageSetInDay.day} />
-										</div>
-
-										{#each messageSetInDay.eventsSets as messageSet}
-											<div class="column" style="gap: 1px">
-												{#each messageSet as [hash, message], i (hash)}
-													{#if unreadDivider.hash === hash}
-														<div
-															class="unread-divider"
-															data-testid="direct-chat-unread-divider"
-														>
-															{m.unreadMessages({
-																count: unreadDivider.count,
-															})}
-														</div>
-													{/if}
-													{@const position = messagePosition(
-														messageSet.length,
-														i,
-													)}
-													{#if myDeviceId == message.author}
-														<div
-															class="self-end max-w-[85%]"
-															data-message-hash={hash}
-															use:scrollToBottomOnMount={hash}
-														>
-															{#await $chatId then chatId}
-																<MessageFromMe
-																	{message}
-																	{position}
-																	{myDeviceId}
-																	{chatId}
-																	searchQuery={searchMode ? searchQuery : ''}
-																/>
-															{/await}
-														</div>
-													{:else}
-														<div
-															class="self-start max-w-[85%]"
-															data-message-hash={hash}
-															use:readMessageOnObserve={readHashes?.has(hash)
-																? null
-																: hash}
-														>
-															{#await $chatId then chatId}
-																<MessageFromOthers
-																	{message}
-																	{position}
-																	{myDeviceId}
-																	{chatId}
-																	searchQuery={searchMode ? searchQuery : ''}
-																	sender={profile}
-																/>
-															{/await}
-														</div>
-													{/if}
-												{/each}
-											</div>
-										{/each}
-									{/each}
+								<div class="column my-6 gap-2 items-center">
+									<Avatar waitingForProfile size={80} />
+									<span class="quiet text-xl">
+										{m.waitingForProfile()}
+									</span>
 								</div>
 							</div>
+						</div>
+					{:else}
+						{#await $readMessageHashes then readHashes}
+							{#await $messagesSets then messagesSetsInDays}
+								{@const unreadDivider = getUnreadDividerInfo(
+									messagesSetsInDays,
+									readHashes,
+									myDeviceId,
+								)}
+								<div
+									class="column"
+									style={`padding-bottom: ${bottomBarHeight}px`}
+								>
+									<div
+										class="column min-w-0"
+										style="align-items: center"
+										data-testid="direct-chat-peer-header"
+									>
+										{#if profile}
+											<Link
+												class="column my-6 gap-2 items-center max-w-full px-4"
+												onclick={() => (showPeerProfile = true)}
+											>
+												<Avatar
+													image={profile.avatar}
+													initials={profile.name.slice(0, 2)}
+													size={80}
+												/>
+												<div class="flex items-center gap-1 max-w-full">
+													<span
+														class="text-xl font-semibold break-words text-center min-w-0"
+														>{fullName(profile)}</span
+													>
+													<wa-icon
+														class="small-icon quiet shrink-0"
+														src={wrapPathInSvg(mdiChevronRight)}
+													></wa-icon>
+												</div>
+											</Link>
+										{:else}
+											<div class="column my-6 gap-2 items-center">
+												<Avatar waitingForProfile size={80} />
+												<span class="quiet text-xl">
+													{m.waitingForProfile()}
+												</span>
+											</div>
+										{/if}
+									</div>
+									<div class="row justify-center mb-4">
+										<div class="outline-card" style="border-radius: 0.75rem;">
+											<div
+												class="flex flex-col gap-1 items-center p-3 text-center"
+											>
+												{#if contactRequest}
+													<div class="flex items-center gap-2 text-amber-600">
+														<wa-icon
+															class="small-icon"
+															src={wrapPathInSvg(mdiAlert)}
+														></wa-icon>
+														<span class="font-semibold"
+															>{m.reviewCarefully()}</span
+														>
+													</div>
+												{/if}
+												<div
+													class="flex flex-col gap-1 text-sm text-gray-700 dark:text-gray-300"
+												>
+													<div
+														class="flex items-center justify-center gap-2"
+														role="button"
+														tabindex="0"
+														onclick={() => (profileNamesSheetOpen = true)}
+														onkeydown={onActivate(
+															() => (profileNamesSheetOpen = true),
+														)}
+													>
+														<wa-icon
+															class="small-icon"
+															src={wrapPathInSvg(mdiAccountQuestion)}
+														></wa-icon>
+														<span
+															><u>{m.profileNames()}</u
+															>{m.areNotVerified()}</span
+														>
+													</div>
+													<div class="flex items-center justify-center gap-2">
+														<wa-icon
+															class="small-icon"
+															src={wrapPathInSvg(mdiAccountGroup)}
+														></wa-icon>
+														<span>{m.noGroupsInCommon()}</span>
+													</div>
+												</div>
+												{#if contactRequest}
+													<div class="row pt-1 justify-center">
+														<Button
+															rounded
+															tonal
+															small
+															onClick={() => (showSecurityTips = true)}
+														>
+															{m.securityTips()}
+														</Button>
+													</div>
+												{/if}
+											</div>
+										</div>
+									</div>
+
+									<ProfileNamesSheet
+										opened={profileNamesSheetOpen}
+										onClose={() => (profileNamesSheetOpen = false)}
+									/>
+
+									<div
+										class="column m-2 gap-1"
+										data-testid="direct-chat-messages"
+									>
+										{#each messagesSetsInDays as messageSetInDay}
+											<div use:navbarSticky class="self-center z-10">
+												<DayTag class="quiet" day={messageSetInDay.day} />
+											</div>
+
+											{#each messageSetInDay.eventsSets as messageSet}
+												<div class="column" style="gap: 1px">
+													{#each messageSet as [hash, message], i (hash)}
+														{#if unreadDivider.hash === hash}
+															<div
+																class="unread-divider"
+																data-testid="direct-chat-unread-divider"
+															>
+																{m.unreadMessages({
+																	count: unreadDivider.count,
+																})}
+															</div>
+														{/if}
+														{@const position = messagePosition(
+															messageSet.length,
+															i,
+														)}
+														{#if myDeviceId == message.author}
+															<div
+																class="self-end max-w-[85%]"
+																data-message-hash={hash}
+																use:scrollToBottomOnMount={hash}
+															>
+																{#await $chatId then chatId}
+																	<MessageFromMe
+																		{message}
+																		{position}
+																		{myDeviceId}
+																		{chatId}
+																		searchQuery={searchMode ? searchQuery : ''}
+																	/>
+																{/await}
+															</div>
+														{:else}
+															<div
+																class="self-start max-w-[85%]"
+																data-message-hash={hash}
+																use:readMessageOnObserve={readHashes?.has(hash)
+																	? null
+																	: hash}
+															>
+																{#await $chatId then chatId}
+																	<MessageFromOthers
+																		{message}
+																		{position}
+																		{myDeviceId}
+																		{chatId}
+																		searchQuery={searchMode ? searchQuery : ''}
+																		sender={profile}
+																	/>
+																{/await}
+															</div>
+														{/if}
+													{/each}
+												</div>
+											{/each}
+										{/each}
+									</div>
+								</div>
+							{/await}
 						{/await}
-					{/await}
+					{/if}
 					{#if contactRequest}
 						<Dialog
 							opened={showAcceptDialog}


### PR DESCRIPTION
Goal: Shorten the QR Code.

Result: This PR drops the QR code from 348 chars to 108 chars. Further optimisations are possible in future PRs

This is done by:

* Expressing time in hours since Epoch
* Ensuring that we don't convert to hex before converting to base64
* Removing agent_id from the contact code

In hindsight, these should have been separate PRs because this has gotten quite large. The bulk of this is the removal of agent ids from the contact code. To achieve this, when someone scans your QR code and requests to be contacts, they also send a topic ID that you can send an acceptance message back on, which includes your agent id.