### PR TITLE
Try uploading blobs to mailbox immediately on publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -317,7 +317,7 @@ jobs:
           echo "PUSH_NOTIFICATIONS_SERVER_URL=$PUSH_NOTIFICATIONS_SERVER_URL" >> "$GITHUB_ENV"
 
       - name: Install and Build 🔧
-        run: pnpm install && pnpm tauri android build --aab --apk -- --stacktrace
+        run: pnpm install && pnpm tauri android build --aab --apk
 
       - name: Upload AAB to release
         uses: svenstaro/upload-release-action@v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -546,6 +546,10 @@ Testing keyboard behavior and UI interactions in the iOS simulator has inherent 
 - **Mobile vs Desktop**: Code paths differ for mobile/desktop (check `#[cfg(mobile)]` and `#[cfg(not(mobile))]`)
 - **Internationalization**: UI supports multiple languages via Weblate integration
 
+### Notes for edits
+
+- Run `just format` before considering any code ready to commit.
+ 
 ## Build Configuration
 
 ### Development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -549,6 +549,7 @@ Testing keyboard behavior and UI interactions in the iOS simulator has inherent 
 ### Notes for edits
 
 - Run `just format` before considering any code ready to commit.
+- IDE diagnostics for Rust code will usually be stale and inaccurate while you're changing things. If you can verify that they're up to date, use them, but otherwise prefer running explicit lints/checks.
  
 ## Build Configuration
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5443,6 +5443,7 @@ dependencies = [
  "axum",
  "axum-test",
  "base64 0.22.1",
+ "bytes",
  "clap",
  "dashchat-utils",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "dash-chat"
-version = "0.19.9"
+version = "0.19.10"
 dependencies = [
  "anyhow",
  "app_dirs2",
@@ -1974,7 +1974,7 @@ dependencies = [
  "mailbox-local-server",
  "mailbox-server",
  "mdns-sd",
- "nanoid 0.5.0",
+ "nanoid 0.4.0",
  "ndk-context",
  "ndk-sys",
  "netdev 0.43.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ resolver = "2"
 aliased = "0.1.0"
 anyhow = "1"
 async-trait = "0.1"
+bytes = "1.11"
 ciborium = "0.2.2"
 ed25519-dalek = "2.2"
 derive_more = { version = "2.1.1", features = ["full"] }

--- a/crates/dashchat-node/Cargo.toml
+++ b/crates/dashchat-node/Cargo.toml
@@ -42,7 +42,7 @@ tokio-stream = "0.1.17"
 tokio-util = "0.7"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-bytes = "1.11.0"
+bytes = { workspace = true }
 sqlx = "0.8.6"
 
 tempfile = { version = "3.24", optional = true }

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -492,6 +492,16 @@ impl Node {
         crate::LocalStoreBlobTracker::new(self.local_store.clone())
     }
 
+    /// A blob-bytes source backed by this node's blob store, for the toy mailbox
+    /// client to upload blob bytes inline. Reads error when blob sync is disabled
+    /// (e.g. the push extension), which makes the client fall back to announcing
+    /// hashes only.
+    pub fn blob_reader(&self) -> std::sync::Arc<dyn mailbox_client::BlobReader> {
+        std::sync::Arc::new(NodeBlobReader {
+            blob_sync: self.blob_sync.clone(),
+        })
+    }
+
     /// Wake the unfetched-blob followup task to run a reconciliation pass now
     /// (e.g. on unpause / network change).
     pub fn notify_unfetched_blob_followup(&self) {
@@ -1552,6 +1562,22 @@ impl Node {
                 .collect();
             return Ok(OutgoingMedia::Photos { photos });
         }
+    }
+}
+
+/// [`mailbox_client::BlobReader`] backed by the node's blob store.
+struct NodeBlobReader {
+    blob_sync: Option<BlobSync>,
+}
+
+#[async_trait::async_trait]
+impl mailbox_client::BlobReader for NodeBlobReader {
+    async fn read_blob(&self, hash: iroh_blobs::Hash) -> anyhow::Result<bytes::Bytes> {
+        let blob_sync = self
+            .blob_sync
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("blob sync disabled"))?;
+        Ok(blob_sync.blobs.get_bytes(hash).await?)
     }
 }
 

--- a/crates/dashchat-node/src/testing/mailbox.rs
+++ b/crates/dashchat-node/src/testing/mailbox.rs
@@ -152,12 +152,15 @@ async fn register_served_mailbox(node: &crate::Node, url: &str) {
         .await
         .unwrap();
     node.mailboxes
-        .register(ToyMailboxClient::<MailboxOperation>::new(
-            health.mailbox_id.clone(),
-            url,
-            node.endpoint_id(),
-            node.unfetched_blob_tracker(),
-        ))
+        .register(
+            ToyMailboxClient::<MailboxOperation>::new(
+                health.mailbox_id.clone(),
+                url,
+                node.endpoint_id(),
+                node.unfetched_blob_tracker(),
+            )
+            .with_blob_reader(node.blob_reader()),
+        )
         .await;
     node.register_with_mailbox(url).await.unwrap();
 }

--- a/crates/dashchat-node/src/unfetched_blobs.rs
+++ b/crates/dashchat-node/src/unfetched_blobs.rs
@@ -63,7 +63,7 @@ pub async fn followup_unfetched_blobs_once(node: &Node) {
         if hashes.is_empty() {
             continue; // no unfetched blobs to re-announce
         }
-        match mailbox_client::toy::send_store_blobs(&url, None, hashes, self_endpoint).await {
+        match mailbox_client::toy::send_store_blobs(&url, hashes, self_endpoint).await {
             Ok(already_stored) => {
                 if let Err(err) = node
                     .local_store

--- a/crates/dashchat-node/src/unfetched_blobs.rs
+++ b/crates/dashchat-node/src/unfetched_blobs.rs
@@ -63,7 +63,9 @@ pub async fn followup_unfetched_blobs_once(node: &Node) {
         if hashes.is_empty() {
             continue; // no unfetched blobs to re-announce
         }
-        match mailbox_client::toy::send_store_blobs(&url, hashes, self_endpoint).await {
+        // Re-announce only; the mailbox should fetch immediately (no upload
+        // follows here), so no grace.
+        match mailbox_client::toy::send_store_blobs(&url, hashes, self_endpoint, None).await {
             Ok(already_stored) => {
                 if let Err(err) = node
                     .local_store

--- a/crates/dashchat-node/src/unfetched_blobs.rs
+++ b/crates/dashchat-node/src/unfetched_blobs.rs
@@ -66,7 +66,7 @@ pub async fn followup_unfetched_blobs_once(node: &Node) {
         // Re-announce so the mailbox re-registers these hashes for fetching. No
         // upload follows here, so ask it to fetch immediately rather than deferring
         // by its grace window.
-        match mailbox_client::toy::send_store_blobs(&url, hashes, self_endpoint, false).await {
+        match mailbox_client::toy::send_register_hashes(&url, hashes, self_endpoint, false).await {
             Ok(already_stored) => {
                 if let Err(err) = node
                     .local_store
@@ -79,7 +79,7 @@ pub async fn followup_unfetched_blobs_once(node: &Node) {
                 tracing::info!(mailbox = %mailbox_id, %already_stored_count, "re-sent unfetched blobs");
             }
             Err(err) => {
-                tracing::warn!(?err, mailbox = %mailbox_id, "followup store_blobs failed");
+                tracing::warn!(?err, mailbox = %mailbox_id, "followup register_hashes failed");
             }
         }
     }

--- a/crates/dashchat-node/src/unfetched_blobs.rs
+++ b/crates/dashchat-node/src/unfetched_blobs.rs
@@ -63,9 +63,10 @@ pub async fn followup_unfetched_blobs_once(node: &Node) {
         if hashes.is_empty() {
             continue; // no unfetched blobs to re-announce
         }
-        // Re-announce so the mailbox re-registers these hashes for fetching; it
-        // applies its own fixed grace window before dialing us.
-        match mailbox_client::toy::send_store_blobs(&url, hashes, self_endpoint).await {
+        // Re-announce so the mailbox re-registers these hashes for fetching. No
+        // upload follows here, so ask it to fetch immediately rather than deferring
+        // by its grace window.
+        match mailbox_client::toy::send_store_blobs(&url, hashes, self_endpoint, false).await {
             Ok(already_stored) => {
                 if let Err(err) = node
                     .local_store

--- a/crates/dashchat-node/src/unfetched_blobs.rs
+++ b/crates/dashchat-node/src/unfetched_blobs.rs
@@ -63,7 +63,7 @@ pub async fn followup_unfetched_blobs_once(node: &Node) {
         if hashes.is_empty() {
             continue; // no unfetched blobs to re-announce
         }
-        match mailbox_client::toy::send_store_blobs(&url, hashes, self_endpoint).await {
+        match mailbox_client::toy::send_store_blobs(&url, None, hashes, self_endpoint).await {
             Ok(already_stored) => {
                 if let Err(err) = node
                     .local_store

--- a/crates/dashchat-node/src/unfetched_blobs.rs
+++ b/crates/dashchat-node/src/unfetched_blobs.rs
@@ -63,9 +63,9 @@ pub async fn followup_unfetched_blobs_once(node: &Node) {
         if hashes.is_empty() {
             continue; // no unfetched blobs to re-announce
         }
-        // Re-announce only; the mailbox should fetch immediately (no upload
-        // follows here), so no grace.
-        match mailbox_client::toy::send_store_blobs(&url, hashes, self_endpoint, None).await {
+        // Re-announce so the mailbox re-registers these hashes for fetching; it
+        // applies its own fixed grace window before dialing us.
+        match mailbox_client::toy::send_store_blobs(&url, hashes, self_endpoint).await {
             Ok(already_stored) => {
                 if let Err(err) = node
                     .local_store

--- a/crates/dashchat-node/tests/common/mod.rs
+++ b/crates/dashchat-node/tests/common/mod.rs
@@ -1,8 +1,13 @@
 use std::path::PathBuf;
+use std::time::Duration;
 
 use dashchat_node::testing::TestNode;
 use mailbox_local_server::LocalMailboxServer;
 use mailbox_server::FetchConfig;
+
+/// Short blob-fetch grace window for tests, so the mailbox's fetch backstop
+/// fires quickly instead of waiting out the production default.
+pub const TEST_UPLOAD_GRACE: Duration = Duration::from_millis(500);
 
 /// Spawn an in-process local mailbox server that shares `relay`'s iroh endpoint
 /// and blob store, wait for it to become healthy, and forward any peer address
@@ -21,6 +26,7 @@ pub async fn spawn_relay_mailbox(
         relay.blob_downloader(),
         relay.iroh_endpoint().await.unwrap(),
         Some(fetch_config),
+        Some(TEST_UPLOAD_GRACE),
         peer_addr_tx,
     )
     .await

--- a/crates/dashchat-node/tests/mailbox_blob_sync.rs
+++ b/crates/dashchat-node/tests/mailbox_blob_sync.rs
@@ -262,6 +262,7 @@ async fn recovers_unfetched_blob_after_source_restart() {
             pass_interval: Duration::from_millis(200),
             retry_cooldown: Duration::from_millis(200),
         }),
+        Some(common::TEST_UPLOAD_GRACE),
         peer_addr_tx,
     )
     .await

--- a/crates/mailbox-client/Cargo.toml
+++ b/crates/mailbox-client/Cargo.toml
@@ -20,7 +20,7 @@ sqlx = { version = "0.8.6", features = ["runtime-tokio", "sqlite"] }
 tokio = { version = "1.43.0", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-bytes = "1.11.0"
+bytes = { workspace = true }
 
 
 

--- a/crates/mailbox-client/src/lib.rs
+++ b/crates/mailbox-client/src/lib.rs
@@ -38,7 +38,9 @@ pub trait MailboxClient<Item: MailboxItem>: Send + Sync + 'static {
         None
     }
 
-    /// Publish an operation to the mailbox for the given topic.
+    /// Publish operations to the mailbox during topic sync.
+    /// Different mailbox implementations have different semantics for this,
+    /// for instance separate storage for logs vs blobs.
     async fn publish(&self, ops: Vec<Item>) -> Result<(), anyhow::Error>;
 
     /// Fetch operations from the mailbox for the given topics.

--- a/crates/mailbox-client/src/lib.rs
+++ b/crates/mailbox-client/src/lib.rs
@@ -128,6 +128,14 @@ pub trait UnfetchedBlobTracker: Send + Sync + 'static {
     async fn remove(&self, mailbox_id: &MailboxId, hashes: &[iroh_blobs::Hash]);
 }
 
+/// Node-side source of blob bytes by hash. Implemented in `dashchat-node` over
+/// the node's blob store; kept as a trait here so this crate stays free of node
+/// types. Used by the toy client to upload blob bytes inline to a mailbox.
+#[async_trait::async_trait]
+pub trait BlobReader: Send + Sync + 'static {
+    async fn read_blob(&self, hash: iroh_blobs::Hash) -> anyhow::Result<bytes::Bytes>;
+}
+
 /// No-op tracker for tests and contexts that don't persist unfetched blobs.
 #[derive(Clone, Default)]
 pub struct NoopUnfetchedBlobTracker;

--- a/crates/mailbox-client/src/manager.rs
+++ b/crates/mailbox-client/src/manager.rs
@@ -542,6 +542,7 @@ where
         }
 
         // For ops we successfully publish, the mailbox now has at least their seq_num.
+        // ACID: a power cut here would lose these ops_to_publish.
         let publish_acks: Vec<(Item::Topic, Item::Author, u64)> = ops_to_publish
             .iter()
             .map(|op| (op.topic(), op.author(), op.seq_num()))

--- a/crates/mailbox-client/src/toy.rs
+++ b/crates/mailbox-client/src/toy.rs
@@ -95,24 +95,28 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
         }
     }
 
-    /// Attach a blob-bytes source so `publish` pushes blob bytes straight to the
-    /// mailbox (best-effort) before announcing their hashes. Without a reader the
-    /// client only announces hashes and the mailbox fetches the bytes from us.
+    /// Attach a blob-bytes source so `publish` streams blob bytes to the mailbox
+    /// (best-effort, in a spawned task) after announcing their hashes. Without a
+    /// reader the client only announces hashes and the mailbox fetches the bytes
+    /// from us.
     pub fn with_blob_reader(mut self, blob_reader: std::sync::Arc<dyn crate::BlobReader>) -> Self {
         self.blob_reader = Some(blob_reader);
         self
     }
 
-    /// Push blob bytes to the mailbox immediately (best-effort), then announce
-    /// their hashes and reconcile the unfetched tracker: record hashes the
-    /// mailbox still needs, remove any it already has. The announce always runs,
-    /// so any blob that failed to upload is still fetched by the mailbox and
-    /// retried by the followup task.
+    /// Announce blob hashes to the mailbox and reconcile the unfetched tracker,
+    /// then push the bytes the mailbox still needs in a detached best-effort task.
+    ///
+    /// The announce goes first and is awaited: it is what atomically locks in the
+    /// publish (the mailbox now knows to fetch these hashes as a backstop). Only
+    /// then do we stream the bytes the mailbox reported it lacks — spawned, so a
+    /// batch of large blobs never stalls this per-mailbox publish iteration, and
+    /// scoped to `not_stored`, so we never re-upload blobs the mailbox already
+    /// holds.
     async fn store_blobs(&self, hashes: Vec<iroh_blobs::Hash>) -> anyhow::Result<()> {
         if hashes.is_empty() {
             return Ok(());
         }
-        self.upload_blobs(&hashes).await;
         let already_stored =
             send_store_blobs(&self.base_url, hashes.clone(), self.sender_pubkey).await?;
         let not_stored: Vec<_> = hashes
@@ -121,30 +125,43 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
             .collect();
         self.tracker.record(&self.id, &not_stored).await;
         self.tracker.remove(&self.id, &already_stored).await;
+        self.spawn_blob_upload(not_stored);
         Ok(())
     }
 
-    /// Best-effort: read each blob from the configured reader and upload its
-    /// bytes to the mailbox, one at a time (so at most one blob is held in
-    /// memory). Logs and continues past any read or upload error — the caller's
-    /// announce is the source of truth, so a missed upload just means the mailbox
-    /// fetches that blob instead. No-op when no reader is configured.
-    async fn upload_blobs(&self, hashes: &[iroh_blobs::Hash]) {
-        let Some(reader) = self.blob_reader.as_ref() else {
+    /// Spawn a detached best-effort task that streams each blob's bytes to the
+    /// mailbox, one at a time (so at most one blob is held in memory). Every blob
+    /// that uploads successfully is removed from the unfetched tracker (the
+    /// mailbox now holds it); anything that fails to read or upload is left in the
+    /// tracker for the followup task and fetched by the mailbox in the meantime.
+    /// No-op when no blob reader is configured.
+    fn spawn_blob_upload(&self, hashes: Vec<iroh_blobs::Hash>) {
+        let Some(reader) = self.blob_reader.clone() else {
             return;
         };
-        for hash in hashes {
-            let bytes = match reader.read_blob(*hash).await {
-                Ok(bytes) => bytes,
-                Err(err) => {
-                    tracing::warn!(%hash, ?err, "failed to read blob for upload; relying on announce");
-                    continue;
-                }
-            };
-            if let Err(err) = upload_blob(&self.base_url, bytes).await {
-                tracing::warn!(%hash, ?err, "blob upload failed; relying on announce");
-            }
+        if hashes.is_empty() {
+            return;
         }
+        let base_url = self.base_url.clone();
+        let id = self.id.clone();
+        let tracker = self.tracker.clone();
+        tokio::spawn(async move {
+            for hash in hashes {
+                let bytes = match reader.read_blob(hash).await {
+                    Ok(bytes) => bytes,
+                    Err(err) => {
+                        tracing::warn!(%hash, ?err, "failed to read blob for upload; relying on announce");
+                        continue;
+                    }
+                };
+                match upload_blob(&base_url, bytes).await {
+                    Ok(()) => tracker.remove(&id, &[hash]).await,
+                    Err(err) => {
+                        tracing::warn!(%hash, ?err, "blob upload failed; relying on announce");
+                    }
+                }
+            }
+        });
     }
 }
 
@@ -482,11 +499,10 @@ mod tests {
         let data = bytes::Bytes::from_static(b"a blob");
         let hash = iroh_blobs::Hash::new(&data);
 
-        // `/blobs/upload` records the pushed bytes; once uploaded, `/blobs/store`
-        // reports the announced hash as already stored.
+        // The mailbox has nothing yet, so the announce reports no `already_stored`
+        // and the client streams the bytes to `/blobs/upload` afterward.
         let uploaded: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
         let uploaded_in_handler = uploaded.clone();
-        let uploaded_for_store = uploaded.clone();
         let app = axum::Router::new()
             .route(
                 "/blobs/upload",
@@ -502,14 +518,10 @@ mod tests {
             .route(
                 "/blobs/store",
                 axum::routing::post(
-                    move |axum::Json(req): axum::Json<mailbox_server::StoreBlobsRequest>| async move {
-                        let has_upload = !uploaded_for_store.lock().unwrap().is_empty();
-                        let already_stored = if has_upload {
-                            req.blob_hashes
-                        } else {
-                            Vec::new()
-                        };
-                        axum::Json(mailbox_server::StoreBlobsResponse { already_stored })
+                    |axum::Json(_req): axum::Json<mailbox_server::StoreBlobsRequest>| async move {
+                        axum::Json(mailbox_server::StoreBlobsResponse {
+                            already_stored: Vec::new(),
+                        })
                     },
                 ),
             );
@@ -529,6 +541,14 @@ mod tests {
         .with_blob_reader(std::sync::Arc::new(StubReader(data.clone())));
 
         client.store_blobs(vec![hash]).await.unwrap();
+
+        // The upload is spawned, so wait for the detached task to deliver it.
+        for _ in 0..100 {
+            if *uploaded.lock().unwrap() == data.to_vec() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
         assert_eq!(*uploaded.lock().unwrap(), data.to_vec());
     }
 }

--- a/crates/mailbox-client/src/toy.rs
+++ b/crates/mailbox-client/src/toy.rs
@@ -16,15 +16,43 @@ use super::*;
 pub trait ToyItemTraits: ItemTraits + Serialize + DeserializeOwned {}
 impl<T> ToyItemTraits for T where T: ItemTraits + Serialize + DeserializeOwned {}
 
-/// Client-side timeout for a single blob upload, larger than the default HTTP
-/// timeout because a blob can be big.
+/// Fixed grace window for the inline-upload path, larger than the default HTTP
+/// timeout because a blob can be big. It serves two roles: the per-request
+/// upload timeout, and the `upload_grace` the client sends to `/blobs/store` so
+/// the mailbox defers its fetch backstop by the same window. Kept a constant but
+/// still sent as a request parameter so a slower client could raise it.
 const UPLOAD_BLOB_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
+/// Why a single blob upload attempt didn't succeed, so the caller can tell an
+/// unreachable mailbox from a failure isolated to one blob.
+#[derive(Debug)]
+enum UploadError {
+    /// The mailbox itself couldn't be reached (connection refused/reset). Every
+    /// other upload in the batch will hit the same wall, so the caller stops and
+    /// lets the announce/fetch backstop take over.
+    MailboxUnavailable(anyhow::Error),
+    /// The mailbox is reachable but this blob didn't store (non-success status,
+    /// or the request timed out mid-transfer). Isolated to this blob, so the
+    /// caller skips it and keeps uploading the rest.
+    Blob(anyhow::Error),
+}
+
+/// A connection-level failure means the mailbox is unreachable; anything else
+/// (including a per-request timeout on one large blob) is scoped to that blob so
+/// a single slow or rejected upload doesn't abort the whole batch.
+fn classify_upload_error(err: reqwest::Error) -> UploadError {
+    if err.is_connect() {
+        UploadError::MailboxUnavailable(err.into())
+    } else {
+        UploadError::Blob(err.into())
+    }
+}
+
 /// POST blob hashes to a mailbox's `/blobs/store`, returning the subset the
-/// mailbox reports it already has stored. Pass `upload_grace` (the caller's
-/// upload timeout) when the caller will stream the bytes to `/blobs/upload` right
-/// after, so the mailbox defers fetching them by exactly that window; pass `None`
-/// to have the mailbox fetch immediately.
+/// mailbox reports it already has stored. Pass `upload_grace` (the fixed grace
+/// window) when the caller will stream the bytes to `/blobs/upload` right after,
+/// so the mailbox defers fetching them by exactly that window; pass `None` to
+/// have the mailbox fetch immediately.
 pub async fn send_store_blobs(
     base_url: &str,
     hashes: Vec<iroh_blobs::Hash>,
@@ -57,17 +85,20 @@ pub async fn send_store_blobs(
 /// POST a single blob's raw bytes to a mailbox's `/blobs/upload`. The body is the
 /// bytes themselves — no JSON/base64 wrapping — so the on-wire size matches the
 /// blob.
-async fn upload_blob(base_url: &str, bytes: bytes::Bytes) -> anyhow::Result<()> {
+async fn upload_blob(base_url: &str, bytes: bytes::Bytes) -> Result<(), UploadError> {
     let response = HTTP_CLIENT
         .post(format!("{base_url}/blobs/upload"))
         .timeout(UPLOAD_BLOB_TIMEOUT)
         .body(bytes)
         .send()
-        .await?;
+        .await
+        .map_err(classify_upload_error)?;
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
-        anyhow::bail!("Failed to upload blob: {status} - {body}");
+        return Err(UploadError::Blob(anyhow::anyhow!(
+            "Failed to upload blob: {status} - {body}"
+        )));
     }
     Ok(())
 }
@@ -122,13 +153,17 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
         if hashes.is_empty() {
             return Ok(());
         }
-        // Send our upload timeout as the grace only when we can actually stream
-        // the bytes, so the mailbox defers fetching by exactly our window and
-        // only when a push is really coming.
+        // Send the fixed grace window only when we can actually stream the bytes,
+        // so the mailbox defers its fetch backstop by exactly our window and only
+        // when a push is really coming.
         let upload_grace = self.blob_reader.is_some().then_some(UPLOAD_BLOB_TIMEOUT);
-        let already_stored =
-            send_store_blobs(&self.base_url, hashes.clone(), self.sender_pubkey, upload_grace)
-                .await?;
+        let already_stored = send_store_blobs(
+            &self.base_url,
+            hashes.clone(),
+            self.sender_pubkey,
+            upload_grace,
+        )
+        .await?;
         let not_stored: Vec<_> = hashes
             .into_iter()
             .filter(|h| !already_stored.contains(h))
@@ -142,9 +177,12 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
     /// Spawn a detached best-effort task that streams each blob's bytes to the
     /// mailbox, one at a time (so at most one blob is held in memory). Every blob
     /// that uploads successfully is removed from the unfetched tracker (the
-    /// mailbox now holds it); anything that fails to read or upload is left in the
-    /// tracker for the followup task and fetched by the mailbox in the meantime.
-    /// No-op when no blob reader is configured.
+    /// mailbox now holds it). We keep going through the batch as long as uploads
+    /// are feasible: a blob we can't read or that the mailbox rejects is left in
+    /// the tracker and skipped, but the moment the mailbox itself is unreachable
+    /// we stop — the remaining blobs stay queued for the mailbox's fetch backstop
+    /// rather than burning through the batch against a dead endpoint. No-op when
+    /// no blob reader is configured.
     fn spawn_blob_upload(&self, hashes: Vec<iroh_blobs::Hash>) {
         let Some(reader) = self.blob_reader.clone() else {
             return;
@@ -166,8 +204,12 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
                 };
                 match upload_blob(&base_url, bytes).await {
                     Ok(()) => tracker.remove(&id, &[hash]).await,
-                    Err(err) => {
+                    Err(UploadError::Blob(err)) => {
                         tracing::warn!(%hash, ?err, "blob upload failed; relying on announce");
+                    }
+                    Err(UploadError::MailboxUnavailable(err)) => {
+                        tracing::warn!(%hash, ?err, "mailbox unreachable; aborting remaining uploads, relying on announce/fetch backstop");
+                        break;
                     }
                 }
             }
@@ -489,10 +531,43 @@ mod tests {
         let base_url = format!("http://{addr}");
 
         let data = bytes::Bytes::from_static(b"raw blob bytes");
-        crate::toy::upload_blob(&base_url, data.clone())
-            .await
-            .unwrap();
+        upload_blob(&base_url, data.clone()).await.unwrap();
         assert_eq!(*received.lock().unwrap(), data.to_vec());
+    }
+
+    #[tokio::test]
+    async fn upload_blob_reports_mailbox_unavailable_when_unreachable() {
+        // Bind then drop the listener so the port is closed and the connect fails.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let base_url = format!("http://{addr}");
+
+        let err = upload_blob(&base_url, bytes::Bytes::from_static(b"x"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, UploadError::MailboxUnavailable(_)));
+    }
+
+    #[tokio::test]
+    async fn upload_blob_reports_blob_failure_on_error_status() {
+        let app = axum::Router::new().route(
+            "/blobs/upload",
+            axum::routing::post(|| async {
+                (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "boom")
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let base_url = format!("http://{addr}");
+
+        let err = upload_blob(&base_url, bytes::Bytes::from_static(b"x"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, UploadError::Blob(_)));
     }
 
     #[tokio::test]

--- a/crates/mailbox-client/src/toy.rs
+++ b/crates/mailbox-client/src/toy.rs
@@ -45,13 +45,13 @@ fn classify_upload_error(err: reqwest::Error) -> UploadError {
     }
 }
 
-/// POST blob hashes to a mailbox's `/blobs/store`, returning the subset the
+/// POST blob hashes to a mailbox's `/blobs/register-hashes`, returning the subset the
 /// mailbox reports it already has stored. Set `expect_upload` when the caller
 /// will stream the bytes to `/blobs/upload` right after, so the mailbox defers
 /// its fetch backstop by its own fixed grace window and lets that upload land
 /// first without a duplicate transfer; pass `false` to have the mailbox fetch
 /// immediately (no upload is coming).
-pub async fn send_store_blobs(
+pub async fn send_register_hashes(
     base_url: &str,
     hashes: Vec<iroh_blobs::Hash>,
     sender_pubkey: iroh::EndpointId,
@@ -60,14 +60,14 @@ pub async fn send_store_blobs(
     if hashes.is_empty() {
         return Ok(Vec::new());
     }
-    let request = mailbox_server::StoreBlobsRequest {
+    let request = mailbox_server::RegisterHashesRequest {
         blob_hashes: hashes,
         sender_pubkey,
         expect_upload,
         signature: Vec::new(),
     };
     let response = HTTP_CLIENT
-        .post(format!("{base_url}/blobs/store"))
+        .post(format!("{base_url}/blobs/register-hashes"))
         .json(&request)
         .send()
         .await?;
@@ -76,7 +76,7 @@ pub async fn send_store_blobs(
         let body = response.text().await.unwrap_or_default();
         anyhow::bail!("Failed to store blobs: {status} - {body}");
     }
-    let response: mailbox_server::StoreBlobsResponse = response.json().await?;
+    let response: mailbox_server::RegisterHashesResponse = response.json().await?;
     Ok(response.already_stored)
 }
 
@@ -155,7 +155,7 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
         // stream the bytes; a reader-less client never uploads, so the mailbox
         // should fetch from us right away.
         let expect_upload = self.blob_reader.is_some();
-        let already_stored = send_store_blobs(
+        let already_stored = send_register_hashes(
             &self.base_url,
             hashes.clone(),
             self.sender_pubkey,
@@ -444,7 +444,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn store_blobs_records_not_stored_and_removes_already_stored() {
+    async fn register_hashes_records_not_stored_and_removes_already_stored() {
         use std::sync::Mutex as StdMutex;
 
         #[derive(Default)]
@@ -472,15 +472,15 @@ mod tests {
         let h_stored = iroh_blobs::Hash::new([1; 32]);
         let h_new = iroh_blobs::Hash::new([2; 32]);
         let app = axum::Router::new().route(
-            "/blobs/store",
+            "/blobs/register-hashes",
             axum::routing::post(
-                move |axum::Json(req): axum::Json<mailbox_server::StoreBlobsRequest>| async move {
+                move |axum::Json(req): axum::Json<mailbox_server::RegisterHashesRequest>| async move {
                     let already_stored: Vec<_> = req
                         .blob_hashes
                         .into_iter()
                         .filter(|h| *h == h_stored)
                         .collect();
-                    axum::Json(mailbox_server::StoreBlobsResponse { already_stored })
+                    axum::Json(mailbox_server::RegisterHashesResponse { already_stored })
                 },
             ),
         );
@@ -492,7 +492,7 @@ mod tests {
         let base_url = format!("http://{addr}");
 
         let _tracker = std::sync::Arc::new(RecordingTracker::default());
-        let already = crate::toy::send_store_blobs(
+        let already = crate::toy::send_register_hashes(
             &base_url,
             vec![h_stored, h_new],
             iroh::SecretKey::from_bytes(&[3; 32]).public(),
@@ -600,10 +600,10 @@ mod tests {
                 }),
             )
             .route(
-                "/blobs/store",
+                "/blobs/register-hashes",
                 axum::routing::post(
-                    |axum::Json(_req): axum::Json<mailbox_server::StoreBlobsRequest>| async move {
-                        axum::Json(mailbox_server::StoreBlobsResponse {
+                    |axum::Json(_req): axum::Json<mailbox_server::RegisterHashesRequest>| async move {
+                        axum::Json(mailbox_server::RegisterHashesResponse {
                             already_stored: Vec::new(),
                         })
                     },

--- a/crates/mailbox-client/src/toy.rs
+++ b/crates/mailbox-client/src/toy.rs
@@ -16,36 +16,30 @@ use super::*;
 pub trait ToyItemTraits: ItemTraits + Serialize + DeserializeOwned {}
 impl<T> ToyItemTraits for T where T: ItemTraits + Serialize + DeserializeOwned {}
 
-/// Client-side timeout for a `/blobs/store` request that carries blob bytes
-/// inline; larger than the default HTTP timeout because the upload can be big.
-const STORE_BLOBS_WITH_BYTES_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+/// Client-side timeout for a single blob upload, larger than the default HTTP
+/// timeout because a blob can be big.
+const UPLOAD_BLOB_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
-/// POST blob hashes (and optionally the blob bytes themselves) to a mailbox's
-/// `/blobs/store`, returning the subset the mailbox reports it already has
-/// stored. When `blobs` is `Some`, a longer per-request timeout is applied.
+/// POST blob hashes to a mailbox's `/blobs/store`, returning the subset the
+/// mailbox reports it already has stored.
 pub async fn send_store_blobs(
     base_url: &str,
-    blobs: Option<Vec<bytes::Bytes>>,
     hashes: Vec<iroh_blobs::Hash>,
     sender_pubkey: iroh::EndpointId,
 ) -> anyhow::Result<Vec<iroh_blobs::Hash>> {
     if hashes.is_empty() {
         return Ok(Vec::new());
     }
-    let has_blobs = blobs.is_some();
     let request = mailbox_server::StoreBlobsRequest {
-        blobs,
         blob_hashes: hashes,
         sender_pubkey,
         signature: Vec::new(),
     };
-    let mut builder = HTTP_CLIENT
+    let response = HTTP_CLIENT
         .post(format!("{base_url}/blobs/store"))
-        .json(&request);
-    if has_blobs {
-        builder = builder.timeout(STORE_BLOBS_WITH_BYTES_TIMEOUT);
-    }
-    let response = builder.send().await?;
+        .json(&request)
+        .send()
+        .await?;
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
@@ -53,6 +47,24 @@ pub async fn send_store_blobs(
     }
     let response: mailbox_server::StoreBlobsResponse = response.json().await?;
     Ok(response.already_stored)
+}
+
+/// POST a single blob's raw bytes to a mailbox's `/blobs/upload`. The body is the
+/// bytes themselves — no JSON/base64 wrapping — so the on-wire size matches the
+/// blob.
+async fn upload_blob(base_url: &str, bytes: bytes::Bytes) -> anyhow::Result<()> {
+    let response = HTTP_CLIENT
+        .post(format!("{base_url}/blobs/upload"))
+        .timeout(UPLOAD_BLOB_TIMEOUT)
+        .body(bytes)
+        .send()
+        .await?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("Failed to upload blob: {status} - {body}");
+    }
+    Ok(())
 }
 
 /// A client for the toy mailbox server.
@@ -83,9 +95,9 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
         }
     }
 
-    /// Attach a blob-bytes source so `publish` uploads blob bytes inline to the
-    /// mailbox (falling back to announcing hashes only on timeout). Without a
-    /// reader the client only announces hashes and the mailbox fetches them.
+    /// Attach a blob-bytes source so `publish` pushes blob bytes straight to the
+    /// mailbox (best-effort) before announcing their hashes. Without a reader the
+    /// client only announces hashes and the mailbox fetches the bytes from us.
     pub fn with_blob_reader(
         mut self,
         blob_reader: std::sync::Arc<dyn crate::BlobReader>,
@@ -94,13 +106,18 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
         self
     }
 
-    /// Announce blob hashes to this mailbox and reconcile the unfetched tracker:
-    /// record hashes the mailbox still needs, remove any it already has.
+    /// Push blob bytes to the mailbox immediately (best-effort), then announce
+    /// their hashes and reconcile the unfetched tracker: record hashes the
+    /// mailbox still needs, remove any it already has. The announce always runs,
+    /// so any blob that failed to upload is still fetched by the mailbox and
+    /// retried by the followup task.
     async fn store_blobs(&self, hashes: Vec<iroh_blobs::Hash>) -> anyhow::Result<()> {
         if hashes.is_empty() {
             return Ok(());
         }
-        let already_stored = self.upload_blobs(hashes.clone()).await?;
+        self.upload_blobs(&hashes).await;
+        let already_stored =
+            send_store_blobs(&self.base_url, hashes.clone(), self.sender_pubkey).await?;
         let not_stored: Vec<_> = hashes
             .into_iter()
             .filter(|h| !already_stored.contains(h))
@@ -110,53 +127,28 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
         Ok(())
     }
 
-    /// Upload blob bytes inline (with a 15s timeout) when a blob reader is
-    /// available; if that upload times out — or no reader is configured — send
-    /// the hashes alone so the mailbox fetches the blobs from us instead.
-    async fn upload_blobs(
-        &self,
-        hashes: Vec<iroh_blobs::Hash>,
-    ) -> anyhow::Result<Vec<iroh_blobs::Hash>> {
-        if let Some(blobs) = self.read_blobs(&hashes).await {
-            match send_store_blobs(&self.base_url, Some(blobs), hashes.clone(), self.sender_pubkey)
-                .await
-            {
-                Ok(already_stored) => return Ok(already_stored),
-                Err(err) if is_timeout(&err) => {
-                    tracing::warn!(
-                        "store_blobs with inline bytes timed out; retrying with hashes only"
-                    );
-                }
-                Err(err) => return Err(err),
-            }
-        }
-        send_store_blobs(&self.base_url, None, hashes, self.sender_pubkey).await
-    }
-
-    /// Read every blob's bytes from the configured reader, returning `None` (so
-    /// the caller announces hashes only) when there is no reader or any read
-    /// fails.
-    async fn read_blobs(&self, hashes: &[iroh_blobs::Hash]) -> Option<Vec<bytes::Bytes>> {
-        let reader = self.blob_reader.as_ref()?;
-        let mut blobs = Vec::with_capacity(hashes.len());
+    /// Best-effort: read each blob from the configured reader and upload its
+    /// bytes to the mailbox, one at a time (so at most one blob is held in
+    /// memory). Logs and continues past any read or upload error — the caller's
+    /// announce is the source of truth, so a missed upload just means the mailbox
+    /// fetches that blob instead. No-op when no reader is configured.
+    async fn upload_blobs(&self, hashes: &[iroh_blobs::Hash]) {
+        let Some(reader) = self.blob_reader.as_ref() else {
+            return;
+        };
         for hash in hashes {
-            match reader.read_blob(*hash).await {
-                Ok(bytes) => blobs.push(bytes),
+            let bytes = match reader.read_blob(*hash).await {
+                Ok(bytes) => bytes,
                 Err(err) => {
-                    tracing::warn!(%hash, ?err, "failed to read blob bytes; announcing hashes only");
-                    return None;
+                    tracing::warn!(%hash, ?err, "failed to read blob for upload; relying on announce");
+                    continue;
                 }
+            };
+            if let Err(err) = upload_blob(&self.base_url, bytes).await {
+                tracing::warn!(%hash, ?err, "blob upload failed; relying on announce");
             }
         }
-        Some(blobs)
     }
-}
-
-/// True when the error was caused by a request timeout, so the caller can retry
-/// via a different path rather than surfacing the failure.
-fn is_timeout(err: &anyhow::Error) -> bool {
-    err.downcast_ref::<reqwest::Error>()
-        .is_some_and(|e| e.is_timeout())
 }
 
 #[async_trait::async_trait]
@@ -435,10 +427,9 @@ mod tests {
         });
         let base_url = format!("http://{addr}");
 
-        let tracker = std::sync::Arc::new(RecordingTracker::default());
+        let _tracker = std::sync::Arc::new(RecordingTracker::default());
         let already = crate::toy::send_store_blobs(
             &base_url,
-            None,
             vec![h_stored, h_new],
             iroh::SecretKey::from_bytes(&[3; 32]).public(),
         )
@@ -448,25 +439,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn store_blobs_sends_inline_bytes_and_reports_them_stored() {
-        // Server that hashes each inline blob it receives and reports those
-        // hashes as already stored (mirroring the real mailbox behavior).
+    async fn upload_blob_posts_raw_bytes() {
+        use std::sync::{Arc, Mutex};
+
+        // Server that records the raw body it received and echoes back its hash.
+        let received: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let received_in_handler = received.clone();
         let app = axum::Router::new().route(
-            "/blobs/store",
-            axum::routing::post(
-                |axum::Json(req): axum::Json<mailbox_server::StoreBlobsRequest>| async move {
-                    let stored: Vec<_> = req
-                        .blobs
-                        .unwrap_or_default()
-                        .iter()
-                        .map(iroh_blobs::Hash::new)
-                        .filter(|h| req.blob_hashes.contains(h))
-                        .collect();
-                    axum::Json(mailbox_server::StoreBlobsResponse {
-                        already_stored: stored,
-                    })
-                },
-            ),
+            "/blobs/upload",
+            axum::routing::post(move |body: axum::body::Bytes| {
+                let received_in_handler = received_in_handler.clone();
+                async move {
+                    let hash = iroh_blobs::Hash::new(&body);
+                    *received_in_handler.lock().unwrap() = body.to_vec();
+                    axum::Json(mailbox_server::UploadBlobResponse { hash })
+                }
+            }),
         );
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -475,16 +463,75 @@ mod tests {
         });
         let base_url = format!("http://{addr}");
 
-        let data = bytes::Bytes::from_static(b"inline blob");
+        let data = bytes::Bytes::from_static(b"raw blob bytes");
+        crate::toy::upload_blob(&base_url, data.clone())
+            .await
+            .unwrap();
+        assert_eq!(*received.lock().unwrap(), data.to_vec());
+    }
+
+    #[tokio::test]
+    async fn store_blobs_uploads_bytes_then_announces() {
+        use std::sync::{Arc, Mutex};
+
+        struct StubReader(bytes::Bytes);
+        #[async_trait::async_trait]
+        impl crate::BlobReader for StubReader {
+            async fn read_blob(&self, _hash: iroh_blobs::Hash) -> anyhow::Result<bytes::Bytes> {
+                Ok(self.0.clone())
+            }
+        }
+
+        let data = bytes::Bytes::from_static(b"a blob");
         let hash = iroh_blobs::Hash::new(&data);
-        let already = crate::toy::send_store_blobs(
-            &base_url,
-            Some(vec![data]),
-            vec![hash],
+
+        // `/blobs/upload` records the pushed bytes; once uploaded, `/blobs/store`
+        // reports the announced hash as already stored.
+        let uploaded: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let uploaded_in_handler = uploaded.clone();
+        let uploaded_for_store = uploaded.clone();
+        let app = axum::Router::new()
+            .route(
+                "/blobs/upload",
+                axum::routing::post(move |body: axum::body::Bytes| {
+                    let uploaded_in_handler = uploaded_in_handler.clone();
+                    async move {
+                        let hash = iroh_blobs::Hash::new(&body);
+                        *uploaded_in_handler.lock().unwrap() = body.to_vec();
+                        axum::Json(mailbox_server::UploadBlobResponse { hash })
+                    }
+                }),
+            )
+            .route(
+                "/blobs/store",
+                axum::routing::post(
+                    move |axum::Json(req): axum::Json<mailbox_server::StoreBlobsRequest>| async move {
+                        let has_upload = !uploaded_for_store.lock().unwrap().is_empty();
+                        let already_stored = if has_upload {
+                            req.blob_hashes
+                        } else {
+                            Vec::new()
+                        };
+                        axum::Json(mailbox_server::StoreBlobsResponse { already_stored })
+                    },
+                ),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let base_url = format!("http://{addr}");
+
+        let client = ToyMailboxClient::<crate::testing::Msg>::new(
+            "mbx".to_string(),
+            base_url,
             iroh::SecretKey::from_bytes(&[3; 32]).public(),
+            std::sync::Arc::new(crate::NoopUnfetchedBlobTracker),
         )
-        .await
-        .unwrap();
-        assert_eq!(already, vec![hash]);
+        .with_blob_reader(std::sync::Arc::new(StubReader(data.clone())));
+
+        client.store_blobs(vec![hash]).await.unwrap();
+        assert_eq!(*uploaded.lock().unwrap(), data.to_vec());
     }
 }

--- a/crates/mailbox-client/src/toy.rs
+++ b/crates/mailbox-client/src/toy.rs
@@ -16,26 +16,36 @@ use super::*;
 pub trait ToyItemTraits: ItemTraits + Serialize + DeserializeOwned {}
 impl<T> ToyItemTraits for T where T: ItemTraits + Serialize + DeserializeOwned {}
 
-/// POST blob hashes to a mailbox's `/blobs/store`, returning the subset the
-/// mailbox reports it already has stored.
+/// Client-side timeout for a `/blobs/store` request that carries blob bytes
+/// inline; larger than the default HTTP timeout because the upload can be big.
+const STORE_BLOBS_WITH_BYTES_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// POST blob hashes (and optionally the blob bytes themselves) to a mailbox's
+/// `/blobs/store`, returning the subset the mailbox reports it already has
+/// stored. When `blobs` is `Some`, a longer per-request timeout is applied.
 pub async fn send_store_blobs(
     base_url: &str,
+    blobs: Option<Vec<bytes::Bytes>>,
     hashes: Vec<iroh_blobs::Hash>,
     sender_pubkey: iroh::EndpointId,
 ) -> anyhow::Result<Vec<iroh_blobs::Hash>> {
     if hashes.is_empty() {
         return Ok(Vec::new());
     }
+    let has_blobs = blobs.is_some();
     let request = mailbox_server::StoreBlobsRequest {
+        blobs,
         blob_hashes: hashes,
         sender_pubkey,
         signature: Vec::new(),
     };
-    let response = HTTP_CLIENT
+    let mut builder = HTTP_CLIENT
         .post(format!("{base_url}/blobs/store"))
-        .json(&request)
-        .send()
-        .await?;
+        .json(&request);
+    if has_blobs {
+        builder = builder.timeout(STORE_BLOBS_WITH_BYTES_TIMEOUT);
+    }
+    let response = builder.send().await?;
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
@@ -52,6 +62,7 @@ pub struct ToyMailboxClient<Item: MailboxItem> {
     base_url: String,
     sender_pubkey: iroh::EndpointId,
     tracker: std::sync::Arc<dyn crate::UnfetchedBlobTracker>,
+    blob_reader: Option<std::sync::Arc<dyn crate::BlobReader>>,
     phantom: std::marker::PhantomData<Item>,
 }
 
@@ -67,8 +78,20 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
             base_url: base_url.into(),
             sender_pubkey,
             tracker,
+            blob_reader: None,
             phantom: std::marker::PhantomData,
         }
+    }
+
+    /// Attach a blob-bytes source so `publish` uploads blob bytes inline to the
+    /// mailbox (falling back to announcing hashes only on timeout). Without a
+    /// reader the client only announces hashes and the mailbox fetches them.
+    pub fn with_blob_reader(
+        mut self,
+        blob_reader: std::sync::Arc<dyn crate::BlobReader>,
+    ) -> Self {
+        self.blob_reader = Some(blob_reader);
+        self
     }
 
     /// Announce blob hashes to this mailbox and reconcile the unfetched tracker:
@@ -77,8 +100,7 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
         if hashes.is_empty() {
             return Ok(());
         }
-        let already_stored =
-            send_store_blobs(&self.base_url, hashes.clone(), self.sender_pubkey).await?;
+        let already_stored = self.upload_blobs(hashes.clone()).await?;
         let not_stored: Vec<_> = hashes
             .into_iter()
             .filter(|h| !already_stored.contains(h))
@@ -87,6 +109,54 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
         self.tracker.remove(&self.id, &already_stored).await;
         Ok(())
     }
+
+    /// Upload blob bytes inline (with a 15s timeout) when a blob reader is
+    /// available; if that upload times out — or no reader is configured — send
+    /// the hashes alone so the mailbox fetches the blobs from us instead.
+    async fn upload_blobs(
+        &self,
+        hashes: Vec<iroh_blobs::Hash>,
+    ) -> anyhow::Result<Vec<iroh_blobs::Hash>> {
+        if let Some(blobs) = self.read_blobs(&hashes).await {
+            match send_store_blobs(&self.base_url, Some(blobs), hashes.clone(), self.sender_pubkey)
+                .await
+            {
+                Ok(already_stored) => return Ok(already_stored),
+                Err(err) if is_timeout(&err) => {
+                    tracing::warn!(
+                        "store_blobs with inline bytes timed out; retrying with hashes only"
+                    );
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        send_store_blobs(&self.base_url, None, hashes, self.sender_pubkey).await
+    }
+
+    /// Read every blob's bytes from the configured reader, returning `None` (so
+    /// the caller announces hashes only) when there is no reader or any read
+    /// fails.
+    async fn read_blobs(&self, hashes: &[iroh_blobs::Hash]) -> Option<Vec<bytes::Bytes>> {
+        let reader = self.blob_reader.as_ref()?;
+        let mut blobs = Vec::with_capacity(hashes.len());
+        for hash in hashes {
+            match reader.read_blob(*hash).await {
+                Ok(bytes) => blobs.push(bytes),
+                Err(err) => {
+                    tracing::warn!(%hash, ?err, "failed to read blob bytes; announcing hashes only");
+                    return None;
+                }
+            }
+        }
+        Some(blobs)
+    }
+}
+
+/// True when the error was caused by a request timeout, so the caller can retry
+/// via a different path rather than surfacing the failure.
+fn is_timeout(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<reqwest::Error>()
+        .is_some_and(|e| e.is_timeout())
 }
 
 #[async_trait::async_trait]
@@ -368,11 +438,53 @@ mod tests {
         let tracker = std::sync::Arc::new(RecordingTracker::default());
         let already = crate::toy::send_store_blobs(
             &base_url,
+            None,
             vec![h_stored, h_new],
             iroh::SecretKey::from_bytes(&[3; 32]).public(),
         )
         .await
         .unwrap();
         assert_eq!(already, vec![h_stored]);
+    }
+
+    #[tokio::test]
+    async fn store_blobs_sends_inline_bytes_and_reports_them_stored() {
+        // Server that hashes each inline blob it receives and reports those
+        // hashes as already stored (mirroring the real mailbox behavior).
+        let app = axum::Router::new().route(
+            "/blobs/store",
+            axum::routing::post(
+                |axum::Json(req): axum::Json<mailbox_server::StoreBlobsRequest>| async move {
+                    let stored: Vec<_> = req
+                        .blobs
+                        .unwrap_or_default()
+                        .iter()
+                        .map(iroh_blobs::Hash::new)
+                        .filter(|h| req.blob_hashes.contains(h))
+                        .collect();
+                    axum::Json(mailbox_server::StoreBlobsResponse {
+                        already_stored: stored,
+                    })
+                },
+            ),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let base_url = format!("http://{addr}");
+
+        let data = bytes::Bytes::from_static(b"inline blob");
+        let hash = iroh_blobs::Hash::new(&data);
+        let already = crate::toy::send_store_blobs(
+            &base_url,
+            Some(vec![data]),
+            vec![hash],
+            iroh::SecretKey::from_bytes(&[3; 32]).public(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(already, vec![hash]);
     }
 }

--- a/crates/mailbox-client/src/toy.rs
+++ b/crates/mailbox-client/src/toy.rs
@@ -16,11 +16,8 @@ use super::*;
 pub trait ToyItemTraits: ItemTraits + Serialize + DeserializeOwned {}
 impl<T> ToyItemTraits for T where T: ItemTraits + Serialize + DeserializeOwned {}
 
-/// Fixed grace window for the inline-upload path, larger than the default HTTP
-/// timeout because a blob can be big. It serves two roles: the per-request
-/// upload timeout, and the `upload_grace` the client sends to `/blobs/store` so
-/// the mailbox defers its fetch backstop by the same window. Kept a constant but
-/// still sent as a request parameter so a slower client could raise it.
+/// Client-side timeout for a single blob upload, larger than the default HTTP
+/// timeout because a blob can be big.
 const UPLOAD_BLOB_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
 /// Why a single blob upload attempt didn't succeed, so the caller can tell an
@@ -49,15 +46,13 @@ fn classify_upload_error(err: reqwest::Error) -> UploadError {
 }
 
 /// POST blob hashes to a mailbox's `/blobs/store`, returning the subset the
-/// mailbox reports it already has stored. Pass `upload_grace` (the fixed grace
-/// window) when the caller will stream the bytes to `/blobs/upload` right after,
-/// so the mailbox defers fetching them by exactly that window; pass `None` to
-/// have the mailbox fetch immediately.
+/// mailbox reports it already has stored. The mailbox registers every other hash
+/// in its fetch pool, deferred by its own fixed grace window so a concurrent
+/// upload of the same bytes can land first without a duplicate transfer.
 pub async fn send_store_blobs(
     base_url: &str,
     hashes: Vec<iroh_blobs::Hash>,
     sender_pubkey: iroh::EndpointId,
-    upload_grace: Option<std::time::Duration>,
 ) -> anyhow::Result<Vec<iroh_blobs::Hash>> {
     if hashes.is_empty() {
         return Ok(Vec::new());
@@ -65,7 +60,6 @@ pub async fn send_store_blobs(
     let request = mailbox_server::StoreBlobsRequest {
         blob_hashes: hashes,
         sender_pubkey,
-        upload_grace,
         signature: Vec::new(),
     };
     let response = HTTP_CLIENT
@@ -153,17 +147,8 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
         if hashes.is_empty() {
             return Ok(());
         }
-        // Send the fixed grace window only when we can actually stream the bytes,
-        // so the mailbox defers its fetch backstop by exactly our window and only
-        // when a push is really coming.
-        let upload_grace = self.blob_reader.is_some().then_some(UPLOAD_BLOB_TIMEOUT);
-        let already_stored = send_store_blobs(
-            &self.base_url,
-            hashes.clone(),
-            self.sender_pubkey,
-            upload_grace,
-        )
-        .await?;
+        let already_stored =
+            send_store_blobs(&self.base_url, hashes.clone(), self.sender_pubkey).await?;
         let not_stored: Vec<_> = hashes
             .into_iter()
             .filter(|h| !already_stored.contains(h))
@@ -498,7 +483,6 @@ mod tests {
             &base_url,
             vec![h_stored, h_new],
             iroh::SecretKey::from_bytes(&[3; 32]).public(),
-            None,
         )
         .await
         .unwrap();

--- a/crates/mailbox-client/src/toy.rs
+++ b/crates/mailbox-client/src/toy.rs
@@ -98,10 +98,7 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
     /// Attach a blob-bytes source so `publish` pushes blob bytes straight to the
     /// mailbox (best-effort) before announcing their hashes. Without a reader the
     /// client only announces hashes and the mailbox fetches the bytes from us.
-    pub fn with_blob_reader(
-        mut self,
-        blob_reader: std::sync::Arc<dyn crate::BlobReader>,
-    ) -> Self {
+    pub fn with_blob_reader(mut self, blob_reader: std::sync::Arc<dyn crate::BlobReader>) -> Self {
         self.blob_reader = Some(blob_reader);
         self
     }

--- a/crates/mailbox-client/src/toy.rs
+++ b/crates/mailbox-client/src/toy.rs
@@ -46,13 +46,16 @@ fn classify_upload_error(err: reqwest::Error) -> UploadError {
 }
 
 /// POST blob hashes to a mailbox's `/blobs/store`, returning the subset the
-/// mailbox reports it already has stored. The mailbox registers every other hash
-/// in its fetch pool, deferred by its own fixed grace window so a concurrent
-/// upload of the same bytes can land first without a duplicate transfer.
+/// mailbox reports it already has stored. Set `expect_upload` when the caller
+/// will stream the bytes to `/blobs/upload` right after, so the mailbox defers
+/// its fetch backstop by its own fixed grace window and lets that upload land
+/// first without a duplicate transfer; pass `false` to have the mailbox fetch
+/// immediately (no upload is coming).
 pub async fn send_store_blobs(
     base_url: &str,
     hashes: Vec<iroh_blobs::Hash>,
     sender_pubkey: iroh::EndpointId,
+    expect_upload: bool,
 ) -> anyhow::Result<Vec<iroh_blobs::Hash>> {
     if hashes.is_empty() {
         return Ok(Vec::new());
@@ -60,6 +63,7 @@ pub async fn send_store_blobs(
     let request = mailbox_server::StoreBlobsRequest {
         blob_hashes: hashes,
         sender_pubkey,
+        expect_upload,
         signature: Vec::new(),
     };
     let response = HTTP_CLIENT
@@ -147,8 +151,17 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
         if hashes.is_empty() {
             return Ok(());
         }
-        let already_stored =
-            send_store_blobs(&self.base_url, hashes.clone(), self.sender_pubkey).await?;
+        // Tell the mailbox to defer its fetch backstop only when we can actually
+        // stream the bytes; a reader-less client never uploads, so the mailbox
+        // should fetch from us right away.
+        let expect_upload = self.blob_reader.is_some();
+        let already_stored = send_store_blobs(
+            &self.base_url,
+            hashes.clone(),
+            self.sender_pubkey,
+            expect_upload,
+        )
+        .await?;
         let not_stored: Vec<_> = hashes
             .into_iter()
             .filter(|h| !already_stored.contains(h))
@@ -483,6 +496,7 @@ mod tests {
             &base_url,
             vec![h_stored, h_new],
             iroh::SecretKey::from_bytes(&[3; 32]).public(),
+            false,
         )
         .await
         .unwrap();

--- a/crates/mailbox-client/src/toy.rs
+++ b/crates/mailbox-client/src/toy.rs
@@ -21,11 +21,15 @@ impl<T> ToyItemTraits for T where T: ItemTraits + Serialize + DeserializeOwned {
 const UPLOAD_BLOB_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
 /// POST blob hashes to a mailbox's `/blobs/store`, returning the subset the
-/// mailbox reports it already has stored.
+/// mailbox reports it already has stored. Pass `upload_grace` (the caller's
+/// upload timeout) when the caller will stream the bytes to `/blobs/upload` right
+/// after, so the mailbox defers fetching them by exactly that window; pass `None`
+/// to have the mailbox fetch immediately.
 pub async fn send_store_blobs(
     base_url: &str,
     hashes: Vec<iroh_blobs::Hash>,
     sender_pubkey: iroh::EndpointId,
+    upload_grace: Option<std::time::Duration>,
 ) -> anyhow::Result<Vec<iroh_blobs::Hash>> {
     if hashes.is_empty() {
         return Ok(Vec::new());
@@ -33,6 +37,7 @@ pub async fn send_store_blobs(
     let request = mailbox_server::StoreBlobsRequest {
         blob_hashes: hashes,
         sender_pubkey,
+        upload_grace,
         signature: Vec::new(),
     };
     let response = HTTP_CLIENT
@@ -117,8 +122,13 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
         if hashes.is_empty() {
             return Ok(());
         }
+        // Send our upload timeout as the grace only when we can actually stream
+        // the bytes, so the mailbox defers fetching by exactly our window and
+        // only when a push is really coming.
+        let upload_grace = self.blob_reader.is_some().then_some(UPLOAD_BLOB_TIMEOUT);
         let already_stored =
-            send_store_blobs(&self.base_url, hashes.clone(), self.sender_pubkey).await?;
+            send_store_blobs(&self.base_url, hashes.clone(), self.sender_pubkey, upload_grace)
+                .await?;
         let not_stored: Vec<_> = hashes
             .into_iter()
             .filter(|h| !already_stored.contains(h))
@@ -446,6 +456,7 @@ mod tests {
             &base_url,
             vec![h_stored, h_new],
             iroh::SecretKey::from_bytes(&[3; 32]).public(),
+            None,
         )
         .await
         .unwrap();

--- a/crates/mailbox-local-server/src/lib.rs
+++ b/crates/mailbox-local-server/src/lib.rs
@@ -8,6 +8,7 @@
 
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
 
 use iroh::EndpointId;
 use iroh_blobs::api::downloader::Downloader;
@@ -44,12 +45,17 @@ impl LocalMailboxServer {
 /// The returned [`LocalMailboxServer`] is not yet announced on the LAN; pair it
 /// with [`register_mdns_with_retry`] and [`spawn_interface_watcher`] for
 /// discovery.
+///
+/// `upload_grace` overrides how long the mailbox defers dialing a blob's source
+/// after an announce that expects an inline upload; `None` uses the production
+/// default. Tests pass a short window to keep the fetch backstop fast.
 pub async fn spawn_local_mailbox_server(
     db_path: PathBuf,
     blobs: BlobsProtocol,
     downloader: Downloader,
     endpoint: iroh::Endpoint,
     fetch_config: Option<FetchConfig>,
+    upload_grace: Option<Duration>,
     peer_addr_tx: UnboundedSender<iroh::EndpointAddr>,
 ) -> anyhow::Result<LocalMailboxServer> {
     let port = free_port()?;
@@ -57,6 +63,9 @@ pub async fn spawn_local_mailbox_server(
     let mut blob_sync = BlobSync::shared(blobs, downloader, endpoint, peer_addr_tx);
     if let Some(fetch_config) = fetch_config {
         blob_sync = blob_sync.with_fetch_config(fetch_config);
+    }
+    if let Some(upload_grace) = upload_grace {
+        blob_sync = blob_sync.with_upload_grace(upload_grace);
     }
 
     let (stop_signal, stop_signal_rx) = tokio::sync::oneshot::channel::<()>();

--- a/crates/mailbox-server/Cargo.toml
+++ b/crates/mailbox-server/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 axum = { version = "0.8", features = ["json"] }
+bytes = { workspace = true }
 futures = "0.3"
 tokio = { version = "1", features = ["full"] }
 p2panda-net = { workspace = true }

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -307,10 +307,7 @@ impl BlobSync {
     /// blobs are tagged the same way so GC treats them alike. `add_bytes` streams
     /// the data into the store and yields a temp tag; we swap that for a
     /// retention tag before dropping it so the blob is never left untagged.
-    pub async fn store_pushed_blob(
-        &self,
-        data: bytes::Bytes,
-    ) -> anyhow::Result<iroh_blobs::Hash> {
+    pub async fn store_pushed_blob(&self, data: bytes::Bytes) -> anyhow::Result<iroh_blobs::Hash> {
         let temp_tag = self.blobs.add_bytes(data).temp_tag().await?;
         let hash = temp_tag.hash();
         self.protect_blob(hash).await;

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -64,6 +64,15 @@ impl BlobFetchPool {
     ) {
         self.add_source_inner(hash, source, Some(tokio::time::Instant::now() + delay))
             .await;
+        // A deferred entry keeps the pool non-empty, so the fetch loop sleeps a
+        // full `pass_interval` and never wakes on its own when the grace expires.
+        // Nudge it at the grace boundary so the backstop fetch isn't delayed to
+        // the next pass.
+        let added = self.added.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(delay).await;
+            added.notify_one();
+        });
     }
 
     async fn add_source_inner(
@@ -501,5 +510,40 @@ mod tests {
         pool.add_source(hash(1), endpoint_id(1)).await;
         pool.remove(hash(1)).await;
         assert!(pool.is_empty().await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn deferred_entry_is_fetched_at_grace_boundary_not_next_pass() {
+        let pool = BlobFetchPool::default();
+        pool.add_source_after(hash(1), endpoint_id(1), Duration::from_secs(5))
+            .await;
+        let start = tokio::time::Instant::now();
+        let fetched_at: Arc<Mutex<Option<Duration>>> = Arc::new(Mutex::new(None));
+        let handle = {
+            let fetched_at = fetched_at.clone();
+            let config = FetchConfig {
+                concurrency: 1,
+                attempt_timeout: Duration::from_secs(5),
+                pass_interval: Duration::from_secs(60),
+                retry_cooldown: Duration::from_secs(30),
+            };
+            tokio::spawn(fetch_loop(pool.clone(), config, move |_item, _t| {
+                let fetched_at = fetched_at.clone();
+                async move {
+                    *fetched_at.lock().await = Some(start.elapsed());
+                    true
+                }
+            }))
+        };
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        let at = fetched_at
+            .lock()
+            .await
+            .expect("deferred entry should have been fetched");
+        assert!(
+            at >= Duration::from_secs(5) && at < Duration::from_secs(30),
+            "expected fetch at the grace boundary (~5s), got {at:?}"
+        );
+        handle.abort();
     }
 }

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -25,11 +25,11 @@ const BLOB_GC_INTERVAL: Duration = Duration::from_secs(60 * 60);
 const MAX_FETCH_FAILURES: u32 = 10;
 /// Hard cap on pending fetch entries; arbitrary entries are dropped if exceeded.
 const MAX_POOL_SIZE: usize = 1_000;
-/// Upper bound on the grace period a client can request before the mailbox
-/// dials the source for a freshly announced hash. The client sends its own
-/// upload timeout so the two stay in lockstep; this only caps a pathological
-/// value so a client can't defer fetching its own blobs indefinitely.
-pub(crate) const MAX_UPLOAD_GRACE: Duration = Duration::from_secs(60);
+/// Fixed grace period the mailbox waits before dialing the source for a freshly
+/// announced hash, giving a concurrent inline upload of the same blob time to
+/// land first. Applied uniformly to every announce: its purpose is to keep the
+/// mailbox from fetching too soon, not to fetch sooner than the next poll.
+pub(crate) const UPLOAD_GRACE: Duration = Duration::from_secs(60);
 
 #[derive(Default)]
 struct PoolEntry {
@@ -364,24 +364,13 @@ impl BlobSync {
         Ok(hash)
     }
 
-    /// Register `source` as a provider for `hash`. When `grace` is set the fetch
-    /// is deferred by that window (capped at [`MAX_UPLOAD_GRACE`]) so a concurrent
-    /// inline upload of the same blob can land first and make the fetch
-    /// unnecessary; when `None` the hash is fetchable immediately.
-    pub(crate) async fn add_fetch_source(
-        &self,
-        hash: iroh_blobs::Hash,
-        source: iroh::EndpointId,
-        grace: Option<Duration>,
-    ) {
-        match grace {
-            Some(grace) => {
-                self.fetch_pool
-                    .add_source_after(hash, source, grace.min(MAX_UPLOAD_GRACE))
-                    .await
-            }
-            None => self.fetch_pool.add_source(hash, source).await,
-        }
+    /// Register `source` as a provider for `hash`, deferring the fetch by
+    /// [`UPLOAD_GRACE`] so a concurrent inline upload of the same blob can land
+    /// first and make the fetch unnecessary.
+    pub(crate) async fn add_fetch_source(&self, hash: iroh_blobs::Hash, source: iroh::EndpointId) {
+        self.fetch_pool
+            .add_source_after(hash, source, UPLOAD_GRACE)
+            .await
     }
 
     /// Drop `hash` from the fetch pool: the mailbox now holds it (e.g. a client

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -302,6 +302,22 @@ impl BlobSync {
         fetched
     }
 
+    /// Store a blob a client pushed directly (via `/blobs/store`) and protect it
+    /// for the retention window, returning its computed hash. Pushed and fetched
+    /// blobs are tagged the same way so GC treats them alike. `add_bytes` streams
+    /// the data into the store and yields a temp tag; we swap that for a
+    /// retention tag before dropping it so the blob is never left untagged.
+    pub async fn store_pushed_blob(
+        &self,
+        data: bytes::Bytes,
+    ) -> anyhow::Result<iroh_blobs::Hash> {
+        let temp_tag = self.blobs.add_bytes(data).temp_tag().await?;
+        let hash = temp_tag.hash();
+        self.protect_blob(hash).await;
+        drop(temp_tag);
+        Ok(hash)
+    }
+
     /// Tag a freshly stored blob so iroh's GC keeps it; the tag name embeds the
     /// fetch time so [`expire_blob_tags`] can drop it after the retention window.
     /// No-op when sharing an in-process node's store (the node owns lifecycle).

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -25,11 +25,21 @@ const BLOB_GC_INTERVAL: Duration = Duration::from_secs(60 * 60);
 const MAX_FETCH_FAILURES: u32 = 10;
 /// Hard cap on pending fetch entries; arbitrary entries are dropped if exceeded.
 const MAX_POOL_SIZE: usize = 1_000;
+/// Grace period before the fetch pool will dial the source for a freshly
+/// announced hash. A publishing client streams the bytes to `/blobs/upload`
+/// right after announcing, so this window lets that upload land before the
+/// mailbox duplicates the transfer by fetching. Roughly the client's upload
+/// timeout.
+pub(crate) const FETCH_GRACE: Duration = Duration::from_secs(15);
 
 #[derive(Default)]
 struct PoolEntry {
     sources: BTreeSet<iroh::EndpointId>,
     failures: u32,
+    /// Earliest time this entry may be fetched, or `None` to fetch immediately.
+    /// Set when a hash is announced, to give a concurrent inline upload time to
+    /// arrive before the mailbox dials the source.
+    not_before: Option<tokio::time::Instant>,
 }
 
 #[derive(Clone, Default)]
@@ -40,6 +50,29 @@ pub struct BlobFetchPool {
 
 impl BlobFetchPool {
     pub async fn add_source(&self, hash: iroh_blobs::Hash, source: iroh::EndpointId) {
+        self.add_source_inner(hash, source, None).await;
+    }
+
+    /// Like [`add_source`](Self::add_source) but holds off fetching a *newly*
+    /// added hash until `delay` has passed, so a concurrent inline upload of the
+    /// same blob can land first. An already-pending entry keeps its existing
+    /// schedule (a re-announce never pushes a fetch further out).
+    pub(crate) async fn add_source_after(
+        &self,
+        hash: iroh_blobs::Hash,
+        source: iroh::EndpointId,
+        delay: Duration,
+    ) {
+        self.add_source_inner(hash, source, Some(tokio::time::Instant::now() + delay))
+            .await;
+    }
+
+    async fn add_source_inner(
+        &self,
+        hash: iroh_blobs::Hash,
+        source: iroh::EndpointId,
+        not_before: Option<tokio::time::Instant>,
+    ) {
         let mut map = self.entries.lock().await;
         if !map.contains_key(&hash) && map.len() >= MAX_POOL_SIZE {
             // Drop the first (lexicographically earliest) entry to stay within the cap.
@@ -47,7 +80,11 @@ impl BlobFetchPool {
                 map.remove(&oldest);
             }
         }
-        map.entry(hash).or_default().sources.insert(source);
+        let entry = map.entry(hash).or_insert_with(|| PoolEntry {
+            not_before,
+            ..Default::default()
+        });
+        entry.sources.insert(source);
         self.added.notify_one();
     }
 
@@ -59,9 +96,12 @@ impl BlobFetchPool {
         &self,
         tried: &HashSet<iroh_blobs::Hash>,
     ) -> Option<(iroh_blobs::Hash, Vec<iroh::EndpointId>)> {
+        let now = tokio::time::Instant::now();
         let map = self.entries.lock().await;
         map.iter()
-            .find(|(hash, _)| !tried.contains(*hash))
+            .find(|(hash, entry)| {
+                !tried.contains(*hash) && entry.not_before.is_none_or(|t| t <= now)
+            })
             .map(|(hash, entry)| (*hash, entry.sources.iter().copied().collect()))
     }
 
@@ -302,17 +342,37 @@ impl BlobSync {
         fetched
     }
 
-    /// Store a blob a client pushed directly (via `/blobs/store`) and protect it
+    /// Store a blob a client pushed directly (via `/blobs/upload`) and protect it
     /// for the retention window, returning its computed hash. Pushed and fetched
     /// blobs are tagged the same way so GC treats them alike. `add_bytes` streams
-    /// the data into the store and yields a temp tag; we swap that for a
-    /// retention tag before dropping it so the blob is never left untagged.
+    /// the data into the store (although each blob is fully loaded into memory)
+    /// and yields a temp tag; we swap that for a retention tag before dropping
+    /// it so the blob is never left untagged.
     pub async fn store_pushed_blob(&self, data: bytes::Bytes) -> anyhow::Result<iroh_blobs::Hash> {
         let temp_tag = self.blobs.add_bytes(data).temp_tag().await?;
         let hash = temp_tag.hash();
         self.protect_blob(hash).await;
         drop(temp_tag);
         Ok(hash)
+    }
+
+    /// Register `source` as a provider for `hash`, deferring the fetch by
+    /// [`FETCH_GRACE`] so a concurrent inline upload of the same blob can land
+    /// first and make the fetch unnecessary.
+    pub(crate) async fn add_delayed_fetch_source(
+        &self,
+        hash: iroh_blobs::Hash,
+        source: iroh::EndpointId,
+    ) {
+        self.fetch_pool
+            .add_source_after(hash, source, FETCH_GRACE)
+            .await;
+    }
+
+    /// Drop `hash` from the fetch pool: the mailbox now holds it (e.g. a client
+    /// just uploaded it) and no longer needs to fetch it.
+    pub(crate) async fn clear_pending_fetch(&self, hash: iroh_blobs::Hash) {
+        self.fetch_pool.remove(hash).await;
     }
 
     /// Tag a freshly stored blob so iroh's GC keeps it; the tag name embeds the

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -25,11 +25,12 @@ const BLOB_GC_INTERVAL: Duration = Duration::from_secs(60 * 60);
 const MAX_FETCH_FAILURES: u32 = 10;
 /// Hard cap on pending fetch entries; arbitrary entries are dropped if exceeded.
 const MAX_POOL_SIZE: usize = 1_000;
-/// Fixed grace period the mailbox waits before dialing the source for a freshly
-/// announced hash, giving a concurrent inline upload of the same blob time to
-/// land first. Applied uniformly to every announce: its purpose is to keep the
-/// mailbox from fetching too soon, not to fetch sooner than the next poll.
-pub(crate) const UPLOAD_GRACE: Duration = Duration::from_secs(60);
+/// Default grace period the mailbox waits before dialing the source for a hash
+/// announced with an expected upload, giving a concurrent inline upload of the
+/// same blob time to land first. Its purpose is to keep the mailbox from
+/// fetching too soon, not to fetch sooner than the next poll. Overridable per
+/// server via [`BlobSync::with_upload_grace`] (tests use a much shorter window).
+pub const DEFAULT_UPLOAD_GRACE: Duration = Duration::from_secs(60);
 
 #[derive(Default)]
 struct PoolEntry {
@@ -176,6 +177,9 @@ pub struct BlobSync {
     /// of the in-process node's endpoint.
     endpoint: iroh::Endpoint,
     fetch_config: FetchConfig,
+    /// Grace window applied to a hash announced with an expected upload before the
+    /// mailbox dials its source. Defaults to [`DEFAULT_UPLOAD_GRACE`].
+    upload_grace: Duration,
     /// True when this BlobSync owns its blob store (standalone server) and is
     /// therefore responsible for GCing stored blobs. False when sharing an
     /// in-process node's store, where the node owns blob lifecycle.
@@ -244,6 +248,7 @@ impl BlobSync {
             downloader,
             endpoint,
             fetch_config: FetchConfig::default(),
+            upload_grace: DEFAULT_UPLOAD_GRACE,
             enable_gc: true,
             _router: Some(router),
             peer_addr_registry: PeerAddrRegistry::Memory(peer_addr_lookup),
@@ -267,6 +272,7 @@ impl BlobSync {
             downloader,
             endpoint,
             fetch_config: FetchConfig::default(),
+            upload_grace: DEFAULT_UPLOAD_GRACE,
             enable_gc: false,
             _router: None,
             peer_addr_registry: PeerAddrRegistry::Channel(peer_addr_tx),
@@ -277,6 +283,14 @@ impl BlobSync {
     /// interval). Used by `spawn_server` when it spawns the loop.
     pub fn with_fetch_config(mut self, config: FetchConfig) -> Self {
         self.fetch_config = config;
+        self
+    }
+
+    /// Override the grace window applied before dialing the source of a hash
+    /// announced with an expected upload. Tests use a short window to avoid
+    /// waiting out the production [`DEFAULT_UPLOAD_GRACE`].
+    pub fn with_upload_grace(mut self, grace: Duration) -> Self {
+        self.upload_grace = grace;
         self
     }
 
@@ -365,9 +379,9 @@ impl BlobSync {
     }
 
     /// Register `source` as a provider for `hash`. When `expect_upload` is set the
-    /// fetch is deferred by [`UPLOAD_GRACE`] so a concurrent inline upload of the
-    /// same blob can land first and make the fetch unnecessary; otherwise the hash
-    /// is fetchable immediately (no upload is coming).
+    /// fetch is deferred by this server's `upload_grace` so a concurrent inline
+    /// upload of the same blob can land first and make the fetch unnecessary;
+    /// otherwise the hash is fetchable immediately (no upload is coming).
     pub(crate) async fn add_fetch_source(
         &self,
         hash: iroh_blobs::Hash,
@@ -376,7 +390,7 @@ impl BlobSync {
     ) {
         if expect_upload {
             self.fetch_pool
-                .add_source_after(hash, source, UPLOAD_GRACE)
+                .add_source_after(hash, source, self.upload_grace)
                 .await
         } else {
             self.fetch_pool.add_source(hash, source).await

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -364,13 +364,23 @@ impl BlobSync {
         Ok(hash)
     }
 
-    /// Register `source` as a provider for `hash`, deferring the fetch by
-    /// [`UPLOAD_GRACE`] so a concurrent inline upload of the same blob can land
-    /// first and make the fetch unnecessary.
-    pub(crate) async fn add_fetch_source(&self, hash: iroh_blobs::Hash, source: iroh::EndpointId) {
-        self.fetch_pool
-            .add_source_after(hash, source, UPLOAD_GRACE)
-            .await
+    /// Register `source` as a provider for `hash`. When `expect_upload` is set the
+    /// fetch is deferred by [`UPLOAD_GRACE`] so a concurrent inline upload of the
+    /// same blob can land first and make the fetch unnecessary; otherwise the hash
+    /// is fetchable immediately (no upload is coming).
+    pub(crate) async fn add_fetch_source(
+        &self,
+        hash: iroh_blobs::Hash,
+        source: iroh::EndpointId,
+        expect_upload: bool,
+    ) {
+        if expect_upload {
+            self.fetch_pool
+                .add_source_after(hash, source, UPLOAD_GRACE)
+                .await
+        } else {
+            self.fetch_pool.add_source(hash, source).await
+        }
     }
 
     /// Drop `hash` from the fetch pool: the mailbox now holds it (e.g. a client

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -118,6 +118,42 @@ impl BlobFetchPool {
         self.entries.lock().await.remove(&hash);
     }
 
+    /// Record that a client uploaded `hash`, then push out the grace window for
+    /// that sender's other still-deferred fetches. Removes `hash` (the mailbox
+    /// now holds it) and, for every remaining entry that shares a source with it
+    /// and whose `not_before` is still in the future, resets `not_before` to a
+    /// fresh `grace` from now — steady upload progress keeps the mailbox from
+    /// racing the client into a duplicate fetch of a sibling in the same batch.
+    /// Entries whose grace has already elapsed are never touched.
+    pub(crate) async fn note_upload(&self, hash: iroh_blobs::Hash, grace: Duration) {
+        let now = tokio::time::Instant::now();
+        let deadline = now + grace;
+        let mut bumped = false;
+        {
+            let mut map = self.entries.lock().await;
+            let Some(uploaded) = map.remove(&hash) else {
+                return;
+            };
+            let senders = uploaded.sources;
+            for entry in map.values_mut() {
+                let deferred = entry.not_before.is_some_and(|t| t > now);
+                if deferred && !entry.sources.is_disjoint(&senders) {
+                    entry.not_before = Some(deadline);
+                    bumped = true;
+                }
+            }
+        }
+        // A bumped entry sits past any nudge an earlier announce scheduled, so
+        // wake the fetch loop at the new boundary (see `add_source_after`).
+        if bumped {
+            let added = self.added.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(grace).await;
+                added.notify_one();
+            });
+        }
+    }
+
     /// Record a failed fetch attempt; evict the entry after [`MAX_FETCH_FAILURES`].
     pub(crate) async fn record_failure(&self, hash: iroh_blobs::Hash) {
         let mut map = self.entries.lock().await;
@@ -397,10 +433,11 @@ impl BlobSync {
         }
     }
 
-    /// Drop `hash` from the fetch pool: the mailbox now holds it (e.g. a client
-    /// just uploaded it) and no longer needs to fetch it.
-    pub(crate) async fn clear_pending_fetch(&self, hash: iroh_blobs::Hash) {
-        self.fetch_pool.remove(hash).await;
+    /// A client just uploaded `hash` via `/blobs/upload`. Drop it from the fetch
+    /// pool (the mailbox now holds it) and push out the grace window for the
+    /// sender's other still-deferred fetches (see [`BlobFetchPool::note_upload`]).
+    pub(crate) async fn note_upload(&self, hash: iroh_blobs::Hash) {
+        self.fetch_pool.note_upload(hash, self.upload_grace).await;
     }
 
     /// Tag a freshly stored blob so iroh's GC keeps it; the tag name embeds the
@@ -523,6 +560,67 @@ mod tests {
         pool.add_source(hash(1), endpoint_id(1)).await;
         pool.remove(hash(1)).await;
         assert!(pool.is_empty().await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn upload_pushes_out_grace_for_same_sender_siblings() {
+        let pool = BlobFetchPool::default();
+        let grace = Duration::from_secs(10);
+        let sender = endpoint_id(1);
+        let other = endpoint_id(2);
+
+        // Sender S announces A and B (uploads expected); a different sender
+        // announces D. All three defer their fetch by the grace window.
+        pool.add_source_after(hash(1), sender, grace).await; // A
+        pool.add_source_after(hash(2), sender, grace).await; // B
+        pool.add_source_after(hash(4), other, grace).await; // D
+
+        // Halfway through the window, S's upload of A lands.
+        tokio::time::advance(grace / 2).await;
+        pool.note_upload(hash(1), grace).await;
+
+        // Just past the ORIGINAL deadline: D (different sender) is fetchable, but
+        // B was pushed out to a fresh grace and is still deferred.
+        tokio::time::advance(grace / 2 + Duration::from_secs(1)).await;
+        let (h, _) = pool.next_untried(&HashSet::new()).await.unwrap();
+        assert_eq!(
+            h,
+            hash(4),
+            "different-sender entry keeps its original deadline"
+        );
+        pool.remove(hash(4)).await;
+        assert!(
+            pool.next_untried(&HashSet::new()).await.is_none(),
+            "same-sender sibling should still be deferred after the bump"
+        );
+
+        // Past the bumped deadline, B finally becomes fetchable.
+        tokio::time::advance(grace).await;
+        let (h, _) = pool.next_untried(&HashSet::new()).await.unwrap();
+        assert_eq!(h, hash(2));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn upload_does_not_revive_already_elapsed_grace() {
+        let pool = BlobFetchPool::default();
+        let grace = Duration::from_secs(10);
+        let sender = endpoint_id(1);
+
+        pool.add_source_after(hash(1), sender, grace).await; // A, will be uploaded
+        pool.add_source_after(hash(2), sender, grace).await; // B, grace elapses
+
+        // Let the whole window elapse so B is already fetchable.
+        tokio::time::advance(grace + Duration::from_secs(1)).await;
+        assert!(pool.next_untried(&HashSet::new()).await.is_some());
+
+        // A late upload of A must not push B's already-elapsed deadline back out.
+        pool.note_upload(hash(1), grace).await;
+        let (h, _) = pool.next_untried(&HashSet::new()).await.unwrap();
+        assert_eq!(
+            h,
+            hash(2),
+            "elapsed entry must remain immediately fetchable"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -25,12 +25,11 @@ const BLOB_GC_INTERVAL: Duration = Duration::from_secs(60 * 60);
 const MAX_FETCH_FAILURES: u32 = 10;
 /// Hard cap on pending fetch entries; arbitrary entries are dropped if exceeded.
 const MAX_POOL_SIZE: usize = 1_000;
-/// Grace period before the fetch pool will dial the source for a freshly
-/// announced hash. A publishing client streams the bytes to `/blobs/upload`
-/// right after announcing, so this window lets that upload land before the
-/// mailbox duplicates the transfer by fetching. Roughly the client's upload
-/// timeout.
-pub(crate) const FETCH_GRACE: Duration = Duration::from_secs(15);
+/// Upper bound on the grace period a client can request before the mailbox
+/// dials the source for a freshly announced hash. The client sends its own
+/// upload timeout so the two stay in lockstep; this only caps a pathological
+/// value so a client can't defer fetching its own blobs indefinitely.
+pub(crate) const MAX_UPLOAD_GRACE: Duration = Duration::from_secs(60);
 
 #[derive(Default)]
 struct PoolEntry {
@@ -356,17 +355,24 @@ impl BlobSync {
         Ok(hash)
     }
 
-    /// Register `source` as a provider for `hash`, deferring the fetch by
-    /// [`FETCH_GRACE`] so a concurrent inline upload of the same blob can land
-    /// first and make the fetch unnecessary.
-    pub(crate) async fn add_delayed_fetch_source(
+    /// Register `source` as a provider for `hash`. When `grace` is set the fetch
+    /// is deferred by that window (capped at [`MAX_UPLOAD_GRACE`]) so a concurrent
+    /// inline upload of the same blob can land first and make the fetch
+    /// unnecessary; when `None` the hash is fetchable immediately.
+    pub(crate) async fn add_fetch_source(
         &self,
         hash: iroh_blobs::Hash,
         source: iroh::EndpointId,
+        grace: Option<Duration>,
     ) {
-        self.fetch_pool
-            .add_source_after(hash, source, FETCH_GRACE)
-            .await;
+        match grace {
+            Some(grace) => {
+                self.fetch_pool
+                    .add_source_after(hash, source, grace.min(MAX_UPLOAD_GRACE))
+                    .await
+            }
+            None => self.fetch_pool.add_source(hash, source).await,
+        }
     }
 
     /// Drop `hash` from the fetch pool: the mailbox now holds it (e.g. a client

--- a/crates/mailbox-server/src/lib.rs
+++ b/crates/mailbox-server/src/lib.rs
@@ -18,10 +18,10 @@ mod blob_sync;
 mod cleanup;
 mod get_blips;
 mod notify_topics_subscribers;
+mod register_hashes;
 mod register_peer;
 mod server_key;
 mod store_blips;
-mod store_blobs;
 mod watermark;
 mod watermarks_table;
 
@@ -41,13 +41,13 @@ pub use dashchat_utils::FetchConfig;
 pub use get_blips::{
     get_blips_for_topics, GetBlipsForTopicResponse, GetBlipsRequest, GetBlipsResponse,
 };
+pub use register_hashes::{
+    record_blob_sources, register_hashes, upload_blob, RegisterHashesRequest,
+    RegisterHashesResponse, UploadBlobResponse,
+};
 pub use register_peer::RegisterPeerRequest;
 pub use server_key::{load_or_create_secret_key, SERVER_KEY_TABLE};
 pub use store_blips::{store_blips, StoreBlipsRequest};
-pub use store_blobs::{
-    record_blob_sources, store_blobs, upload_blob, StoreBlobsRequest, StoreBlobsResponse,
-    UploadBlobResponse,
-};
 pub use watermark::compute_initial_watermarks;
 pub use watermarks_table::{WatermarksKey, WatermarksKeyError, WATERMARKS_TABLE};
 
@@ -208,8 +208,11 @@ pub fn create_app(
     Router::new()
         .route("/health", get(health_check))
         .route("/blips/store", post(store_blips))
-        .route("/blobs/store", post(store_blobs::store_blobs))
-        .route("/blobs/upload", post(store_blobs::upload_blob))
+        .route(
+            "/blobs/register-hashes",
+            post(register_hashes::register_hashes),
+        )
+        .route("/blobs/upload", post(register_hashes::upload_blob))
         .route("/blips/get", post(get_blips_for_topics))
         .route("/peers/register", post(register_peer::register_peer))
         .layer(CorsLayer::permissive())

--- a/crates/mailbox-server/src/lib.rs
+++ b/crates/mailbox-server/src/lib.rs
@@ -44,7 +44,10 @@ pub use get_blips::{
 pub use register_peer::RegisterPeerRequest;
 pub use server_key::{load_or_create_secret_key, SERVER_KEY_TABLE};
 pub use store_blips::{store_blips, StoreBlipsRequest};
-pub use store_blobs::{record_blob_sources, store_blobs, StoreBlobsRequest, StoreBlobsResponse};
+pub use store_blobs::{
+    record_blob_sources, store_blobs, upload_blob, StoreBlobsRequest, StoreBlobsResponse,
+    UploadBlobResponse,
+};
 pub use watermark::compute_initial_watermarks;
 pub use watermarks_table::{WatermarksKey, WatermarksKeyError, WATERMARKS_TABLE};
 
@@ -206,6 +209,7 @@ pub fn create_app(
         .route("/health", get(health_check))
         .route("/blips/store", post(store_blips))
         .route("/blobs/store", post(store_blobs::store_blobs))
+        .route("/blobs/upload", post(store_blobs::upload_blob))
         .route("/blips/get", post(get_blips_for_topics))
         .route("/peers/register", post(register_peer::register_peer))
         .layer(CorsLayer::permissive())

--- a/crates/mailbox-server/src/register_hashes.rs
+++ b/crates/mailbox-server/src/register_hashes.rs
@@ -105,8 +105,9 @@ pub async fn upload_blob(
         .await
         .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
     // The mailbox now holds this blob, so drop any pending fetch an earlier
-    // announce queued for it.
-    state.blob_sync.clear_pending_fetch(hash).await;
+    // announce queued for it and push out the grace window for the sender's
+    // other still-deferred fetches (upload progress defers the fetch backstop).
+    state.blob_sync.note_upload(hash).await;
     Ok(Json(UploadBlobResponse { hash }))
 }
 
@@ -186,7 +187,7 @@ mod tests {
         record_blob_sources(&blob_sync, &[h], source, true).await;
         // ...then the client's upload lands, which must drop the pending fetch.
         blob_sync.store_pushed_blob(data.clone()).await.unwrap();
-        blob_sync.clear_pending_fetch(h).await;
+        blob_sync.note_upload(h).await;
 
         tokio::time::advance(
             crate::blob_sync::DEFAULT_UPLOAD_GRACE + std::time::Duration::from_secs(1),

--- a/crates/mailbox-server/src/register_hashes.rs
+++ b/crates/mailbox-server/src/register_hashes.rs
@@ -9,7 +9,7 @@ use crate::{AppState, BlobSync};
 /// bytes are never carried here — clients push those separately to
 /// `/blobs/upload` and use this announce to reconcile what actually landed.
 #[derive(Serialize, Deserialize)]
-pub struct StoreBlobsRequest {
+pub struct RegisterHashesRequest {
     pub blob_hashes: Vec<iroh_blobs::Hash>,
     /// The peer the mailbox should dial to fetch any hash it does not already
     /// hold (typically the sending client itself).
@@ -30,7 +30,7 @@ pub struct StoreBlobsRequest {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct StoreBlobsResponse {
+pub struct RegisterHashesResponse {
     /// Hashes the mailbox already has stored (empty if it has stored none).
     pub already_stored: Vec<iroh_blobs::Hash>,
 }
@@ -60,16 +60,16 @@ pub async fn record_blob_sources(
     }
 }
 
-/// Handle `POST /blobs/store`: partition the announced hashes into those the
-/// mailbox already holds (reported back as `already_stored`) and those it lacks
-/// (registered in the fetch pool so it pulls them from `sender_pubkey`). This is
-/// the source of truth for what the mailbox has: a blob pushed to `/blobs/upload`
-/// shows up here as `already_stored`, and anything that never arrived falls into
-/// the fetch pool as a backstop.
-pub async fn store_blobs(
+/// Handle `POST /blobs/register-hashes`: partition the announced hashes into
+/// those the mailbox already holds (reported back as `already_stored`) and those
+/// it lacks (registered in the fetch pool so it pulls them from `sender_pubkey`).
+/// This is the source of truth for what the mailbox has: a blob pushed to
+/// `/blobs/upload` shows up here as `already_stored`, and anything that never
+/// arrived falls into the fetch pool as a backstop.
+pub async fn register_hashes(
     State(state): State<AppState>,
-    Json(payload): Json<StoreBlobsRequest>,
-) -> Json<StoreBlobsResponse> {
+    Json(payload): Json<RegisterHashesRequest>,
+) -> Json<RegisterHashesResponse> {
     let mut already_stored = Vec::new();
     let mut to_fetch = Vec::new();
     for hash in payload.blob_hashes {
@@ -86,14 +86,14 @@ pub async fn store_blobs(
         payload.expect_upload,
     )
     .await;
-    Json(StoreBlobsResponse { already_stored })
+    Json(RegisterHashesResponse { already_stored })
 }
 
 /// Handle `POST /blobs/upload`: store the raw blob bytes in the request body and
 /// return the hash they hash to. This is the direct-upload fast path — clients
 /// push bytes here immediately on publish so recipients get them without waiting
 /// for the mailbox to dial back and fetch. It is best-effort from the client's
-/// side: `/blobs/store` remains the source of truth, so a failed upload simply
+/// side: `/blobs/register-hashes` remains the source of truth, so a failed upload simply
 /// falls back to a fetch. The 64MB `DefaultBodyLimit` caps a single upload.
 pub async fn upload_blob(
     State(state): State<AppState>,

--- a/crates/mailbox-server/src/store_blobs.rs
+++ b/crates/mailbox-server/src/store_blobs.rs
@@ -3,10 +3,28 @@ use serde::{Deserialize, Serialize};
 
 use crate::{AppState, BlobSync};
 
+/// A client's request to make blobs available on the mailbox. Clients send this
+/// two ways: first with the blob bytes inline (`blobs = Some`) so the mailbox can
+/// store them without a round trip back to the client, and — if that upload times
+/// out — again with `blobs = None`, leaving the mailbox to fetch them from
+/// `sender_pubkey` via its fetch pool.
 #[derive(Serialize, Deserialize)]
 pub struct StoreBlobsRequest {
+    /// The blob bytes themselves, when the client uploads them inline. `None`
+    /// means announce-only: the mailbox fetches any hashes it lacks from
+    /// `sender_pubkey` instead. Bytes are matched to `blob_hashes` by content
+    /// hash, not position, so order and extra/missing entries are harmless.
+    pub blobs: Option<Vec<bytes::Bytes>>,
+    /// Every blob hash this request is about, whether or not its bytes are
+    /// included in `blobs`. Hashes the mailbox ends up without are added to the
+    /// fetch pool.
     pub blob_hashes: Vec<iroh_blobs::Hash>,
+    /// The peer the mailbox should dial to fetch any hash it does not receive
+    /// inline (typically the sending client itself).
     pub sender_pubkey: iroh::EndpointId,
+    /// Reserved for a `sender_pubkey` signature over the request; currently
+    /// unverified, so clients send it empty. `#[serde(default)]` keeps older
+    /// payloads that omit the field entirely decodable.
     #[serde(default)]
     pub signature: Vec<u8>,
 }
@@ -28,10 +46,25 @@ pub async fn record_blob_sources(
     }
 }
 
+/// Handle `POST /blobs/store`: persist any inline blob bytes, then partition the
+/// announced hashes into those the mailbox now holds (reported back as
+/// `already_stored`) and those it still lacks (registered in the fetch pool so it
+/// pulls them from `sender_pubkey`). A hash sent with matching bytes lands in the
+/// former group and is never fetched; a hash sent without bytes (or whose bytes
+/// failed to store) lands in the latter. The `has` check does double duty here:
+/// it catches both blobs stored moments ago from this request and blobs the
+/// mailbox already had from a previous one.
 pub async fn store_blobs(
     State(state): State<AppState>,
     Json(payload): Json<StoreBlobsRequest>,
 ) -> Json<StoreBlobsResponse> {
+    if let Some(blobs) = payload.blobs {
+        for blob in blobs {
+            if let Err(err) = state.blob_sync.store_pushed_blob(blob).await {
+                tracing::warn!(?err, "failed to store pushed blob");
+            }
+        }
+    }
     let mut already_stored = Vec::new();
     let mut to_fetch = Vec::new();
     for hash in payload.blob_hashes {
@@ -70,5 +103,20 @@ mod tests {
             .unwrap();
         assert_eq!(got, h);
         assert!(sources.contains(&source));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pushed_blob_is_stored_under_its_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = iroh::SecretKey::generate();
+        let blob_sync = crate::BlobSync::new(key, dir.path().to_path_buf(), None)
+            .await
+            .unwrap();
+
+        let data = bytes::Bytes::from_static(b"pushed blob contents");
+        let stored = blob_sync.store_pushed_blob(data.clone()).await.unwrap();
+
+        assert_eq!(stored, iroh_blobs::Hash::new(&data));
+        assert!(blob_sync.blobs.has(stored).await.unwrap());
     }
 }

--- a/crates/mailbox-server/src/store_blobs.rs
+++ b/crates/mailbox-server/src/store_blobs.rs
@@ -1,26 +1,18 @@
-use axum::{extract::State, Json};
+use axum::{body::Bytes, extract::State, http::StatusCode, Json};
 use serde::{Deserialize, Serialize};
 
 use crate::{AppState, BlobSync};
 
-/// A client's request to make blobs available on the mailbox. Clients send this
-/// two ways: first with the blob bytes inline (`blobs = Some`) so the mailbox can
-/// store them without a round trip back to the client, and — if that upload times
-/// out — again with `blobs = None`, leaving the mailbox to fetch them from
-/// `sender_pubkey` via its fetch pool.
+/// A client's request to announce blob hashes to the mailbox. For each hash the
+/// mailbox already holds it reports `already_stored`; every other hash it
+/// registers in its fetch pool so it pulls the blob from `sender_pubkey`. Blob
+/// bytes are never carried here — clients push those separately to
+/// `/blobs/upload` and use this announce to reconcile what actually landed.
 #[derive(Serialize, Deserialize)]
 pub struct StoreBlobsRequest {
-    /// The blob bytes themselves, when the client uploads them inline. `None`
-    /// means announce-only: the mailbox fetches any hashes it lacks from
-    /// `sender_pubkey` instead. Bytes are matched to `blob_hashes` by content
-    /// hash, not position, so order and extra/missing entries are harmless.
-    pub blobs: Option<Vec<bytes::Bytes>>,
-    /// Every blob hash this request is about, whether or not its bytes are
-    /// included in `blobs`. Hashes the mailbox ends up without are added to the
-    /// fetch pool.
     pub blob_hashes: Vec<iroh_blobs::Hash>,
-    /// The peer the mailbox should dial to fetch any hash it does not receive
-    /// inline (typically the sending client itself).
+    /// The peer the mailbox should dial to fetch any hash it does not already
+    /// hold (typically the sending client itself).
     pub sender_pubkey: iroh::EndpointId,
     /// Reserved for a `sender_pubkey` signature over the request; currently
     /// unverified, so clients send it empty. `#[serde(default)]` keeps older
@@ -35,6 +27,13 @@ pub struct StoreBlobsResponse {
     pub already_stored: Vec<iroh_blobs::Hash>,
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct UploadBlobResponse {
+    /// The hash the uploaded bytes hash to, so the client can confirm the
+    /// mailbox stored what it intended.
+    pub hash: iroh_blobs::Hash,
+}
+
 /// Register `source` as a provider for each hash the mailbox does not yet hold.
 pub async fn record_blob_sources(
     blob_sync: &BlobSync,
@@ -46,25 +45,16 @@ pub async fn record_blob_sources(
     }
 }
 
-/// Handle `POST /blobs/store`: persist any inline blob bytes, then partition the
-/// announced hashes into those the mailbox now holds (reported back as
-/// `already_stored`) and those it still lacks (registered in the fetch pool so it
-/// pulls them from `sender_pubkey`). A hash sent with matching bytes lands in the
-/// former group and is never fetched; a hash sent without bytes (or whose bytes
-/// failed to store) lands in the latter. The `has` check does double duty here:
-/// it catches both blobs stored moments ago from this request and blobs the
-/// mailbox already had from a previous one.
+/// Handle `POST /blobs/store`: partition the announced hashes into those the
+/// mailbox already holds (reported back as `already_stored`) and those it lacks
+/// (registered in the fetch pool so it pulls them from `sender_pubkey`). This is
+/// the source of truth for what the mailbox has: a blob pushed to `/blobs/upload`
+/// shows up here as `already_stored`, and anything that never arrived falls into
+/// the fetch pool as a backstop.
 pub async fn store_blobs(
     State(state): State<AppState>,
     Json(payload): Json<StoreBlobsRequest>,
 ) -> Json<StoreBlobsResponse> {
-    if let Some(blobs) = payload.blobs {
-        for blob in blobs {
-            if let Err(err) = state.blob_sync.store_pushed_blob(blob).await {
-                tracing::warn!(?err, "failed to store pushed blob");
-            }
-        }
-    }
     let mut already_stored = Vec::new();
     let mut to_fetch = Vec::new();
     for hash in payload.blob_hashes {
@@ -76,6 +66,24 @@ pub async fn store_blobs(
     }
     record_blob_sources(&state.blob_sync, &to_fetch, payload.sender_pubkey).await;
     Json(StoreBlobsResponse { already_stored })
+}
+
+/// Handle `POST /blobs/upload`: store the raw blob bytes in the request body and
+/// return the hash they hash to. This is the direct-upload fast path — clients
+/// push bytes here immediately on publish so recipients get them without waiting
+/// for the mailbox to dial back and fetch. It is best-effort from the client's
+/// side: `/blobs/store` remains the source of truth, so a failed upload simply
+/// falls back to a fetch. The 64MB `DefaultBodyLimit` caps a single upload.
+pub async fn upload_blob(
+    State(state): State<AppState>,
+    body: Bytes,
+) -> Result<Json<UploadBlobResponse>, (StatusCode, String)> {
+    let hash = state
+        .blob_sync
+        .store_pushed_blob(body)
+        .await
+        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
+    Ok(Json(UploadBlobResponse { hash }))
 }
 
 #[cfg(test)]

--- a/crates/mailbox-server/src/store_blobs.rs
+++ b/crates/mailbox-server/src/store_blobs.rs
@@ -157,8 +157,10 @@ mod tests {
             .await
             .is_none());
 
-        tokio::time::advance(crate::blob_sync::UPLOAD_GRACE + std::time::Duration::from_secs(1))
-            .await;
+        tokio::time::advance(
+            crate::blob_sync::DEFAULT_UPLOAD_GRACE + std::time::Duration::from_secs(1),
+        )
+        .await;
         let (got, sources) = blob_sync
             .fetch_pool_for_test()
             .next_untried(&tried)
@@ -186,8 +188,10 @@ mod tests {
         blob_sync.store_pushed_blob(data.clone()).await.unwrap();
         blob_sync.clear_pending_fetch(h).await;
 
-        tokio::time::advance(crate::blob_sync::UPLOAD_GRACE + std::time::Duration::from_secs(1))
-            .await;
+        tokio::time::advance(
+            crate::blob_sync::DEFAULT_UPLOAD_GRACE + std::time::Duration::from_secs(1),
+        )
+        .await;
         assert!(blob_sync
             .fetch_pool_for_test()
             .next_untried(&HashSet::new())

--- a/crates/mailbox-server/src/store_blobs.rs
+++ b/crates/mailbox-server/src/store_blobs.rs
@@ -5,16 +5,23 @@ use crate::{AppState, BlobSync};
 
 /// A client's request to announce blob hashes to the mailbox. For each hash the
 /// mailbox already holds it reports `already_stored`; every other hash it
-/// registers in its fetch pool (deferred by the mailbox's fixed grace window) so
-/// it pulls the blob from `sender_pubkey`. Blob bytes are never carried here —
-/// clients push those separately to `/blobs/upload` and use this announce to
-/// reconcile what actually landed.
+/// registers in its fetch pool so it pulls the blob from `sender_pubkey`. Blob
+/// bytes are never carried here — clients push those separately to
+/// `/blobs/upload` and use this announce to reconcile what actually landed.
 #[derive(Serialize, Deserialize)]
 pub struct StoreBlobsRequest {
     pub blob_hashes: Vec<iroh_blobs::Hash>,
     /// The peer the mailbox should dial to fetch any hash it does not already
     /// hold (typically the sending client itself).
     pub sender_pubkey: iroh::EndpointId,
+    /// Set when the client intends to stream the announced blobs to
+    /// `/blobs/upload` right after this announce. The mailbox then defers dialing
+    /// `sender_pubkey` by its fixed grace window so the upload can land first
+    /// without a duplicate transfer. Clients that only announce (no bytes to
+    /// push, e.g. the re-announce followup) leave it `false` for an immediate
+    /// fetch. `#[serde(default)]` keeps older payloads that omit it decodable.
+    #[serde(default)]
+    pub expect_upload: bool,
     /// Reserved for a `sender_pubkey` signature over the request; currently
     /// unverified, so clients send it empty. `#[serde(default)]` keeps older
     /// payloads that omit the field entirely decodable.
@@ -36,16 +43,20 @@ pub struct UploadBlobResponse {
 }
 
 /// Register `source` as a provider for each hash the mailbox does not yet hold.
-/// Each fetch is deferred by the mailbox's fixed grace window so a client that
-/// announces and then streams the same blobs doesn't race the mailbox into a
-/// duplicate fetch.
+/// When `expect_upload` is set, each fetch is deferred by the mailbox's fixed
+/// grace window so a client that announces and then streams the same blobs
+/// doesn't race the mailbox into a duplicate fetch; otherwise each hash is
+/// fetchable immediately.
 pub async fn record_blob_sources(
     blob_sync: &BlobSync,
     hashes: &[iroh_blobs::Hash],
     source: iroh::EndpointId,
+    expect_upload: bool,
 ) {
     for hash in hashes {
-        blob_sync.add_fetch_source(*hash, source).await;
+        blob_sync
+            .add_fetch_source(*hash, source, expect_upload)
+            .await;
     }
 }
 
@@ -68,7 +79,13 @@ pub async fn store_blobs(
             to_fetch.push(hash);
         }
     }
-    record_blob_sources(&state.blob_sync, &to_fetch, payload.sender_pubkey).await;
+    record_blob_sources(
+        &state.blob_sync,
+        &to_fetch,
+        payload.sender_pubkey,
+        payload.expect_upload,
+    )
+    .await;
     Json(StoreBlobsResponse { already_stored })
 }
 
@@ -99,7 +116,7 @@ mod tests {
     use std::collections::HashSet;
 
     #[tokio::test(start_paused = true)]
-    async fn absent_blob_registers_source_deferred_by_the_grace_window() {
+    async fn absent_blob_without_expected_upload_is_fetchable_at_once() {
         let dir = tempfile::tempdir().unwrap();
         let key = iroh::SecretKey::generate();
         let blob_sync = crate::BlobSync::new(key, dir.path().to_path_buf(), None)
@@ -108,10 +125,31 @@ mod tests {
         let source = iroh::SecretKey::from_bytes(&[7; 32]).public();
         let h = iroh_blobs::Hash::new([9; 32]);
 
-        // Announcing a hash the mailbox lacks registers the source but holds the
-        // fetch off until the grace window passes, giving a concurrent upload
-        // time to land.
-        record_blob_sources(&blob_sync, &[h], source).await;
+        // Announce with no expected upload: the source is fetchable immediately.
+        record_blob_sources(&blob_sync, &[h], source, false).await;
+        let tried = HashSet::new();
+        let (got, sources) = blob_sync
+            .fetch_pool_for_test()
+            .next_untried(&tried)
+            .await
+            .unwrap();
+        assert_eq!(got, h);
+        assert!(sources.contains(&source));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn expected_upload_defers_the_fetch_by_the_grace_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = iroh::SecretKey::generate();
+        let blob_sync = crate::BlobSync::new(key, dir.path().to_path_buf(), None)
+            .await
+            .unwrap();
+        let source = iroh::SecretKey::from_bytes(&[7; 32]).public();
+        let h = iroh_blobs::Hash::new([9; 32]);
+
+        // Announce with an expected upload: the fetch is held off until the grace
+        // window passes, giving the upload time to land.
+        record_blob_sources(&blob_sync, &[h], source, true).await;
         let tried = HashSet::new();
         assert!(blob_sync
             .fetch_pool_for_test()
@@ -141,8 +179,9 @@ mod tests {
         let data = bytes::Bytes::from_static(b"raced blob");
         let h = iroh_blobs::Hash::new(&data);
 
-        // A hash is announced (queued for fetch after the grace window)...
-        record_blob_sources(&blob_sync, &[h], source).await;
+        // A hash is announced with an expected upload (queued for fetch after the
+        // grace window)...
+        record_blob_sources(&blob_sync, &[h], source, true).await;
         // ...then the client's upload lands, which must drop the pending fetch.
         blob_sync.store_pushed_blob(data.clone()).await.unwrap();
         blob_sync.clear_pending_fetch(h).await;

--- a/crates/mailbox-server/src/store_blobs.rs
+++ b/crates/mailbox-server/src/store_blobs.rs
@@ -34,14 +34,16 @@ pub struct UploadBlobResponse {
     pub hash: iroh_blobs::Hash,
 }
 
-/// Register `source` as a provider for each hash the mailbox does not yet hold.
+/// Register `source` as a provider for each hash the mailbox does not yet hold,
+/// deferring each fetch by the upload grace window so a client that announces and
+/// then streams the same blobs doesn't race the mailbox into a duplicate fetch.
 pub async fn record_blob_sources(
     blob_sync: &BlobSync,
     hashes: &[iroh_blobs::Hash],
     source: iroh::EndpointId,
 ) {
     for hash in hashes {
-        blob_sync.fetch_pool().add_source(*hash, source).await;
+        blob_sync.add_delayed_fetch_source(*hash, source).await;
     }
 }
 
@@ -83,6 +85,9 @@ pub async fn upload_blob(
         .store_pushed_blob(body)
         .await
         .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
+    // The mailbox now holds this blob, so drop any pending fetch an earlier
+    // announce queued for it.
+    state.blob_sync.clear_pending_fetch(hash).await;
     Ok(Json(UploadBlobResponse { hash }))
 }
 
@@ -102,8 +107,19 @@ mod tests {
         let h = iroh_blobs::Hash::new([9; 32]);
 
         record_blob_sources(&blob_sync, &[h], source).await;
-
         let tried = HashSet::new();
+
+        // The announce defers the fetch by the grace window, so it is not yet
+        // ready to dial the source.
+        assert!(blob_sync
+            .fetch_pool_for_test()
+            .next_untried(&tried)
+            .await
+            .is_none());
+
+        // Once the grace window passes, the source is fetchable.
+        tokio::time::advance(crate::blob_sync::FETCH_GRACE + std::time::Duration::from_secs(1))
+            .await;
         let (got, sources) = blob_sync
             .fetch_pool_for_test()
             .next_untried(&tried)
@@ -111,6 +127,32 @@ mod tests {
             .unwrap();
         assert_eq!(got, h);
         assert!(sources.contains(&source));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn uploading_a_blob_clears_its_pending_fetch() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = iroh::SecretKey::generate();
+        let blob_sync = crate::BlobSync::new(key, dir.path().to_path_buf(), None)
+            .await
+            .unwrap();
+        let source = iroh::SecretKey::from_bytes(&[7; 32]).public();
+        let data = bytes::Bytes::from_static(b"raced blob");
+        let h = iroh_blobs::Hash::new(&data);
+
+        // A hash is announced (queued for fetch after the grace window)...
+        record_blob_sources(&blob_sync, &[h], source).await;
+        // ...then the client's upload lands, which must drop the pending fetch.
+        blob_sync.store_pushed_blob(data.clone()).await.unwrap();
+        blob_sync.clear_pending_fetch(h).await;
+
+        tokio::time::advance(crate::blob_sync::FETCH_GRACE + std::time::Duration::from_secs(1))
+            .await;
+        assert!(blob_sync
+            .fetch_pool_for_test()
+            .next_untried(&HashSet::new())
+            .await
+            .is_none());
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/mailbox-server/src/store_blobs.rs
+++ b/crates/mailbox-server/src/store_blobs.rs
@@ -5,22 +5,16 @@ use crate::{AppState, BlobSync};
 
 /// A client's request to announce blob hashes to the mailbox. For each hash the
 /// mailbox already holds it reports `already_stored`; every other hash it
-/// registers in its fetch pool so it pulls the blob from `sender_pubkey`. Blob
-/// bytes are never carried here — clients push those separately to
-/// `/blobs/upload` and use this announce to reconcile what actually landed.
+/// registers in its fetch pool (deferred by the mailbox's fixed grace window) so
+/// it pulls the blob from `sender_pubkey`. Blob bytes are never carried here —
+/// clients push those separately to `/blobs/upload` and use this announce to
+/// reconcile what actually landed.
 #[derive(Serialize, Deserialize)]
 pub struct StoreBlobsRequest {
     pub blob_hashes: Vec<iroh_blobs::Hash>,
     /// The peer the mailbox should dial to fetch any hash it does not already
     /// hold (typically the sending client itself).
     pub sender_pubkey: iroh::EndpointId,
-    /// Set to the client's upload timeout when it intends to stream the announced
-    /// blobs to `/blobs/upload` right after this announce. The mailbox defers
-    /// dialing `sender_pubkey` by exactly this window so the upload can land first
-    /// without a duplicate transfer. Clients that only announce (e.g. the
-    /// re-announce followup) leave it `None` for an immediate fetch.
-    #[serde(default)]
-    pub upload_grace: Option<std::time::Duration>,
     /// Reserved for a `sender_pubkey` signature over the request; currently
     /// unverified, so clients send it empty. `#[serde(default)]` keeps older
     /// payloads that omit the field entirely decodable.
@@ -42,17 +36,16 @@ pub struct UploadBlobResponse {
 }
 
 /// Register `source` as a provider for each hash the mailbox does not yet hold.
-/// When `grace` is set, each fetch is deferred by that window so a client that
+/// Each fetch is deferred by the mailbox's fixed grace window so a client that
 /// announces and then streams the same blobs doesn't race the mailbox into a
-/// duplicate fetch; otherwise the hash is fetchable immediately.
+/// duplicate fetch.
 pub async fn record_blob_sources(
     blob_sync: &BlobSync,
     hashes: &[iroh_blobs::Hash],
     source: iroh::EndpointId,
-    grace: Option<std::time::Duration>,
 ) {
     for hash in hashes {
-        blob_sync.add_fetch_source(*hash, source, grace).await;
+        blob_sync.add_fetch_source(*hash, source).await;
     }
 }
 
@@ -75,13 +68,7 @@ pub async fn store_blobs(
             to_fetch.push(hash);
         }
     }
-    record_blob_sources(
-        &state.blob_sync,
-        &to_fetch,
-        payload.sender_pubkey,
-        payload.upload_grace,
-    )
-    .await;
+    record_blob_sources(&state.blob_sync, &to_fetch, payload.sender_pubkey).await;
     Json(StoreBlobsResponse { already_stored })
 }
 
@@ -112,7 +99,7 @@ mod tests {
     use std::collections::HashSet;
 
     #[tokio::test(start_paused = true)]
-    async fn absent_blob_registers_source_and_is_not_already_stored() {
+    async fn absent_blob_registers_source_deferred_by_the_grace_window() {
         let dir = tempfile::tempdir().unwrap();
         let key = iroh::SecretKey::generate();
         let blob_sync = crate::BlobSync::new(key, dir.path().to_path_buf(), None)
@@ -121,32 +108,10 @@ mod tests {
         let source = iroh::SecretKey::from_bytes(&[7; 32]).public();
         let h = iroh_blobs::Hash::new([9; 32]);
 
-        // Announce without an expected upload: the source is fetchable at once.
-        record_blob_sources(&blob_sync, &[h], source, None).await;
-        let tried = HashSet::new();
-        let (got, sources) = blob_sync
-            .fetch_pool_for_test()
-            .next_untried(&tried)
-            .await
-            .unwrap();
-        assert_eq!(got, h);
-        assert!(sources.contains(&source));
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn expected_upload_defers_the_fetch_by_the_grace_window() {
-        let dir = tempfile::tempdir().unwrap();
-        let key = iroh::SecretKey::generate();
-        let blob_sync = crate::BlobSync::new(key, dir.path().to_path_buf(), None)
-            .await
-            .unwrap();
-        let source = iroh::SecretKey::from_bytes(&[7; 32]).public();
-        let h = iroh_blobs::Hash::new([9; 32]);
-
-        // Announce with an expected upload: the fetch is held off until the grace
-        // window passes, giving the upload time to land.
-        let grace = std::time::Duration::from_secs(15);
-        record_blob_sources(&blob_sync, &[h], source, Some(grace)).await;
+        // Announcing a hash the mailbox lacks registers the source but holds the
+        // fetch off until the grace window passes, giving a concurrent upload
+        // time to land.
+        record_blob_sources(&blob_sync, &[h], source).await;
         let tried = HashSet::new();
         assert!(blob_sync
             .fetch_pool_for_test()
@@ -154,13 +119,15 @@ mod tests {
             .await
             .is_none());
 
-        tokio::time::advance(grace + std::time::Duration::from_secs(1)).await;
-        let (got, _sources) = blob_sync
+        tokio::time::advance(crate::blob_sync::UPLOAD_GRACE + std::time::Duration::from_secs(1))
+            .await;
+        let (got, sources) = blob_sync
             .fetch_pool_for_test()
             .next_untried(&tried)
             .await
             .unwrap();
         assert_eq!(got, h);
+        assert!(sources.contains(&source));
     }
 
     #[tokio::test(start_paused = true)]
@@ -174,15 +141,14 @@ mod tests {
         let data = bytes::Bytes::from_static(b"raced blob");
         let h = iroh_blobs::Hash::new(&data);
 
-        // A hash is announced with an expected upload (queued for fetch after the
-        // grace window)...
-        let grace = std::time::Duration::from_secs(15);
-        record_blob_sources(&blob_sync, &[h], source, Some(grace)).await;
+        // A hash is announced (queued for fetch after the grace window)...
+        record_blob_sources(&blob_sync, &[h], source).await;
         // ...then the client's upload lands, which must drop the pending fetch.
         blob_sync.store_pushed_blob(data.clone()).await.unwrap();
         blob_sync.clear_pending_fetch(h).await;
 
-        tokio::time::advance(grace + std::time::Duration::from_secs(1)).await;
+        tokio::time::advance(crate::blob_sync::UPLOAD_GRACE + std::time::Duration::from_secs(1))
+            .await;
         assert!(blob_sync
             .fetch_pool_for_test()
             .next_untried(&HashSet::new())

--- a/crates/mailbox-server/src/store_blobs.rs
+++ b/crates/mailbox-server/src/store_blobs.rs
@@ -14,6 +14,13 @@ pub struct StoreBlobsRequest {
     /// The peer the mailbox should dial to fetch any hash it does not already
     /// hold (typically the sending client itself).
     pub sender_pubkey: iroh::EndpointId,
+    /// Set to the client's upload timeout when it intends to stream the announced
+    /// blobs to `/blobs/upload` right after this announce. The mailbox defers
+    /// dialing `sender_pubkey` by exactly this window so the upload can land first
+    /// without a duplicate transfer. Clients that only announce (e.g. the
+    /// re-announce followup) leave it `None` for an immediate fetch.
+    #[serde(default)]
+    pub upload_grace: Option<std::time::Duration>,
     /// Reserved for a `sender_pubkey` signature over the request; currently
     /// unverified, so clients send it empty. `#[serde(default)]` keeps older
     /// payloads that omit the field entirely decodable.
@@ -34,16 +41,18 @@ pub struct UploadBlobResponse {
     pub hash: iroh_blobs::Hash,
 }
 
-/// Register `source` as a provider for each hash the mailbox does not yet hold,
-/// deferring each fetch by the upload grace window so a client that announces and
-/// then streams the same blobs doesn't race the mailbox into a duplicate fetch.
+/// Register `source` as a provider for each hash the mailbox does not yet hold.
+/// When `grace` is set, each fetch is deferred by that window so a client that
+/// announces and then streams the same blobs doesn't race the mailbox into a
+/// duplicate fetch; otherwise the hash is fetchable immediately.
 pub async fn record_blob_sources(
     blob_sync: &BlobSync,
     hashes: &[iroh_blobs::Hash],
     source: iroh::EndpointId,
+    grace: Option<std::time::Duration>,
 ) {
     for hash in hashes {
-        blob_sync.add_delayed_fetch_source(*hash, source).await;
+        blob_sync.add_fetch_source(*hash, source, grace).await;
     }
 }
 
@@ -66,7 +75,13 @@ pub async fn store_blobs(
             to_fetch.push(hash);
         }
     }
-    record_blob_sources(&state.blob_sync, &to_fetch, payload.sender_pubkey).await;
+    record_blob_sources(
+        &state.blob_sync,
+        &to_fetch,
+        payload.sender_pubkey,
+        payload.upload_grace,
+    )
+    .await;
     Json(StoreBlobsResponse { already_stored })
 }
 
@@ -106,20 +121,9 @@ mod tests {
         let source = iroh::SecretKey::from_bytes(&[7; 32]).public();
         let h = iroh_blobs::Hash::new([9; 32]);
 
-        record_blob_sources(&blob_sync, &[h], source).await;
+        // Announce without an expected upload: the source is fetchable at once.
+        record_blob_sources(&blob_sync, &[h], source, None).await;
         let tried = HashSet::new();
-
-        // The announce defers the fetch by the grace window, so it is not yet
-        // ready to dial the source.
-        assert!(blob_sync
-            .fetch_pool_for_test()
-            .next_untried(&tried)
-            .await
-            .is_none());
-
-        // Once the grace window passes, the source is fetchable.
-        tokio::time::advance(crate::blob_sync::FETCH_GRACE + std::time::Duration::from_secs(1))
-            .await;
         let (got, sources) = blob_sync
             .fetch_pool_for_test()
             .next_untried(&tried)
@@ -127,6 +131,36 @@ mod tests {
             .unwrap();
         assert_eq!(got, h);
         assert!(sources.contains(&source));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn expected_upload_defers_the_fetch_by_the_grace_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = iroh::SecretKey::generate();
+        let blob_sync = crate::BlobSync::new(key, dir.path().to_path_buf(), None)
+            .await
+            .unwrap();
+        let source = iroh::SecretKey::from_bytes(&[7; 32]).public();
+        let h = iroh_blobs::Hash::new([9; 32]);
+
+        // Announce with an expected upload: the fetch is held off until the grace
+        // window passes, giving the upload time to land.
+        let grace = std::time::Duration::from_secs(15);
+        record_blob_sources(&blob_sync, &[h], source, Some(grace)).await;
+        let tried = HashSet::new();
+        assert!(blob_sync
+            .fetch_pool_for_test()
+            .next_untried(&tried)
+            .await
+            .is_none());
+
+        tokio::time::advance(grace + std::time::Duration::from_secs(1)).await;
+        let (got, _sources) = blob_sync
+            .fetch_pool_for_test()
+            .next_untried(&tried)
+            .await
+            .unwrap();
+        assert_eq!(got, h);
     }
 
     #[tokio::test(start_paused = true)]
@@ -140,14 +174,15 @@ mod tests {
         let data = bytes::Bytes::from_static(b"raced blob");
         let h = iroh_blobs::Hash::new(&data);
 
-        // A hash is announced (queued for fetch after the grace window)...
-        record_blob_sources(&blob_sync, &[h], source).await;
+        // A hash is announced with an expected upload (queued for fetch after the
+        // grace window)...
+        let grace = std::time::Duration::from_secs(15);
+        record_blob_sources(&blob_sync, &[h], source, Some(grace)).await;
         // ...then the client's upload lands, which must drop the pending fetch.
         blob_sync.store_pushed_blob(data.clone()).await.unwrap();
         blob_sync.clear_pending_fetch(h).await;
 
-        tokio::time::advance(crate::blob_sync::FETCH_GRACE + std::time::Duration::from_secs(1))
-            .await;
+        tokio::time::advance(grace + std::time::Duration::from_secs(1)).await;
         assert!(blob_sync
             .fetch_pool_for_test()
             .next_untried(&HashSet::new())

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dash-chat"
-version = "0.19.9"
+version = "0.19.10"
 description = "Dash Chat"
 authors = ["you"]
 license = ""

--- a/src-tauri/gen/apple/dash-chat_iOS/Info.plist
+++ b/src-tauri/gen/apple/dash-chat_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.19.9</string>
+	<string>0.19.10</string>
 	<key>CFBundleVersion</key>
-	<string>0.19.9</string>
+	<string>0.19.10</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/src-tauri/src/filesystem.rs
+++ b/src-tauri/src/filesystem.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use tauri::{AppHandle, Manager, Runtime};
 
-const DATABASE_VERSION: &str = "0.5";
+const DATABASE_VERSION: &str = "0.6";
 
 /// When `DATA_DIR` is set, isolate the XDG directories under it so concurrently
 /// running desktop instances don't share WebKitGTK's SQLite databases (which

--- a/src-tauri/src/mailbox.rs
+++ b/src-tauri/src/mailbox.rs
@@ -185,12 +185,15 @@ async fn handle_browse_events(
 
                     let url = format!("http://{host}:{port}");
                     node.mailboxes
-                        .register(mailbox_client::toy::ToyMailboxClient::new(
-                            mailbox_id.clone(),
-                            url.clone(),
-                            node.endpoint_id(),
-                            node.unfetched_blob_tracker(),
-                        ))
+                        .register(
+                            mailbox_client::toy::ToyMailboxClient::new(
+                                mailbox_id.clone(),
+                                url.clone(),
+                                node.endpoint_id(),
+                                node.unfetched_blob_tracker(),
+                            )
+                            .with_blob_reader(node.blob_reader()),
+                        )
                         .await;
                     // Add the mailbox's dialing address to the address book so
                     // the blob downloader can reach it by EndpointId rather than

--- a/src-tauri/src/mailbox/server.rs
+++ b/src-tauri/src/mailbox/server.rs
@@ -58,6 +58,7 @@ pub async fn start_local_mailbox<R: Runtime>(handle: &AppHandle<R>) -> anyhow::R
         node.blob_downloader(),
         endpoint,
         None,
+        None,
         peer_addr_tx,
     )
     .await?;

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -23,7 +23,8 @@ pub(crate) async fn track_cloud_mailbox(node: &Node) -> anyhow::Result<String> {
             mailbox_url.clone(),
             node.endpoint_id(),
             node.unfetched_blob_tracker(),
-        );
+        )
+        .with_blob_reader(node.blob_reader());
         node.mailboxes.register(mailbox_client).await;
     }
     Ok(mailbox_url)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
 	"productName": "Dash Chat",
-	"version": "0.19.9",
+	"version": "0.19.10",
 	"identifier": "studio.darksoil.dashchat",
 	"build": {
 		"beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Adds a `/blobs/upload` endpoint which is used during payload publishing during log sync.
Instead of just asking the server to store blob hashes that it will fetch "later" (now renamed to `/blobs/register-hashes`), clients now register hashes as before, but also immediately upload blobs. 
This upload is a best-effort attempt to get the blobs to the server as quickly as possible.

The server will remove from its pending fetch pool the hashes of any blobs received via upload. Also, now when the server registers hashes, it includes a grace period during which the server will not attempt to fetch those blobs, which gives the client time to upload and prevents duplicates. Whenever an upload is successful, it refreshes the grace period for all other hash entries whose grace period has not yet expired.