### PR TITLE
Make tombstoning a cross-device operation

### DIFF
--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -1208,9 +1208,15 @@ impl Node {
         let Some(payload) = Payload::try_from_body_opt(operation.body.as_ref())? else {
             return Ok(());
         };
-        if self.is_tombstoneable(&payload) {
+        if Self::is_tombstoneable(&payload) {
             let hash = operation.hash;
-            self.local_store.add_tombstone(topic, hash.clone()).await?;
+            self.publish(
+                self.device_group_topic(),
+                Payload::DeviceGroup(DeviceGroupPayload::TombstoneMessage { topic, hash }),
+                Some(&format!("tombstone {:?}", hash.aliased())),
+            )
+            .await?;
+
             self.unprocess_app(operation).await?;
             self.op_store.delete_body(&hash).await?;
         } else {

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -1192,14 +1192,10 @@ impl Node {
         Ok(latest.map(|(_, d)| d))
     }
 
-    /// Tombstone an operation: record its hash in the topic's persisted
-    /// tombstone set so its payload is never stored or synced again, and
-    /// immediately drop any payload already stored for it.
-    ///
-    /// This has the effect that when the operation is played back, it will
-    /// not have a payload. Therefore, payloads for which [`Self::is_tombstoneable`]
-    /// is `true` MUST also revert their changes in [`Self::unprocess_app`]
-    /// so that they leave behind no traces in local state.
+    /// Record a Tombstone in the device group topic for a given operation,
+    /// which when processed has the effect that the target payload is
+    /// never stored or synced again, and the node immediately drops any payload
+    /// already stored for it.
     pub async fn tombstone_operation(
         &self,
         topic: TopicId,

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -1216,9 +1216,6 @@ impl Node {
                 Some(&format!("tombstone {:?}", hash.aliased())),
             )
             .await?;
-
-            self.unprocess_app(operation).await?;
-            self.op_store.delete_body(&hash).await?;
         } else {
             tracing::warn!(operation = ?operation.hash.aliased(), "operation is not tombstoneable");
         }

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -251,6 +251,8 @@ impl Node {
     /// synced onward. The operation arrives here already written to the op
     /// store (by peers or by mailbox sync), so this deletes the body after the
     /// fact.
+    //
+    // TODO: when device groups exist, test that tombstones are enforced across devices.
     async fn enforce_tombstone(
         &self,
         topic: TopicId,

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -253,12 +253,12 @@ impl Node {
     /// fact.
     async fn enforce_tombstone(
         &self,
-        operation: &ProcessedOperation<Payload>,
+        topic: TopicId,
+        tombstoned_op: &Operation,
     ) -> anyhow::Result<bool> {
-        let topic = operation.topic();
-        let hash = operation.id();
+        let hash = tombstoned_op.hash;
         if self.projection.is_tombstoned(topic, hash).await? {
-            self.unprocess_app(&operation.processed().operation).await?;
+            self.unprocess_app(tombstoned_op).await?;
             self.op_store.delete_body(&hash).await?;
             Ok(true)
         } else {
@@ -416,19 +416,6 @@ impl Node {
         let dashchat_topic = crate::Topic::new(*topic.as_bytes());
         let header = operation.processed().header();
 
-        // NOTE: realistically the tombstone will only be enforced here
-        // upon playback of operations. The first time through, it will
-        // have been processed and potentially have modified local state.
-        // Upon tombstoning (or enforcement), it will be "unprocessed"
-        // via [`Self::unprocess_app`] to undo those state changes,
-        // as if it were never processed at all. On playback, the operation
-        // simply doesn't get processed.
-        if self.enforce_tombstone(&operation).await? {
-            // The payload is tombstoned, so there's nothing to process.
-            self.notify_header(dashchat_topic, header).await?;
-            return Ok(());
-        }
-
         // If an operation is invalidated by the projection layer, we don't process it,
         // but still allow it to be acknowledged as processed.
         match self.projection.reduce(self.agent_id(), operation).await {
@@ -452,6 +439,21 @@ impl Node {
         let payload = operation.message();
 
         match &payload {
+            Payload::DeviceGroup(DeviceGroupPayload::TombstoneMessage { topic, hash }) => {
+                // If a node is processing this as the author of the tombstone (and hence the target),
+                // then the target operation needs to be cleared from all storage.
+                // If a receiver is processing this, they may have already received and processed the operation,
+                // or they may receive the operation after this point.
+
+                if let Some(tombstoned_op) = self.op_store.get_operation(hash).await? {
+                    let purged = self.enforce_tombstone(*topic, &tombstoned_op).await?;
+                    assert!(purged);
+                    // The payload is tombstoned, so there's nothing to process.
+                    self.notify_header(dashchat_topic, header).await?;
+                    return Ok(());
+                }
+            }
+
             Payload::GroupControl(_) => {
                 // Nothing to do.
             }

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -461,9 +461,6 @@ impl Node {
                         purged,
                         "operation was expected to be tombstoned but was not"
                     );
-                    // The payload is tombstoned, so there's nothing to process.
-                    self.notify_header(dashchat_topic, header).await?;
-                    return Ok(());
                 }
             }
 

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -436,20 +436,31 @@ impl Node {
             }
         }
 
+        // If a receiver is processing this, the tombstone may have been processed prior,
+        // so we want to drop the payload now and not process it.
+        if self
+            .enforce_tombstone(topic, &operation.event.operation)
+            .await?
+        {
+            // The payload is tombstoned, so we must not process it. Return early.
+            self.notify_header(dashchat_topic, header).await?;
+            return Ok(());
+        }
+
         let hash = operation.id();
         let author = DeviceId::from(operation.author());
         let payload = operation.message();
 
         match &payload {
             Payload::DeviceGroup(DeviceGroupPayload::TombstoneMessage { topic, hash }) => {
-                // If a node is processing this as the author of the tombstone (and hence the target),
-                // then the target operation needs to be cleared from all storage.
-                // If a receiver is processing this, they may have already received and processed the operation,
-                // or they may receive the operation after this point.
-
+                // If a node has already processed the target, now that the tombstone has arrived
+                // it's time to purge it.
                 if let Some(tombstoned_op) = self.op_store.get_operation(hash).await? {
                     let purged = self.enforce_tombstone(*topic, &tombstoned_op).await?;
-                    assert!(purged);
+                    debug_assert!(
+                        purged,
+                        "operation was expected to be tombstoned but was not"
+                    );
                     // The payload is tombstoned, so there's nothing to process.
                     self.notify_header(dashchat_topic, header).await?;
                     return Ok(());

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -256,7 +256,7 @@ impl Node {
     ) -> anyhow::Result<bool> {
         let topic = operation.topic();
         let hash = operation.id();
-        if self.local_store.is_tombstoned(topic, hash).await? {
+        if self.projection.is_tombstoned(topic, hash).await? {
             self.unprocess_app(&operation.processed().operation).await?;
             self.op_store.delete_body(&hash).await?;
             Ok(true)
@@ -266,7 +266,7 @@ impl Node {
     }
 
     /// Filter out operations whose payloads are not able to be deleted.
-    pub(crate) fn is_tombstoneable(&self, payload: &Payload) -> bool {
+    pub(crate) fn is_tombstoneable(payload: &Payload) -> bool {
         matches!(payload, Payload::Chat(ChatPayload::Message(_)))
     }
 
@@ -351,7 +351,7 @@ impl Node {
         let Some(payload) = Payload::try_from_body_opt(operation.body.as_ref())? else {
             return Ok(());
         };
-        if self.is_tombstoneable(&payload) {
+        if Self::is_tombstoneable(&payload) {
             match payload {
                 Payload::Chat(ChatPayload::Message(m)) => {
                     use p2panda_store::topics::TopicStore;

--- a/crates/dashchat-node/src/payload.rs
+++ b/crates/dashchat-node/src/payload.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 
 use crate::chat::ChatId;
 use crate::topic::{Topic, kind};
-use crate::{AgentId, AsBody, Cbor, ChatMessageContent, ChatReaction, DeviceId};
+use crate::{AgentId, AsBody, Cbor, ChatMessageContent, ChatReaction, DeviceId, TopicId};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Profile {
@@ -141,6 +141,10 @@ pub enum DeviceGroupPayload {
     },
     RejectContactRequest(AgentId),
     ReadMessages(ReadMessagesPayload),
+    TombstoneMessage {
+        topic: TopicId,
+        hash: Hash,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/dashchat-node/src/stores/local_store.rs
+++ b/crates/dashchat-node/src/stores/local_store.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
 
 use chrono::{DateTime, Utc};
-use p2panda::Hash;
 use sqlx::SqlitePool;
 
 use crate::{
@@ -37,11 +36,6 @@ const MIGRATIONS: &[&str] = &[
         expires_at_nanos INTEGER NOT NULL,
         role INTEGER NOT NULL DEFAULT 0,
         expected_ack_author BLOB NULL
-    )",
-    "CREATE TABLE IF NOT EXISTS tombstones (
-        topic_id BLOB NOT NULL,
-        op_hash BLOB NOT NULL,
-        PRIMARY KEY (topic_id, op_hash)
     )",
     "CREATE TABLE IF NOT EXISTS unfetched_blob_hashes (
         blob_hash BLOB NOT NULL,
@@ -313,43 +307,6 @@ impl LocalStore {
         Ok(())
     }
 
-    /// Record an operation hash in the per-topic tombstone set. Payloads for
-    /// tombstoned operations must never be stored or synced.
-    pub async fn add_tombstone(&self, topic: TopicId, op_hash: Hash) -> anyhow::Result<()> {
-        sqlx::query("INSERT OR IGNORE INTO tombstones (topic_id, op_hash) VALUES (?, ?)")
-            .bind(topic.as_bytes().to_vec())
-            .bind(op_hash.as_bytes().to_vec())
-            .execute(&self.pool)
-            .await?;
-        Ok(())
-    }
-
-    pub async fn is_tombstoned(&self, topic: TopicId, op_hash: Hash) -> anyhow::Result<bool> {
-        let row: Option<(i64,)> =
-            sqlx::query_as("SELECT 1 FROM tombstones WHERE topic_id = ? AND op_hash = ?")
-                .bind(topic.as_bytes().to_vec())
-                .bind(op_hash.as_bytes().to_vec())
-                .fetch_optional(&self.pool)
-                .await?;
-        Ok(row.is_some())
-    }
-
-    pub async fn tombstoned_hashes(&self, topic: TopicId) -> anyhow::Result<BTreeSet<Hash>> {
-        let rows: Vec<(Vec<u8>,)> =
-            sqlx::query_as("SELECT op_hash FROM tombstones WHERE topic_id = ?")
-                .bind(topic.as_bytes().to_vec())
-                .fetch_all(&self.pool)
-                .await?;
-        rows.into_iter()
-            .map(|(bytes,)| {
-                let arr: [u8; 32] = bytes
-                    .try_into()
-                    .map_err(|_| anyhow::anyhow!("tombstone op_hash is not 32 bytes"))?;
-                Ok(Hash::from_bytes(arr))
-            })
-            .collect()
-    }
-
     pub async fn add_unfetched_blobs(
         &self,
         mailbox_id: &str,
@@ -464,57 +421,6 @@ mod tests {
             private_key.as_bytes()
         );
         assert_eq!(store.agent_id().await.unwrap(), agent_id);
-    }
-
-    #[tokio::test]
-    async fn test_tombstones_per_topic() {
-        let dir = tempfile::tempdir().unwrap();
-        let pool = create_sqlite_pool(dir.path().join("test_tombstones.db"))
-            .await
-            .unwrap();
-        let store = LocalStore::new(pool.clone()).await.unwrap();
-
-        let topic_a = *Topic::<kind::Untyped>::new([1; 32]);
-        let topic_b = *Topic::<kind::Untyped>::new([2; 32]);
-        let hash1 = Hash::digest(b"op1");
-        let hash2 = Hash::digest(b"op2");
-
-        assert!(!store.is_tombstoned(topic_a, hash1).await.unwrap());
-
-        store.add_tombstone(topic_a, hash1).await.unwrap();
-        store.add_tombstone(topic_a, hash2).await.unwrap();
-        store.add_tombstone(topic_b, hash1).await.unwrap();
-        // Adding the same hash again is idempotent.
-        store.add_tombstone(topic_a, hash1).await.unwrap();
-
-        assert!(store.is_tombstoned(topic_a, hash1).await.unwrap());
-        assert!(store.is_tombstoned(topic_a, hash2).await.unwrap());
-        // Tombstones are scoped per-topic: hash2 in topic_a does not leak into topic_b.
-        assert!(store.is_tombstoned(topic_b, hash1).await.unwrap());
-        assert!(!store.is_tombstoned(topic_b, hash2).await.unwrap());
-
-        assert_eq!(
-            store.tombstoned_hashes(topic_a).await.unwrap(),
-            maplit::btreeset![hash1, hash2]
-        );
-        assert_eq!(
-            store.tombstoned_hashes(topic_b).await.unwrap(),
-            maplit::btreeset![hash1]
-        );
-
-        // Tombstones persist across reopening the database.
-        drop(store);
-        pool.close().await;
-
-        let pool = create_sqlite_pool(dir.path().join("test_tombstones.db"))
-            .await
-            .unwrap();
-        let store = LocalStore::new(pool).await.unwrap();
-        assert!(store.is_tombstoned(topic_a, hash1).await.unwrap());
-        assert_eq!(
-            store.tombstoned_hashes(topic_a).await.unwrap(),
-            maplit::btreeset![hash1, hash2]
-        );
     }
 
     #[tokio::test]

--- a/crates/dashchat-node/src/stores/op_projection.rs
+++ b/crates/dashchat-node/src/stores/op_projection.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 // TODO: rework this not as migrations, but as a single schema that, when changed,
-//       triggers a re-projection of the store.
+//       triggers a re-projection of the db.
 const MIGRATIONS: &[&str] = &[
     "CREATE TABLE IF NOT EXISTS devices (
         device_id BLOB PRIMARY KEY,
@@ -224,12 +224,11 @@ impl OpProjection {
                 DeviceGroupPayload::UnblockAgent(agent_id) => {
                     self.unblock_agent(*agent_id).await?;
                 }
+                DeviceGroupPayload::TombstoneMessage { topic, hash } => {
+                    self.add_tombstone(*topic, *hash).await?;
+                }
                 _ => (),
             },
-
-            Payload::DeviceGroup(DeviceGroupPayload::TombstoneMessage { topic, hash }) => {
-                self.add_tombstone(*topic, *hash).await?;
-            }
 
             // ACID: TODO: it's not correct to unconditionally save contact info here.
             //             This needs to be limited to only accepted requests.
@@ -362,64 +361,6 @@ impl OpProjection {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use crate::{stores::create_sqlite_pool, topic::kind};
-
-    use super::*;
-
-    #[tokio::test]
-    async fn test_tombstones_per_topic() {
-        let dir = tempfile::tempdir().unwrap();
-        let pool = create_sqlite_pool(dir.path().join("test_tombstones.db"))
-            .await
-            .unwrap();
-        let projection = OpProjection::new(pool.clone()).await.unwrap();
-
-        let topic_a = *Topic::<kind::Untyped>::new([1; 32]);
-        let topic_b = *Topic::<kind::Untyped>::new([2; 32]);
-        let hash1 = Hash::digest(b"op1");
-        let hash2 = Hash::digest(b"op2");
-
-        assert!(!projection.is_tombstoned(topic_a, hash1).await.unwrap());
-
-        projection.add_tombstone(topic_a, hash1).await.unwrap();
-        projection.add_tombstone(topic_a, hash2).await.unwrap();
-        projection.add_tombstone(topic_b, hash1).await.unwrap();
-        // Adding the same hash again is idempotent.
-        projection.add_tombstone(topic_a, hash1).await.unwrap();
-
-        assert!(projection.is_tombstoned(topic_a, hash1).await.unwrap());
-        assert!(projection.is_tombstoned(topic_a, hash2).await.unwrap());
-        // Tombstones are scoped per-topic: hash2 in topic_a does not leak into topic_b.
-        assert!(projection.is_tombstoned(topic_b, hash1).await.unwrap());
-        assert!(!projection.is_tombstoned(topic_b, hash2).await.unwrap());
-
-        assert_eq!(
-            projection.tombstoned_hashes(topic_a).await.unwrap(),
-            maplit::btreeset![hash1, hash2]
-        );
-        assert_eq!(
-            projection.tombstoned_hashes(topic_b).await.unwrap(),
-            maplit::btreeset![hash1]
-        );
-
-        // Tombstones persist across reopening the database.
-        drop(projection);
-        pool.close().await;
-
-        let pool = create_sqlite_pool(dir.path().join("test_tombstones.db"))
-            .await
-            .unwrap();
-        let projection = OpProjection::new(pool).await.unwrap();
-        assert!(projection.is_tombstoned(topic_a, hash1).await.unwrap());
-        assert_eq!(
-            projection.tombstoned_hashes(topic_a).await.unwrap(),
-            maplit::btreeset![hash1, hash2]
-        );
-    }
-}
-
 #[derive(Debug)]
 pub enum ProjectionError {
     InvalidOp(String),
@@ -443,7 +384,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
-    use crate::stores::create_sqlite_pool;
+    use crate::{stores::create_sqlite_pool, topic::kind};
 
     fn agent(n: u8) -> AgentId {
         AgentId::from(crate::ActorId::from(
@@ -470,78 +411,129 @@ mod tests {
     /// restores every device.
     #[tokio::test]
     async fn test_block_applies_to_all_devices_of_agent() {
-        let store = projection().await;
+        let db = projection().await;
 
         let agent_a = agent(1);
         let agent_b = agent(2);
         let (d1, d2, d3) = (device(10), device(11), device(20));
 
         // agent_a controls two devices, agent_b controls one.
-        store.save_agent_mapping(d1, agent_a).await.unwrap();
-        store.save_agent_mapping(d2, agent_a).await.unwrap();
-        store.save_agent_mapping(d3, agent_b).await.unwrap();
+        db.save_agent_mapping(d1, agent_a).await.unwrap();
+        db.save_agent_mapping(d2, agent_a).await.unwrap();
+        db.save_agent_mapping(d3, agent_b).await.unwrap();
 
         // Nothing blocked initially.
-        assert!(!store.is_author_blocked(&d1).await.unwrap());
-        assert!(!store.is_author_blocked(&d2).await.unwrap());
-        assert!(!store.is_author_blocked(&d3).await.unwrap());
+        assert!(!db.is_author_blocked(&d1).await.unwrap());
+        assert!(!db.is_author_blocked(&d2).await.unwrap());
+        assert!(!db.is_author_blocked(&d3).await.unwrap());
 
-        store.block_agent(agent_a).await.unwrap();
+        db.block_agent(agent_a).await.unwrap();
 
         // Both of agent_a's devices are blocked; agent_b's device is not.
-        assert!(store.is_author_blocked(&d1).await.unwrap());
-        assert!(store.is_author_blocked(&d2).await.unwrap());
-        assert!(!store.is_author_blocked(&d3).await.unwrap());
+        assert!(db.is_author_blocked(&d1).await.unwrap());
+        assert!(db.is_author_blocked(&d2).await.unwrap());
+        assert!(!db.is_author_blocked(&d3).await.unwrap());
 
-        store.unblock_agent(agent_a).await.unwrap();
+        db.unblock_agent(agent_a).await.unwrap();
 
         // Unblocking restores every device of the agent.
-        assert!(!store.is_author_blocked(&d1).await.unwrap());
-        assert!(!store.is_author_blocked(&d2).await.unwrap());
-        assert!(!store.is_author_blocked(&d3).await.unwrap());
+        assert!(!db.is_author_blocked(&d1).await.unwrap());
+        assert!(!db.is_author_blocked(&d2).await.unwrap());
+        assert!(!db.is_author_blocked(&d3).await.unwrap());
     }
 
     /// A device with no contact entry is never considered blocked.
     #[tokio::test]
     async fn test_unknown_device_is_not_blocked() {
-        let store = projection().await;
-        assert!(!store.is_author_blocked(&device(99)).await.unwrap());
+        let db = projection().await;
+        assert!(!db.is_author_blocked(&device(99)).await.unwrap());
     }
 
     /// A device newly mapped to an already-blocked agent is immediately blocked,
     /// since the block lives on the agent, not the device.
     #[tokio::test]
     async fn test_block_covers_devices_added_after_block() {
-        let store = projection().await;
+        let db = projection().await;
         let agent_a = agent(1);
 
-        store.save_agent_mapping(device(10), agent_a).await.unwrap();
-        store.block_agent(agent_a).await.unwrap();
+        db.save_agent_mapping(device(10), agent_a).await.unwrap();
+        db.block_agent(agent_a).await.unwrap();
 
         // A second device shows up for the same agent after the block.
-        store.save_agent_mapping(device(11), agent_a).await.unwrap();
+        db.save_agent_mapping(device(11), agent_a).await.unwrap();
 
-        assert!(store.is_author_blocked(&device(11)).await.unwrap());
+        assert!(db.is_author_blocked(&device(11)).await.unwrap());
     }
 
     /// `all_contact_agent_ids` returns one entry per agent, even when an agent
     /// has multiple devices, and includes blocked agents.
     #[tokio::test]
     async fn test_all_contact_agent_ids_dedups_by_agent() {
-        let store = projection().await;
+        let db = projection().await;
 
         let agent_a = agent(1);
         let agent_b = agent(2);
 
-        store.save_agent_mapping(device(10), agent_a).await.unwrap();
-        store.save_agent_mapping(device(11), agent_a).await.unwrap();
-        store.save_agent_mapping(device(20), agent_b).await.unwrap();
+        db.save_agent_mapping(device(10), agent_a).await.unwrap();
+        db.save_agent_mapping(device(11), agent_a).await.unwrap();
+        db.save_agent_mapping(device(20), agent_b).await.unwrap();
 
-        store.block_agent(agent_b).await.unwrap();
+        db.block_agent(agent_b).await.unwrap();
 
         assert_eq!(
-            store.all_contact_agent_ids().await.unwrap(),
+            db.all_contact_agent_ids().await.unwrap(),
             maplit::btreeset![agent_a, agent_b]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tombstones_per_topic() {
+        let dir = tempfile::tempdir().unwrap();
+        let pool = create_sqlite_pool(dir.path().join("test_tombstones.db"))
+            .await
+            .unwrap();
+        let db = OpProjection::new(pool.clone()).await.unwrap();
+
+        let topic_a = *Topic::<kind::Untyped>::new([1; 32]);
+        let topic_b = *Topic::<kind::Untyped>::new([2; 32]);
+        let hash1 = Hash::digest(b"op1");
+        let hash2 = Hash::digest(b"op2");
+
+        assert!(!db.is_tombstoned(topic_a, hash1).await.unwrap());
+
+        db.add_tombstone(topic_a, hash1).await.unwrap();
+        db.add_tombstone(topic_a, hash2).await.unwrap();
+        db.add_tombstone(topic_b, hash1).await.unwrap();
+        // Adding the same hash again is idempotent.
+        db.add_tombstone(topic_a, hash1).await.unwrap();
+
+        assert!(db.is_tombstoned(topic_a, hash1).await.unwrap());
+        assert!(db.is_tombstoned(topic_a, hash2).await.unwrap());
+        // Tombstones are scoped per-topic: hash2 in topic_a does not leak into topic_b.
+        assert!(db.is_tombstoned(topic_b, hash1).await.unwrap());
+        assert!(!db.is_tombstoned(topic_b, hash2).await.unwrap());
+
+        assert_eq!(
+            db.tombstoned_hashes(topic_a).await.unwrap(),
+            maplit::btreeset![hash1, hash2]
+        );
+        assert_eq!(
+            db.tombstoned_hashes(topic_b).await.unwrap(),
+            maplit::btreeset![hash1]
+        );
+
+        // Tombstones persist across reopening the database.
+        drop(db);
+        pool.close().await;
+
+        let pool = create_sqlite_pool(dir.path().join("test_tombstones.db"))
+            .await
+            .unwrap();
+        let db = OpProjection::new(pool).await.unwrap();
+        assert!(db.is_tombstoned(topic_a, hash1).await.unwrap());
+        assert_eq!(
+            db.tombstoned_hashes(topic_a).await.unwrap(),
+            maplit::btreeset![hash1, hash2]
         );
     }
 }

--- a/crates/dashchat-node/src/stores/op_projection.rs
+++ b/crates/dashchat-node/src/stores/op_projection.rs
@@ -1,11 +1,12 @@
 use aliased::Aliasing;
+use p2panda::Hash;
 use p2panda::streams::ProcessedOperation;
 use p2panda_auth::group::GroupAction;
 use p2panda_auth::processor::GroupsArgs;
 use sqlx::SqlitePool;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
-use crate::{AgentId, DeviceId, Profile};
+use crate::{AgentId, DeviceId, Profile, TopicId};
 use crate::{
     AnnouncementsPayload, ChatId, ChatPayload, DeviceGroupPayload, InboxPayload, Payload, Topic,
 };
@@ -29,14 +30,19 @@ const MIGRATIONS: &[&str] = &[
     "CREATE TABLE IF NOT EXISTS group_chats (
         chat_id BLOB NOT NULL PRIMARY KEY
     )",
+    "CREATE TABLE IF NOT EXISTS tombstones (
+        topic_id BLOB NOT NULL,
+        op_hash BLOB NOT NULL,
+        PRIMARY KEY (topic_id, op_hash)
+    )",
 ];
 
 /// The [`OpProjection`] is a projection of the [`crate::stores::OpStore`] that is used to make streamlined queries.
 /// It only contains data already present in the operations, just reshaped to be more queryable.
 ///
 /// - Writes only occur in the [`Self::reduce`] method.
-/// - The store is populated by streaming operations through [`Self::reduce`].
-/// - The store can be purged and rebuilt by replaying operation streams.
+/// - The projection is populated by streaming operations through [`Self::reduce`].
+/// - The projection can be purged and rebuilt by replaying operation streams.
 /// - If a log is partially purged, the OpProjection can be deleted and the streams replayed from their new starting point.
 /// - To achieve ACID compliance:
 ///   - every write must be idempotent in case operations need to be replayed.
@@ -52,8 +58,8 @@ impl OpProjection {
             sqlx::query(sql).execute(&pool).await?;
         }
 
-        let store = Self { pool };
-        Ok(store)
+        let projection = Self { pool };
+        Ok(projection)
     }
 
     pub async fn all_contact_agent_ids(&self) -> anyhow::Result<Vec<AgentId>> {
@@ -139,6 +145,32 @@ impl OpProjection {
             .collect()
     }
 
+    pub async fn is_tombstoned(&self, topic: TopicId, op_hash: Hash) -> anyhow::Result<bool> {
+        let row: Option<(i64,)> =
+            sqlx::query_as("SELECT 1 FROM tombstones WHERE topic_id = ? AND op_hash = ?")
+                .bind(topic.as_bytes().to_vec())
+                .bind(op_hash.as_bytes().to_vec())
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.is_some())
+    }
+
+    pub async fn tombstoned_hashes(&self, topic: TopicId) -> anyhow::Result<BTreeSet<Hash>> {
+        let rows: Vec<(Vec<u8>,)> =
+            sqlx::query_as("SELECT op_hash FROM tombstones WHERE topic_id = ?")
+                .bind(topic.as_bytes().to_vec())
+                .fetch_all(&self.pool)
+                .await?;
+        rows.into_iter()
+            .map(|(bytes,)| {
+                let arr: [u8; 32] = bytes
+                    .try_into()
+                    .map_err(|_| anyhow::anyhow!("tombstone op_hash is not 32 bytes"))?;
+                Ok(Hash::from_bytes(arr))
+            })
+            .collect()
+    }
+
     pub async fn reduce(
         &self,
         me: AgentId,
@@ -169,6 +201,10 @@ impl OpProjection {
 
             Payload::DeviceGroup(DeviceGroupPayload::AddContact { agent_id }) => {
                 self.save_agent_mapping(author, *agent_id).await?;
+            }
+
+            Payload::DeviceGroup(DeviceGroupPayload::TombstoneMessage { topic, hash }) => {
+                self.add_tombstone(*topic, *hash).await?;
             }
 
             // ACID: TODO: it's not correct to unconditionally save contact info here.
@@ -246,5 +282,74 @@ impl OpProjection {
             .await?;
         tx.commit().await?;
         Ok(())
+    }
+
+    /// Record an operation hash in the per-topic tombstone set. Payloads for
+    /// tombstoned operations must never be stored or synced.
+    async fn add_tombstone(&self, topic: TopicId, op_hash: Hash) -> anyhow::Result<()> {
+        sqlx::query("INSERT OR IGNORE INTO tombstones (topic_id, op_hash) VALUES (?, ?)")
+            .bind(topic.as_bytes().to_vec())
+            .bind(op_hash.as_bytes().to_vec())
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{stores::create_sqlite_pool, topic::kind};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_tombstones_per_topic() {
+        let dir = tempfile::tempdir().unwrap();
+        let pool = create_sqlite_pool(dir.path().join("test_tombstones.db"))
+            .await
+            .unwrap();
+        let projection = OpProjection::new(pool.clone()).await.unwrap();
+
+        let topic_a = *Topic::<kind::Untyped>::new([1; 32]);
+        let topic_b = *Topic::<kind::Untyped>::new([2; 32]);
+        let hash1 = Hash::digest(b"op1");
+        let hash2 = Hash::digest(b"op2");
+
+        assert!(!projection.is_tombstoned(topic_a, hash1).await.unwrap());
+
+        projection.add_tombstone(topic_a, hash1).await.unwrap();
+        projection.add_tombstone(topic_a, hash2).await.unwrap();
+        projection.add_tombstone(topic_b, hash1).await.unwrap();
+        // Adding the same hash again is idempotent.
+        projection.add_tombstone(topic_a, hash1).await.unwrap();
+
+        assert!(projection.is_tombstoned(topic_a, hash1).await.unwrap());
+        assert!(projection.is_tombstoned(topic_a, hash2).await.unwrap());
+        // Tombstones are scoped per-topic: hash2 in topic_a does not leak into topic_b.
+        assert!(projection.is_tombstoned(topic_b, hash1).await.unwrap());
+        assert!(!projection.is_tombstoned(topic_b, hash2).await.unwrap());
+
+        assert_eq!(
+            projection.tombstoned_hashes(topic_a).await.unwrap(),
+            maplit::btreeset![hash1, hash2]
+        );
+        assert_eq!(
+            projection.tombstoned_hashes(topic_b).await.unwrap(),
+            maplit::btreeset![hash1]
+        );
+
+        // Tombstones persist across reopening the database.
+        drop(projection);
+        pool.close().await;
+
+        let pool = create_sqlite_pool(dir.path().join("test_tombstones.db"))
+            .await
+            .unwrap();
+        let projection = OpProjection::new(pool).await.unwrap();
+        assert!(projection.is_tombstoned(topic_a, hash1).await.unwrap());
+        assert_eq!(
+            projection.tombstoned_hashes(topic_a).await.unwrap(),
+            maplit::btreeset![hash1, hash2]
+        );
     }
 }

--- a/crates/dashchat-node/tests/tombstones.rs
+++ b/crates/dashchat-node/tests/tombstones.rs
@@ -52,13 +52,13 @@ async fn tombstone_drops_existing_payload() {
         payload_present(&node, *topic, node.device_id(), hash).await,
         Some(true)
     );
-    assert!(!node.local_store.is_tombstoned(*topic, hash).await.unwrap());
+    assert!(!node.projection.is_tombstoned(*topic, hash).await.unwrap());
 
     let operation = node.op_store.get_operation(&hash).await.unwrap().unwrap();
     node.tombstone_operation(*topic, &operation).await.unwrap();
 
     // The hash is recorded and the payload is gone, but the header remains.
-    assert!(node.local_store.is_tombstoned(*topic, hash).await.unwrap());
+    assert!(node.projection.is_tombstoned(*topic, hash).await.unwrap());
     assert_eq!(
         payload_present(&node, *topic, node.device_id(), hash).await,
         Some(false)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1376,67 +1376,56 @@ packages:
     resolution: {integrity: sha512-IoerZJ4l1wRMopEHRKOO16e04iXRDyZFZnNZKrWeNquh5d6bucjezgd+OxG03mOMTnS1x7hilzb3uURPkJ0OfA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.3':
     resolution: {integrity: sha512-ZYdtqgHTDfvrJHSh3W22TvjWxwOgc3ThK/XjgcNGP2DIwFIPeAPNsQxrJO5XqleSlgDux2VAoWQ5iJrtaC1TbA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.3':
     resolution: {integrity: sha512-NcViG7A0YtuFDA6xWSgmFb6iPFzHlf5vcqb2p0lGEbT+gjrEEz8nC/EeDHvx6mnGXnGCC1SeVV+8u+smj0CeGQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.3':
     resolution: {integrity: sha512-d3pY7LWno6SYNXRm6Ebsq0DJGoiLXTb83AIPCXl9fmtIQs/rXoS8SJxxUNtFbJ5MiOvs+7y34np77+9l4nfFMw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.3':
     resolution: {integrity: sha512-3y5GA0JkBuirLqmjwAKwB0keDlI6JfGYduMlJD/Rl7fvb4Ni8iKdQs1eiunMZJhwDWdCvrcqXRY++VEBbvk6Eg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.3':
     resolution: {integrity: sha512-AUUH65a0p3Q0Yfm5oD2KVgzTKgwPyp9DSXc3UA7DtxhEb/WSPfbG4wqXeSN62OG5gSo18em4xv6dbfcUGXcagw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.3':
     resolution: {integrity: sha512-1makPhFFVBqZE+XFg3Dkq+IkQ7JvmUrwwqaYBL2CE+ZpxPaqkGaiWFEWVGyvTwZace6WLJHwjVh/+CXbKDGPmg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.3':
     resolution: {integrity: sha512-OOFJa28dxfl8kLOPMUOQBCO6z3X2SAfzIE276fwT52uXDWUS178KWq0pL7d6p1kz7pkzA0yQwtqL0dEPoVcRWg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.3':
     resolution: {integrity: sha512-jMdsML2VI5l+V7cKfZx3ak+SLlJ8fKvLJ0Eoa4b9/vCUrzXKgoKxvHqvJ/mkWhFiyp88nCkM5S2v6nIwRtPcgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.3':
     resolution: {integrity: sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.3':
     resolution: {integrity: sha512-BCFkJjgk+WFzP+tcSMXq77ymAPIxsX9lFJWs+2JzuZTLtksJ2o5hvgTdIcZ5+oKzUDMwI0PfWzRBYAydAHF2Mw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.3':
     resolution: {integrity: sha512-KTD/EqjZF3yvRaWUJdD1cW+IQBk4fbQaHYJUmP8N4XoKFZilVL8cobFSTDnjTtxWJQ3JYaMgF4nObY/+nYkumA==}
@@ -1575,28 +1564,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1663,35 +1648,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.8.4':
     resolution: {integrity: sha512-zumFeaU1Ws5Ay872FTyIm7z8kfzEHu8NcIn8M6TxbJs0a7GRV21KBdpW1zNj2qy7HynnpQCqjAYXTUUmm9JAOw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.8.4':
     resolution: {integrity: sha512-qiqbB3Zz6IyO201f+1ojxLj65WYj8mixL5cOMo63nlg8CIzsP23cPYUrx1YaDPsCLszKZo7tVs14pc7BWf+/aQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.8.4':
     resolution: {integrity: sha512-TaqaDd9Oy6k45Hotx3pOf+pkbsxLaApv4rGd9mLuRM1k6YS/aw81YrsMryYPThrxrScEIUcmNIHaHsLiU4GMkw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.8.4':
     resolution: {integrity: sha512-ot9STAwyezN8w+bBHZ+bqSQIJ0qPZFlz/AyscpGqB/JnJQVDFQcRDmUPFEaAtt2UUHSWzN3GoTJ5ypqLBp2WQA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.8.4':
     resolution: {integrity: sha512-+2aJ/g90dhLiOLFSD1PbElXX3SoMdpO7HFPAZB+xot3CWlAZD1tReUFy7xe0L5GAR16ZmrxpIDM9v9gn5xRy/w==}
@@ -3336,28 +3316,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}


### PR DESCRIPTION
Mostly moves tombstoning code from LocalStore to OpProjection. Adds the new DeviceGroup payload for tombstoning an operation, so that it's an agent-level rather than device-level decision.

Needed because Delete is also an agent-level decision, and Delete partially relies on tombstoning.