### PR TITLE
Restore paste-contact-code box in dev builds

### DIFF
--- a/ui/src/lib/components/layout/AddContactPanel.svelte
+++ b/ui/src/lib/components/layout/AddContactPanel.svelte
@@ -8,12 +8,15 @@
 	} from 'dash-chat-stores';
 	import { m } from '$lib/paraglide/messages.js';
 
+	import { isWideScreen } from '$lib/stores/screen.svelte';
 	import { useReactivePromise } from '$lib/stores/use-signal';
 	import { isMobile } from '$lib/utils/environment';
 	import {
 		Page,
 		Navbar,
 		NavbarBackLink,
+		List,
+		ListInput,
 		Preloader,
 		Button,
 		useTheme,
@@ -30,6 +33,8 @@
 	import {
 		toDeepLink,
 		addContactFromDeepLink,
+		addContactFromCode,
+		extractCodeFromDeepLink,
 	} from '$lib/deep-links/add-contact';
 	import { defaultQrColor } from '$lib/utils/qrcode';
 	import SelectColor from './SelectColor.svelte';
@@ -65,6 +70,18 @@
 
 	function receiveDeepLink(link: string) {
 		return addContactFromDeepLink(contactsStore, link);
+	}
+
+	let pastedCode = $state('');
+
+	async function submitPastedCode() {
+		const input = pastedCode.trim();
+		if (input === '') return;
+		pastedCode = '';
+		await addContactFromCode(
+			contactsStore,
+			extractCodeFromDeepLink(input) ?? input,
+		);
 	}
 
 	const qrColor = useReactivePromise(settingsStore.qrColor);
@@ -266,6 +283,34 @@
 									class="mx-6 mb-2 text-center quiet"
 									style="font-size: 13px">{m.shareCodeWarning()}</span
 								>
+
+								{#if import.meta.env.DEV}
+									<div class="column w-full gap-2">
+										<List
+											nested
+											strongIos
+											inset={isWideScreen.value || theme === 'ios'}
+										>
+											<ListInput
+												floatingLabel
+												label="Paste contact link or code (dev only)"
+												type="text"
+												outline
+												data-testid="add-contact-code-input"
+												value={pastedCode}
+												onInput={(e: Event) =>
+													(pastedCode = (e.target as HTMLInputElement).value)}
+											/>
+										</List>
+										<Button
+											rounded
+											disabled={pastedCode.trim() === ''}
+											data-testid="add-contact-code-submit"
+											onClick={() => void submitPastedCode()}
+											>{m.addContact()}</Button
+										>
+									</div>
+								{/if}
 							</div>
 						</div>
 						<QrCodeUploader


### PR DESCRIPTION
Looks like we lost this during the deep link work, but I think this is necessary for dev work, and may be something we want to continue to expose to the user (unless I'm missing where else it got moved to).

The input is gated behind import.meta.env.DEV so it only appears under `just dev`, and accepts either a full contact deep link or a bare code. The label is hardcoded English rather than a paraglide message so a dev-only string doesn't reach Weblate.
