### PR TITLE
Shorten qr code 2

### DIFF
--- a/crates/dashchat-node/Cargo.toml
+++ b/crates/dashchat-node/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { version = "1.43.0", features = ["fs"] }
 base64 = "0.22"
 blake3 = "1.8.2"
 chrono = { version = "0.4.42", features = ["serde"] }
-hex = "0.4.3"
+hex = { version = "0.4.3", features = ["serde"] }
 rand = "0.9.2"
 tokio-stream = "0.1.17"
 tokio-util = "0.7"

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -156,7 +156,7 @@ impl From<QrCode> for String {
 impl TryFrom<String> for QrCode {
     type Error = anyhow::Error;
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        Ok(QrCode::from_str(&value).unwrap())
+        Ok(QrCode::from_str(&value)?)
     }
 }
 

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -33,6 +33,10 @@ impl<'de> Deserialize<'de> for InboxNonce {
 }
 
 impl InboxNonce {
+    pub fn random() -> Self {
+        InboxNonce(rand::random())
+    }
+
     pub fn as_bytes(&self) -> [u8; 8] {
         self.0
     }
@@ -55,8 +59,7 @@ pub struct QrCode {
     /// The intent of the QR code: whether to add this node as a contact or a device.
     pub share_intent: ShareIntent,
     /// 8-byte nonce used with `derive_inbox_topic` to reconstruct the inbox topic.
-    /// Absent on reply codes.
-    pub inbox_nonce: Option<InboxNonce>,
+    pub inbox_nonce: InboxNonce,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_repr, Deserialize_repr)]
@@ -76,6 +79,11 @@ pub struct InboxTopic {
 }
 
 impl InboxTopic {
+    pub fn new_random(device_pubkey: &DeviceId, expires_at: DateTime<Utc>) -> (Self, InboxNonce) {
+        let nonce = InboxNonce::random();
+        (Self::from_nonce(device_pubkey, &nonce, expires_at), nonce)
+    }
+
     pub fn from_nonce(
         device_pubkey: &DeviceId,
         nonce: &InboxNonce,
@@ -115,9 +123,12 @@ mod expires_at_minutes {
 
 impl std::fmt::Display for QrCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let inbox_nonce_raw = self.inbox_nonce.map(|n| n.as_bytes());
-        let bytes = encode_cbor(&(&self.device_pubkey, &inbox_nonce_raw, &self.share_intent))
-            .map_err(|_| std::fmt::Error)?;
+        let bytes = encode_cbor(&(
+            &self.device_pubkey,
+            &self.inbox_nonce.as_bytes(),
+            &self.share_intent,
+        ))
+        .map_err(|_| std::fmt::Error)?;
         write!(f, "{}", hex::encode(bytes))
     }
 }
@@ -126,15 +137,12 @@ impl FromStr for QrCode {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let bytes = hex::decode(s)?;
-        let (device_pubkey, inbox_nonce_raw, share_intent): (
-            DeviceId,
-            Option<[u8; 8]>,
-            ShareIntent,
-        ) = decode_cbor(bytes.as_slice())?;
+        let (device_pubkey, inbox_nonce_raw, share_intent): (DeviceId, [u8; 8], ShareIntent) =
+            decode_cbor(bytes.as_slice())?;
         Ok(QrCode {
             device_pubkey,
             share_intent,
-            inbox_nonce: inbox_nonce_raw.map(InboxNonce),
+            inbox_nonce: InboxNonce(inbox_nonce_raw),
         })
     }
 }
@@ -167,22 +175,7 @@ mod tests {
         let contact = QrCode {
             device_pubkey,
             share_intent: ShareIntent::AddDevice,
-            inbox_nonce: Some(InboxNonce(nonce)),
-        };
-        let encoded = contact.to_string();
-        let decoded = QrCode::from_str(&encoded).unwrap();
-
-        assert_eq!(contact, decoded);
-    }
-
-    #[test]
-    fn test_contact_roundtrip_no_nonce() {
-        let pubkey = VerifyingKey::from_bytes(&[22; 32]).unwrap();
-        let device_pubkey = DeviceId::from(pubkey);
-        let contact = QrCode {
-            device_pubkey,
-            share_intent: ShareIntent::AddDevice,
-            inbox_nonce: None,
+            inbox_nonce: InboxNonce(nonce),
         };
         let encoded = contact.to_string();
         let decoded = QrCode::from_str(&encoded).unwrap();

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -1,5 +1,5 @@
-use chrono::{DateTime, Utc};
 use aliased::Aliasing;
+use chrono::{DateTime, Utc};
 use p2panda_core::cbor::{decode_cbor, encode_cbor};
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -97,8 +97,13 @@ impl InboxTopic {
         expires_at: DateTime<Utc>,
     ) -> Self {
         Self {
-            topic: Topic::new(derive_inbox_topic(device_pubkey, &nonce.as_bytes()))
-                .alias_named(&format!("inbox({:?},nonce={})", device_pubkey.aliased(), hex::encode(nonce.as_bytes()))),
+            topic: Topic::new(derive_inbox_topic(device_pubkey, &nonce.as_bytes())).alias_named(
+                &format!(
+                    "inbox({:?},nonce={})",
+                    device_pubkey.aliased(),
+                    hex::encode(nonce.as_bytes())
+                ),
+            ),
             expires_at,
         }
     }
@@ -136,8 +141,11 @@ impl FromStr for QrCode {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let bytes = hex::decode(s)?;
-        let (device_pubkey, inbox_nonce_raw, share_intent): (DeviceId, Option<[u8; 8]>, ShareIntent) =
-            decode_cbor(bytes.as_slice())?;
+        let (device_pubkey, inbox_nonce_raw, share_intent): (
+            DeviceId,
+            Option<[u8; 8]>,
+            ShareIntent,
+        ) = decode_cbor(bytes.as_slice())?;
         Ok(QrCode {
             device_pubkey,
             share_intent,

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -6,6 +6,14 @@ use std::str::FromStr;
 
 use crate::{DeviceId, Topic, topic::kind};
 
+/// Derive an inbox topic's 32-byte ID from the code owner's device pubkey and a short nonce.
+pub fn derive_inbox_topic(device_pubkey: &DeviceId, nonce: &[u8; 8]) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(device_pubkey.as_bytes());
+    hasher.update(nonce);
+    *hasher.finalize().as_bytes()
+}
+
 /// The content for a QR code or deep link.
 ///
 /// These codes are used to introduce two nodes for the purpose of either establishing
@@ -27,13 +35,11 @@ use crate::{DeviceId, Topic, topic::kind};
 pub struct QrCode {
     /// Pubkey of this node: allows adding this node to groups.
     pub device_pubkey: DeviceId,
-    /// Topic for receiving messages from this node during the lifetime of the QR code.
-    /// The initiator will specify an InboxTopic, and the recipient will send back a QR
-    /// code without an associated inbox, because after this exchange the two nodes
-    /// can communicate directly.
-    pub inbox_topic: Option<InboxTopic>,
     /// The intent of the QR code: whether to add this node as a contact or a device.
     pub share_intent: ShareIntent,
+    /// 8-byte nonce used with `derive_inbox_topic` to reconstruct the inbox topic.
+    /// Absent on reply codes.
+    pub inbox_nonce: Option<[u8; 8]>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_repr, Deserialize_repr)]
@@ -73,7 +79,7 @@ mod expires_at_minutes {
 
 impl std::fmt::Display for QrCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let bytes = encode_cbor(&(&self.device_pubkey, &self.inbox_topic, &self.share_intent))
+        let bytes = encode_cbor(&(&self.device_pubkey, &self.inbox_nonce, &self.share_intent))
             .map_err(|_| std::fmt::Error)?;
         write!(f, "{}", hex::encode(bytes))
     }
@@ -83,11 +89,12 @@ impl FromStr for QrCode {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let bytes = hex::decode(s)?;
-        let (device_pubkey, inbox_topic, share_intent) = decode_cbor(bytes.as_slice())?;
+        let (device_pubkey, inbox_nonce, share_intent): (DeviceId, Option<[u8; 8]>, ShareIntent) =
+            decode_cbor(bytes.as_slice())?;
         Ok(QrCode {
             device_pubkey,
-            inbox_topic,
             share_intent,
+            inbox_nonce,
         })
     }
 }
@@ -115,14 +122,12 @@ mod tests {
     #[test]
     fn test_contact_roundtrip() {
         let pubkey = VerifyingKey::from_bytes(&[11; 32]).unwrap();
+        let device_pubkey = DeviceId::from(pubkey);
+        let nonce: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
         let contact = QrCode {
-            device_pubkey: DeviceId::from(pubkey),
-            inbox_topic: Some(InboxTopic {
-                topic: Topic::inbox(),
-                // Minute-aligned so it survives the (minutes-since-epoch) serialization.
-                expires_at: DateTime::from_timestamp(1_700_000_000 / 60 * 60, 0).unwrap(),
-            }),
+            device_pubkey,
             share_intent: ShareIntent::AddDevice,
+            inbox_nonce: Some(nonce),
         };
         let encoded = contact.to_string();
         let decoded = QrCode::from_str(&encoded).unwrap();

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -189,4 +189,19 @@ mod tests {
 
         assert_eq!(contact, decoded);
     }
+
+    #[test]
+    fn test_contact_roundtrip_no_nonce() {
+        let pubkey = VerifyingKey::from_bytes(&[22; 32]).unwrap();
+        let device_pubkey = DeviceId::from(pubkey);
+        let contact = QrCode {
+            device_pubkey,
+            share_intent: ShareIntent::AddDevice,
+            inbox_nonce: None,
+        };
+        let encoded = contact.to_string();
+        let decoded = QrCode::from_str(&encoded).unwrap();
+
+        assert_eq!(contact, decoded);
+    }
 }

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -1,10 +1,42 @@
 use chrono::{DateTime, Utc};
+use aliased::Aliasing;
 use p2panda_core::cbor::{decode_cbor, encode_cbor};
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::str::FromStr;
 
 use crate::{DeviceId, Topic, topic::kind};
+
+/// An 8-byte nonce serialized as a hex string at the JSON/Tauri boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub struct InboxNonce(#[serde(with = "hex::serde")] pub [u8; 8]);
+
+impl<'de> Deserialize<'de> for InboxNonce {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Vis;
+        impl serde::de::Visitor<'_> for Vis {
+            type Value = InboxNonce;
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a 16-character hex string")
+            }
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                let bytes = hex::decode(v).map_err(serde::de::Error::custom)?;
+                let arr: [u8; 8] = bytes.try_into().map_err(|_| {
+                    serde::de::Error::custom("expected exactly 8 bytes (16 hex chars)")
+                })?;
+                Ok(InboxNonce(arr))
+            }
+        }
+        deserializer.deserialize_str(Vis)
+    }
+}
+
+impl InboxNonce {
+    pub fn as_bytes(&self) -> [u8; 8] {
+        self.0
+    }
+}
 
 /// Derive an inbox topic's 32-byte ID from the code owner's device pubkey and a short nonce.
 pub fn derive_inbox_topic(device_pubkey: &DeviceId, nonce: &[u8; 8]) -> [u8; 32] {
@@ -39,7 +71,7 @@ pub struct QrCode {
     pub share_intent: ShareIntent,
     /// 8-byte nonce used with `derive_inbox_topic` to reconstruct the inbox topic.
     /// Absent on reply codes.
-    pub inbox_nonce: Option<[u8; 8]>,
+    pub inbox_nonce: Option<InboxNonce>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_repr, Deserialize_repr)]
@@ -56,6 +88,20 @@ pub struct InboxTopic {
     #[serde(with = "expires_at_minutes")]
     pub expires_at: DateTime<Utc>,
     pub topic: Topic<kind::Inbox>,
+}
+
+impl InboxTopic {
+    pub fn from_nonce(
+        device_pubkey: &DeviceId,
+        nonce: &InboxNonce,
+        expires_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            topic: Topic::new(derive_inbox_topic(device_pubkey, &nonce.as_bytes()))
+                .alias_named(&format!("inbox({:?},nonce={})", device_pubkey.aliased(), hex::encode(nonce.as_bytes()))),
+            expires_at,
+        }
+    }
 }
 
 /// Serialize a `DateTime<Utc>` as a `u64` count of whole minutes since the Unix epoch.
@@ -79,7 +125,8 @@ mod expires_at_minutes {
 
 impl std::fmt::Display for QrCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let bytes = encode_cbor(&(&self.device_pubkey, &self.inbox_nonce, &self.share_intent))
+        let inbox_nonce_raw = self.inbox_nonce.map(|n| n.as_bytes());
+        let bytes = encode_cbor(&(&self.device_pubkey, &inbox_nonce_raw, &self.share_intent))
             .map_err(|_| std::fmt::Error)?;
         write!(f, "{}", hex::encode(bytes))
     }
@@ -89,12 +136,12 @@ impl FromStr for QrCode {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let bytes = hex::decode(s)?;
-        let (device_pubkey, inbox_nonce, share_intent): (DeviceId, Option<[u8; 8]>, ShareIntent) =
+        let (device_pubkey, inbox_nonce_raw, share_intent): (DeviceId, Option<[u8; 8]>, ShareIntent) =
             decode_cbor(bytes.as_slice())?;
         Ok(QrCode {
             device_pubkey,
             share_intent,
-            inbox_nonce,
+            inbox_nonce: inbox_nonce_raw.map(InboxNonce),
         })
     }
 }
@@ -127,7 +174,7 @@ mod tests {
         let contact = QrCode {
             device_pubkey,
             share_intent: ShareIntent::AddDevice,
-            inbox_nonce: Some(nonce),
+            inbox_nonce: Some(InboxNonce(nonce)),
         };
         let encoded = contact.to_string();
         let decoded = QrCode::from_str(&encoded).unwrap();

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -47,21 +47,6 @@ pub fn derive_inbox_topic(device_pubkey: &DeviceId, nonce: &[u8; 8]) -> [u8; 32]
 }
 
 /// The content for a QR code or deep link.
-///
-/// These codes are used to introduce two nodes for the purpose of either establishing
-/// mutual friendship, or linking these two devices together under the same identity.
-///
-/// The flow has some similarities in either case. In both cases, an "inbox" is established
-/// for the lifetime of the QR code, so that the QR code recipient can send its own
-/// data back to the sender, without needing to exchange QR codes in both directions.
-///
-/// When linking a device, the QR code sender adds the recipient to the device group.
-/// Whenever a person joins a chat group, they join with their device group, so that all of
-/// their devices can participate in the chat. The ActorId of the group is the unified
-/// identity which that person uses to join chat groups.
-///
-/// When adding a contact, no groups are joined, it's only for the purpose of exchanging
-/// pubkeys and key bundles, so that chat groups can be joined in the future.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 // #[serde(into = "String", try_from = "String")]
 pub struct QrCode {

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -1361,7 +1361,6 @@ impl Node {
     pub async fn add_contact(&self, contact: QrCode) -> Result<(), AddContactError> {
         tracing::debug!(
             device_pub_key = ?contact.device_pubkey.aliased(),
-            inbox_nonce = ?contact.inbox_nonce,
             "adding contact",
         );
 

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -30,7 +30,7 @@ use mailbox_client::manager::{Mailboxes, MailboxesConfig};
 use tokio::task::JoinHandle;
 
 use crate::chat::{ChatMessageContent, ChatOp, ChatOpKind, EditCandidate, ValidChatOps};
-use crate::contact::{InboxNonce, InboxTopic, QrCode, ShareIntent, derive_inbox_topic};
+use crate::contact::{InboxTopic, QrCode, ShareIntent};
 use crate::mailbox::MailboxOperation;
 use crate::payload::{AnnouncementsPayload, ChatPayload, InboxPayload, Payload, Profile};
 use crate::stores::{GroupStore, LocalStore, NodeKeys, OpStore};
@@ -442,35 +442,23 @@ impl Node {
 
     /// Create a new contact QR code with configured expiry time,
     /// subscribe to the inbox topic for it, and register the topic as active.
-    pub async fn new_qr_code(
-        &self,
-        share_intent: ShareIntent,
-        inbox: bool,
-    ) -> Result<QrCode, crate::Error> {
-        let inbox_nonce = if inbox {
-            let nonce: [u8; 8] = rand::random();
-            let topic_bytes = derive_inbox_topic(&self.device_id(), &nonce);
-            let inbox_topic = InboxTopic {
-                topic: Topic::new(topic_bytes)
-                    .alias_named(&format!("inbox({:?})", self.device_id().aliased())),
-                expires_at: Utc::now() + self.config.contact_code_expiry,
-            };
-            self.initialize_topic(*inbox_topic.topic)
-                .await
-                .map_err(|err| crate::Error::InitializeTopic(format!("{err}")))?;
-            self.local_store
-                .add_active_inbox_topic(inbox_topic.clone())
-                .await
-                .map_err(|err| crate::Error::AddActiveInbox(format!("{err}")))?;
-            Some(InboxNonce(nonce))
-        } else {
-            None
-        };
+    pub async fn new_qr_code(&self, share_intent: ShareIntent) -> Result<QrCode, crate::Error> {
+        let (inbox_topic, nonce) = InboxTopic::new_random(
+            &self.device_id(),
+            Utc::now() + self.config.contact_code_expiry,
+        );
+        self.initialize_topic(*inbox_topic.topic)
+            .await
+            .map_err(|err| crate::Error::InitializeTopic(format!("{err}")))?;
+        self.local_store
+            .add_active_inbox_topic(inbox_topic.clone())
+            .await
+            .map_err(|err| crate::Error::AddActiveInbox(format!("{err}")))?;
 
         Ok(QrCode {
             device_pubkey: self.device_id(),
             share_intent,
-            inbox_nonce,
+            inbox_nonce: nonce,
         })
     }
 
@@ -1377,15 +1365,9 @@ impl Node {
             "adding contact",
         );
 
-        let Some(inbox_nonce) = contact.inbox_nonce else {
-            return Err(AddContactError::CreateQrCode(
-                "contact code has no inbox nonce to send a request to".to_string(),
-            ));
-        };
-
         let inbox_topic = InboxTopic::from_nonce(
             &contact.device_pubkey,
-            &inbox_nonce,
+            &contact.inbox_nonce,
             Utc::now() + self.config.contact_code_expiry,
         );
 

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -30,7 +30,7 @@ use mailbox_client::manager::{Mailboxes, MailboxesConfig};
 use tokio::task::JoinHandle;
 
 use crate::chat::{ChatMessageContent, ChatOp, ChatOpKind, EditCandidate, ValidChatOps};
-use crate::contact::{InboxTopic, QrCode, ShareIntent};
+use crate::contact::{InboxTopic, QrCode, ShareIntent, derive_inbox_topic};
 use crate::mailbox::MailboxOperation;
 use crate::payload::{AnnouncementsPayload, ChatPayload, InboxPayload, Payload, Profile};
 use crate::stores::{GroupStore, LocalStore, NodeKeys, OpStore};
@@ -447,9 +447,11 @@ impl Node {
         share_intent: ShareIntent,
         inbox: bool,
     ) -> Result<QrCode, crate::Error> {
-        let inbox_topic = if inbox {
+        let inbox_nonce = if inbox {
+            let nonce: [u8; 8] = rand::random();
+            let topic_bytes = derive_inbox_topic(&self.device_id(), &nonce);
             let inbox_topic = InboxTopic {
-                topic: Topic::inbox()
+                topic: Topic::new(topic_bytes)
                     .alias_named(&format!("inbox({:?})", self.device_id().aliased())),
                 expires_at: Utc::now() + self.config.contact_code_expiry,
             };
@@ -460,15 +462,15 @@ impl Node {
                 .add_active_inbox_topic(inbox_topic.clone())
                 .await
                 .map_err(|err| crate::Error::AddActiveInbox(format!("{err}")))?;
-            Some(inbox_topic)
+            Some(nonce)
         } else {
             None
         };
 
         Ok(QrCode {
             device_pubkey: self.device_id(),
-            inbox_topic,
             share_intent,
+            inbox_nonce,
         })
     }
 
@@ -1371,14 +1373,24 @@ impl Node {
     pub async fn add_contact(&self, contact: QrCode) -> Result<(), AddContactError> {
         tracing::debug!(
             device_pub_key = ?contact.device_pubkey.aliased(),
-            inbox_topic = ?contact.inbox_topic,
+            inbox_nonce = ?contact.inbox_nonce,
             "adding contact",
         );
 
-        let Some(inbox_topic) = contact.inbox_topic.clone() else {
+        let Some(inbox_nonce) = contact.inbox_nonce else {
             return Err(AddContactError::CreateQrCode(
-                "contact code has no inbox to send a request to".to_string(),
+                "contact code has no inbox nonce to send a request to".to_string(),
             ));
+        };
+
+        let inbox_topic = InboxTopic {
+            topic: Topic::new(derive_inbox_topic(&contact.device_pubkey, &inbox_nonce))
+                .alias_named(&format!(
+                    "inbox({:?},nonce={})",
+                    self.device_id().aliased(),
+                    hex::encode(inbox_nonce)
+                )),
+            expires_at: Utc::now() + self.config.contact_code_expiry,
         };
 
         // TODO: use all of this commented out stuff when spaces are possible again

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -1452,10 +1452,6 @@ impl Node {
             .add_reply_inbox_topic(reply_inbox.clone(), contact.device_pubkey)
             .await
             .map_err(|e| Error::AddActiveInbox(format!("{e}")))?;
-        let code = self
-            .new_qr_code(ShareIntent::AddContact, false)
-            .await
-            .map_err(|e| AddContactError::CreateQrCode(e.to_string()))?;
         let Some(profile) = self
             .my_profile()
             .await
@@ -1466,7 +1462,6 @@ impl Node {
         self.publish(
             inbox_topic.topic,
             Payload::Inbox(InboxPayload::ContactRequest {
-                code,
                 profile,
                 agent_id: self.agent_id(),
                 reply_topic: reply_inbox.topic.clone(),

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -30,7 +30,7 @@ use mailbox_client::manager::{Mailboxes, MailboxesConfig};
 use tokio::task::JoinHandle;
 
 use crate::chat::{ChatMessageContent, ChatOp, ChatOpKind, EditCandidate, ValidChatOps};
-use crate::contact::{InboxTopic, QrCode, ShareIntent, derive_inbox_topic};
+use crate::contact::{InboxNonce, InboxTopic, QrCode, ShareIntent, derive_inbox_topic};
 use crate::mailbox::MailboxOperation;
 use crate::payload::{AnnouncementsPayload, ChatPayload, InboxPayload, Payload, Profile};
 use crate::stores::{GroupStore, LocalStore, NodeKeys, OpStore};
@@ -462,7 +462,7 @@ impl Node {
                 .add_active_inbox_topic(inbox_topic.clone())
                 .await
                 .map_err(|err| crate::Error::AddActiveInbox(format!("{err}")))?;
-            Some(nonce)
+            Some(InboxNonce(nonce))
         } else {
             None
         };
@@ -1383,15 +1383,11 @@ impl Node {
             ));
         };
 
-        let inbox_topic = InboxTopic {
-            topic: Topic::new(derive_inbox_topic(&contact.device_pubkey, &inbox_nonce))
-                .alias_named(&format!(
-                    "inbox({:?},nonce={})",
-                    self.device_id().aliased(),
-                    hex::encode(inbox_nonce)
-                )),
-            expires_at: Utc::now() + self.config.contact_code_expiry,
-        };
+        let inbox_topic = InboxTopic::from_nonce(
+            &contact.device_pubkey,
+            &inbox_nonce,
+            Utc::now() + self.config.contact_code_expiry,
+        );
 
         // TODO: use all of this commented out stuff when spaces are possible again
         // // XXX: there should be a better way to wait for the device group to be created,

--- a/crates/dashchat-node/src/payload.rs
+++ b/crates/dashchat-node/src/payload.rs
@@ -9,7 +9,6 @@ use std::collections::BTreeMap;
 
 use crate::chat::ChatId;
 use crate::compat::Capabilities;
-use crate::contact::QrCode;
 use crate::topic::{Topic, kind};
 use crate::{AgentId, AsBody, Cbor, ChatMessageContent, ChatReaction, DeviceId};
 
@@ -50,7 +49,6 @@ pub enum InboxPayload {
     /// `agent_id` is the sender's agent id; the recipient records it against the
     /// op author (device_pubkey)
     ContactRequest {
-        code: QrCode,
         profile: Profile,
         agent_id: AgentId,
         reply_topic: Topic<kind::Inbox>,

--- a/crates/dashchat-node/src/testing/behavior.rs
+++ b/crates/dashchat-node/src/testing/behavior.rs
@@ -27,7 +27,7 @@ impl Behavior {
         other: &TestNode,
         share_intent: ShareIntent,
     ) -> anyhow::Result<()> {
-        let qr = self.new_qr_code(share_intent, true).await?;
+        let qr = self.new_qr_code(share_intent).await?;
         other.add_contact(qr).await?;
         self.accept_next_contact().await?;
         self.await_first_capabilities(other.device_id()).await?;

--- a/crates/dashchat-node/tests/contacts.rs
+++ b/crates/dashchat-node/tests/contacts.rs
@@ -30,10 +30,7 @@ async fn test_reject_contact_request() {
     println!("bobbi: {}", bobbi.device_id());
 
     // Alice generates a QR code with inbox
-    let qr = alice
-        .new_qr_code(ShareIntent::AddContact, true)
-        .await
-        .unwrap();
+    let qr = alice.new_qr_code(ShareIntent::AddContact).await.unwrap();
 
     // Bobbi scans the QR code and sends a contact request to Alice's inbox
     bobbi.add_contact(qr).await.unwrap();
@@ -91,14 +88,8 @@ async fn test_reject_multiple_contact_requests() {
     println!("### {:3.1?} alice creating QR codes", start.elapsed());
 
     // Alice generates QR codes for both Bobbi and Carol
-    let qr_for_bobbi = alice
-        .new_qr_code(ShareIntent::AddContact, true)
-        .await
-        .unwrap();
-    let qr_for_carol = alice
-        .new_qr_code(ShareIntent::AddContact, true)
-        .await
-        .unwrap();
+    let qr_for_bobbi = alice.new_qr_code(ShareIntent::AddContact).await.unwrap();
+    let qr_for_carol = alice.new_qr_code(ShareIntent::AddContact).await.unwrap();
 
     println!(
         "### {:3.1?} bobbi and carol scanning QR codes",
@@ -179,10 +170,7 @@ async fn test_inbox_two_way_flow() {
 
     // Alice generates a QR code with an inbox and Bobbi scans it, sending his
     // contact request to Alice's inbox.
-    let qr = alice
-        .new_qr_code(ShareIntent::AddContact, true)
-        .await
-        .unwrap();
+    let qr = alice.new_qr_code(ShareIntent::AddContact).await.unwrap();
     bobbi.add_contact(qr).await.unwrap();
 
     // Alice waits for Bobbi's contact request and explicitly accepts it. Since

--- a/crates/dashchat-node/tests/device_groups.rs
+++ b/crates/dashchat-node/tests/device_groups.rs
@@ -33,12 +33,7 @@ async fn device_group_solo() {
     println!("peers see each other");
 
     alice
-        .add_contact(
-            alicia
-                .new_qr_code(ShareIntent::AddDevice, true)
-                .await
-                .unwrap(),
-        )
+        .add_contact(alicia.new_qr_code(ShareIntent::AddDevice).await.unwrap())
         .await
         .unwrap();
 

--- a/crates/dashchat-node/tests/mailboxes.rs
+++ b/crates/dashchat-node/tests/mailboxes.rs
@@ -25,10 +25,7 @@ async fn mailbox_late_join() {
     let alice = TestNode::new(config.clone(), "alice").await;
     let bobbi = TestNode::new(config.clone(), "bobbi").await;
 
-    let qr = alice
-        .new_qr_code(ShareIntent::AddContact, true)
-        .await
-        .unwrap();
+    let qr = alice.new_qr_code(ShareIntent::AddContact).await.unwrap();
     bobbi.add_contact(qr).await.unwrap();
 
     alice.add_mailbox(&mailbox).await;
@@ -100,10 +97,7 @@ async fn test_mailbox_restart_relay() {
     let alice_agent_id = alice.agent_id();
     let bobbi_agent_id = bobbi.agent_id();
 
-    let qr = alice
-        .new_qr_code(ShareIntent::AddContact, true)
-        .await
-        .unwrap();
+    let qr = alice.new_qr_code(ShareIntent::AddContact).await.unwrap();
     bobbi.add_contact(qr).await.unwrap();
 
     let dummy_key = || iroh::SecretKey::generate().public();

--- a/crates/dashchat-node/tests/profiles.rs
+++ b/crates/dashchat-node/tests/profiles.rs
@@ -97,12 +97,7 @@ async fn test_profiles_sync_between_contacts() {
         .unwrap();
 
     alice
-        .add_contact(
-            bobbi
-                .new_qr_code(ShareIntent::AddContact, true)
-                .await
-                .unwrap(),
-        )
+        .add_contact(bobbi.new_qr_code(ShareIntent::AddContact).await.unwrap())
         .await
         .unwrap();
 

--- a/packages/stores/src/contacts/contact-code.ts
+++ b/packages/stores/src/contacts/contact-code.ts
@@ -24,6 +24,17 @@ function bytesToHex(bytes: Uint8Array): string {
 	return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
 }
 
+function toPaddedBase64(base64: string): string {
+	const remainder = base64.length % 4;
+	if (remainder === 0) {
+		return base64;
+	}
+	if (remainder === 1) {
+		throw new Error('Invalid base64 contact code');
+	}
+	return base64.padEnd(base64.length + (4 - remainder), '=');
+}
+
 // The hex string keys are converted to raw bytes before CBOR encoding.
 // The inbox topic is replaced by an 8-byte nonce, cutting the code length by ~30%.
 export function encodeContactCode(contactCode: ContactCode): string {
@@ -32,14 +43,16 @@ export function encodeContactCode(contactCode: ContactCode): string {
 		contactCode.inbox_nonce ? toBytes(contactCode.inbox_nonce) : null,
 		contactCode.share_intent,
 	]);
-	return fromByteArray(bin);
+	return fromByteArray(bin).replace(/=+$/, '');
 }
 
 export function decodeContactCode(contactCodeString: string): ContactCode {
-	const bin = toByteArray(contactCodeString);
+	const bin = toByteArray(toPaddedBase64(contactCodeString));
 	const [device_pubkey_bytes, inbox_nonce_bytes, share_intent] = decode(bin);
 	const device_pubkey = bytesToHex(device_pubkey_bytes);
-	const inbox_nonce = inbox_nonce_bytes ? bytesToHex(inbox_nonce_bytes) : undefined;
+	const inbox_nonce = inbox_nonce_bytes
+		? bytesToHex(inbox_nonce_bytes)
+		: undefined;
 	return { device_pubkey, share_intent, inbox_nonce };
 }
 

--- a/packages/stores/src/contacts/contact-code.ts
+++ b/packages/stores/src/contacts/contact-code.ts
@@ -40,7 +40,7 @@ function toPaddedBase64(base64: string): string {
 export function encodeContactCode(contactCode: ContactCode): string {
 	const bin = encode([
 		toBytes(contactCode.device_pubkey),
-		contactCode.inbox_nonce ? toBytes(contactCode.inbox_nonce) : null,
+		toBytes(contactCode.inbox_nonce),
 		contactCode.share_intent,
 	]);
 	return fromByteArray(bin).replace(/=+$/, '');
@@ -50,9 +50,7 @@ export function decodeContactCode(contactCodeString: string): ContactCode {
 	const bin = toByteArray(toPaddedBase64(contactCodeString));
 	const [device_pubkey_bytes, inbox_nonce_bytes, share_intent] = decode(bin);
 	const device_pubkey = bytesToHex(device_pubkey_bytes);
-	const inbox_nonce = inbox_nonce_bytes
-		? bytesToHex(inbox_nonce_bytes as Uint8Array)
-		: undefined;
+	const inbox_nonce = bytesToHex(inbox_nonce_bytes as Uint8Array);
 	return { device_pubkey, share_intent, inbox_nonce };
 }
 

--- a/packages/stores/src/contacts/contact-code.ts
+++ b/packages/stores/src/contacts/contact-code.ts
@@ -10,23 +10,26 @@ function hexToBytes(hex: string): Uint8Array {
 	);
 }
 
+function toBytes(value: string | Uint8Array | number[]): Uint8Array {
+	if (typeof value === 'string') {
+		return hexToBytes(value);
+	}
+	if (value instanceof Uint8Array) {
+		return value;
+	}
+	return Uint8Array.from(value);
+}
+
 function bytesToHex(bytes: Uint8Array): string {
 	return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
 }
 
-// The hex string keys (device_pubkey, inbox_topic.topic) are converted to raw
-// bytes before CBOR encoding so each 32-byte key costs 32 bytes rather than a
-// 64-char text string, roughly halving the encoded contact code.
+// The hex string keys are converted to raw bytes before CBOR encoding.
+// The inbox topic is replaced by an 8-byte nonce, cutting the code length by ~30%.
 export function encodeContactCode(contactCode: ContactCode): string {
-	const inboxTopic = contactCode.inbox_topic
-		? [
-				contactCode.inbox_topic.expires_at,
-				hexToBytes(contactCode.inbox_topic.topic),
-			]
-		: null;
 	const bin = encode([
-		hexToBytes(contactCode.device_pubkey),
-		inboxTopic,
+		toBytes(contactCode.device_pubkey),
+		contactCode.inbox_nonce ? toBytes(contactCode.inbox_nonce) : null,
 		contactCode.share_intent,
 	]);
 	return fromByteArray(bin);
@@ -34,14 +37,10 @@ export function encodeContactCode(contactCode: ContactCode): string {
 
 export function decodeContactCode(contactCodeString: string): ContactCode {
 	const bin = toByteArray(contactCodeString);
-	const [device_pubkey, inbox_topic, share_intent] = decode(bin);
-	return {
-		device_pubkey: bytesToHex(device_pubkey),
-		inbox_topic: inbox_topic
-			? { expires_at: inbox_topic[0], topic: bytesToHex(inbox_topic[1]) }
-			: undefined,
-		share_intent,
-	};
+	const [device_pubkey_bytes, inbox_nonce_bytes, share_intent] = decode(bin);
+	const device_pubkey = bytesToHex(device_pubkey_bytes);
+	const inbox_nonce = inbox_nonce_bytes ? bytesToHex(inbox_nonce_bytes) : undefined;
+	return { device_pubkey, share_intent, inbox_nonce };
 }
 
 export const compress = async (

--- a/packages/stores/src/contacts/contact-code.ts
+++ b/packages/stores/src/contacts/contact-code.ts
@@ -10,16 +10,6 @@ function hexToBytes(hex: string): Uint8Array {
 	);
 }
 
-function toBytes(value: string | Uint8Array | number[]): Uint8Array {
-	if (typeof value === 'string') {
-		return hexToBytes(value);
-	}
-	if (value instanceof Uint8Array) {
-		return value;
-	}
-	return Uint8Array.from(value);
-}
-
 function bytesToHex(bytes: Uint8Array): string {
 	return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
 }
@@ -39,8 +29,8 @@ function toPaddedBase64(base64: string): string {
 // The inbox topic is replaced by an 8-byte nonce, cutting the code length by ~30%.
 export function encodeContactCode(contactCode: ContactCode): string {
 	const bin = encode([
-		toBytes(contactCode.device_pubkey),
-		toBytes(contactCode.inbox_nonce),
+		hexToBytes(contactCode.device_pubkey),
+		hexToBytes(contactCode.inbox_nonce),
 		contactCode.share_intent,
 	]);
 	return fromByteArray(bin).replace(/=+$/, '');

--- a/packages/stores/src/contacts/contact-code.ts
+++ b/packages/stores/src/contacts/contact-code.ts
@@ -2,7 +2,7 @@ import { fromByteArray, toByteArray } from 'base64-js';
 // @ts-ignore
 import { decode, encode } from 'cbor-web';
 
-import { ContactCode } from '../types';
+import { ContactCode, ShareIntent } from '../types';
 
 function hexToBytes(hex: string): Uint8Array {
 	return Uint8Array.from(
@@ -26,7 +26,6 @@ function toPaddedBase64(base64: string): string {
 }
 
 // The hex string keys are converted to raw bytes before CBOR encoding.
-// The inbox topic is replaced by an 8-byte nonce, cutting the code length by ~30%.
 export function encodeContactCode(contactCode: ContactCode): string {
 	const bin = encode([
 		hexToBytes(contactCode.device_pubkey),
@@ -38,9 +37,11 @@ export function encodeContactCode(contactCode: ContactCode): string {
 
 export function decodeContactCode(contactCodeString: string): ContactCode {
 	const bin = toByteArray(toPaddedBase64(contactCodeString));
-	const [device_pubkey_bytes, inbox_nonce_bytes, share_intent] = decode(bin);
+	const [device_pubkey_bytes, inbox_nonce_bytes, share_intent] = decode(
+		bin,
+	) as [Uint8Array, Uint8Array, ShareIntent];
 	const device_pubkey = bytesToHex(device_pubkey_bytes);
-	const inbox_nonce = bytesToHex(inbox_nonce_bytes as Uint8Array);
+	const inbox_nonce = bytesToHex(inbox_nonce_bytes);
 	return { device_pubkey, share_intent, inbox_nonce };
 }
 

--- a/packages/stores/src/contacts/contact-code.ts
+++ b/packages/stores/src/contacts/contact-code.ts
@@ -51,7 +51,7 @@ export function decodeContactCode(contactCodeString: string): ContactCode {
 	const [device_pubkey_bytes, inbox_nonce_bytes, share_intent] = decode(bin);
 	const device_pubkey = bytesToHex(device_pubkey_bytes);
 	const inbox_nonce = inbox_nonce_bytes
-		? bytesToHex(inbox_nonce_bytes)
+		? bytesToHex(inbox_nonce_bytes as Uint8Array)
 		: undefined;
 	return { device_pubkey, share_intent, inbox_nonce };
 }

--- a/packages/stores/src/contacts/contacts-store.ts
+++ b/packages/stores/src/contacts/contacts-store.ts
@@ -5,12 +5,11 @@ import { LogsStore } from '../p2panda/logs-store';
 import { SimplifiedOperation } from '../p2panda/simplified-types';
 import { AgentId, DeviceId, TopicId } from '../p2panda/types';
 import { personalTopicFor } from '../topics';
-import { AnnouncementPayload, ContactCode, Payload } from '../types';
+import { AnnouncementPayload, Payload } from '../types';
 import { IContactsClient, Profile } from './contacts-client';
 
 export interface ContactRequest {
 	profile: Profile;
-	code: ContactCode;
 	agentId: AgentId;
 	timestamp: number;
 	topicId: TopicId;
@@ -173,7 +172,7 @@ export class ContactsStore {
 				for (const operation of operations) {
 					if (operation.body?.type !== 'Inbox') continue;
 					if (operation.body.payload.type !== 'ContactRequest') continue;
-					const { code, profile, agent_id } = operation.body.payload.payload;
+					const { profile, agent_id } = operation.body.payload.payload;
 					if (!agent_id) continue;
 					const agentId = agent_id;
 
@@ -189,7 +188,6 @@ export class ContactsStore {
 						continue;
 
 					contactRequests.push({
-						code,
 						profile,
 						agentId,
 						topicId,

--- a/packages/stores/src/mock/contacts-client.ts
+++ b/packages/stores/src/mock/contacts-client.ts
@@ -1,7 +1,7 @@
 import type { IContactsClient, Profile } from '../contacts/contacts-client';
 import type { AgentId, DeviceId, TopicId } from '../p2panda/types';
 import { personalTopicFor } from '../topics';
-import type { ContactCode, InboxTopic } from '../types';
+import type { ContactCode } from '../types';
 import { ShareIntent } from '../types';
 import type { LocalStorageLogsClient } from './client';
 
@@ -36,10 +36,10 @@ export class MockContactsClient implements IContactsClient {
 	async createContactCode(): Promise<ContactCode> {
 		return {
 			device_pubkey: this.deviceId,
-			inbox_topic: this.inboxTopics[0]
-				? { topic: this.inboxTopics[0], expires_at: Date.now() + 86400000 }
-				: undefined,
 			share_intent: ShareIntent.AddContact,
+			inbox_nonce: Array.from(crypto.getRandomValues(new Uint8Array(8)), b =>
+				b.toString(16).padStart(2, '0'),
+			).join(''),
 		};
 	}
 

--- a/packages/stores/src/mock/contacts-client.ts
+++ b/packages/stores/src/mock/contacts-client.ts
@@ -37,7 +37,9 @@ export class MockContactsClient implements IContactsClient {
 		return {
 			device_pubkey: this.deviceId,
 			share_intent: ShareIntent.AddContact,
-			inbox_nonce: Array.from(crypto.getRandomValues(new Uint8Array(8)), b => b.toString(16).padStart(2, '0')).join(''),
+			inbox_nonce: Array.from(crypto.getRandomValues(new Uint8Array(8)), b =>
+				b.toString(16).padStart(2, '0'),
+			).join(''),
 		};
 	}
 

--- a/packages/stores/src/mock/contacts-client.ts
+++ b/packages/stores/src/mock/contacts-client.ts
@@ -37,9 +37,7 @@ export class MockContactsClient implements IContactsClient {
 		return {
 			device_pubkey: this.deviceId,
 			share_intent: ShareIntent.AddContact,
-			inbox_nonce: Array.from(crypto.getRandomValues(new Uint8Array(8)), b =>
-				b.toString(16).padStart(2, '0'),
-			).join(''),
+			inbox_nonce: Array.from(crypto.getRandomValues(new Uint8Array(8)), b => b.toString(16).padStart(2, '0')).join(''),
 		};
 	}
 

--- a/packages/stores/src/mock/seed-demo-data.ts
+++ b/packages/stores/src/mock/seed-demo-data.ts
@@ -220,7 +220,7 @@ export function seedDemoData(logsClient: LocalStorageLogsClient) {
 				payload: {
 					code: {
 						device_pubkey: EVE.deviceId,
-						inbox_topic: undefined,
+						inbox_nonce: 'ee'.repeat(8),
 						share_intent: ShareIntent.AddContact,
 					},
 					agent_id: EVE.agentId,

--- a/packages/stores/src/mock/seed-demo-data.ts
+++ b/packages/stores/src/mock/seed-demo-data.ts
@@ -1,5 +1,4 @@
 import { personalTopicFor } from '../topics';
-import { ShareIntent } from '../types';
 import { LocalStorageLogsClient, hash } from './client';
 
 export const DEMO_IDS = {
@@ -218,11 +217,6 @@ export function seedDemoData(logsClient: LocalStorageLogsClient) {
 			payload: {
 				type: 'ContactRequest',
 				payload: {
-					code: {
-						device_pubkey: EVE.deviceId,
-						inbox_nonce: 'ee'.repeat(8),
-						share_intent: ShareIntent.AddContact,
-					},
 					agent_id: EVE.agentId,
 					reply_topic: DEMO_IDS.INBOX_TOPIC,
 					profile: {

--- a/packages/stores/src/types.ts
+++ b/packages/stores/src/types.ts
@@ -167,7 +167,7 @@ export interface ContactCode {
 	device_pubkey: DeviceId;
 	/// The intent of the QR code: whether to add this node as a contact or a device.
 	share_intent: ShareIntent;
-	/// 8-byte nonce (hex string) used with blake3(device_pubkey || nonce) to derive
+	/// 8-byte nonce used with blake3(device_pubkey || nonce) to derive
 	/// the inbox topic. Absent on reply codes.
 	inbox_nonce?: string;
 }

--- a/packages/stores/src/types.ts
+++ b/packages/stores/src/types.ts
@@ -168,8 +168,8 @@ export interface ContactCode {
 	/// The intent of the QR code: whether to add this node as a contact or a device.
 	share_intent: ShareIntent;
 	/// 8-byte nonce used with blake3(device_pubkey || nonce) to derive
-	/// the inbox topic. Absent on reply codes.
-	inbox_nonce?: string;
+	/// the inbox topic.
+	inbox_nonce: string;
 }
 
 export interface ReadMessagesPayload {

--- a/packages/stores/src/types.ts
+++ b/packages/stores/src/types.ts
@@ -165,9 +165,11 @@ export const ShareIntent = {
 export interface ContactCode {
 	/// Pubkey of this node: allows adding this node to groups.
 	device_pubkey: DeviceId;
-	inbox_topic: InboxTopic | undefined;
 	/// The intent of the QR code: whether to add this node as a contact or a device.
 	share_intent: ShareIntent;
+	/// 8-byte nonce (hex string) used with blake3(device_pubkey || nonce) to derive
+	/// the inbox topic. Absent on reply codes.
+	inbox_nonce?: string;
 }
 
 export interface ReadMessagesPayload {

--- a/packages/stores/src/types.ts
+++ b/packages/stores/src/types.ts
@@ -150,11 +150,6 @@ export type ChatPayload =
 	| { type: 'JoinGroup'; payload: { chat_id: string } }
 	| { type: 'GroupInfo'; payload: GroupInfo };
 
-export interface InboxTopic {
-	expires_at: number;
-	topic: TopicId;
-}
-
 /** Numeric discriminant matching `dashchat_node::ShareIntent` (serde_repr u8). */
 export type ShareIntent = 0 | 1;
 export const ShareIntent = {

--- a/packages/stores/src/types.ts
+++ b/packages/stores/src/types.ts
@@ -186,7 +186,6 @@ export type DeviceGroupPayload =
 export type InboxPayload = {
 	type: 'ContactRequest';
 	payload: {
-		code: ContactCode;
 		profile: Profile;
 		agent_id: AgentId;
 		reply_topic: TopicId;

--- a/src-tauri/src/commands/contacts.rs
+++ b/src-tauri/src/commands/contacts.rs
@@ -8,7 +8,7 @@ use crate::error::Error;
 #[tauri::command]
 pub async fn create_contact_code(app_node: State<'_, AppNode>) -> Result<QrCode, Error> {
     let node = app_node.get().await?;
-    Ok(node.new_qr_code(ShareIntent::AddContact, true).await?)
+    Ok(node.new_qr_code(ShareIntent::AddContact).await?)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/redact_log.rs
+++ b/src-tauri/src/commands/redact_log.rs
@@ -19,8 +19,8 @@ static REDACTION_REGEXES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
         r"[A-Za-z0-9+/]{40,}={0,2}",
         // DeviceId and AgentId wrappers (must precede bare VerifyingKey/Hash patterns)
         r"(DeviceId|AgentId)\([^)]*\([^)]*\)\)",
-        // Debug-formatted byte arrays: VerifyingKey([1, 2, ...]), Hash([...]), Signature([...])
-        r"(VerifyingKey|Hash|Signature)\(\[[\d, ]+\]\)",
+        // Debug-formatted byte arrays: VerifyingKey([1, 2, ...]), Hash([...]), Signature([...]), InboxNonce([...])
+        r"(VerifyingKey|Hash|Signature|InboxNonce)\(\[[\d, ]+\]\)",
         // Timestamps (seconds or microseconds since epoch, 10+ digits)
         r#""?timestamp"?\s*:?\s*\d{10,}"#,
         // Debug format: name/surname/about/description fields with quoted values


### PR DESCRIPTION
Further shortening of the QR Code

This is done by replacing the 32 byte topic with an 8 byte nonce that can be used to derive the topic. 
And, by switching to an unpadded code to avoid the couple of "==" on the end.