### PR TITLE
Add mailbox scrubbing design doc

### DIFF
--- a/crates/dashchat-node/src/mailbox.rs
+++ b/crates/dashchat-node/src/mailbox.rs
@@ -36,6 +36,19 @@ impl MailboxItem for MailboxOperation {
         self.topic
     }
 
+    /// The operation with its body dropped. The header is untouched — it still
+    /// carries the payload hash and size, which the signature covers — so every
+    /// node that holds the operation produces identical bytes here, which is
+    /// what lets one node's commitment validate another node's scrub.
+    fn scrubbed(&self) -> Option<Self> {
+        self.body.as_ref()?;
+        Some(Self {
+            topic: self.topic,
+            header: self.header.clone(),
+            body: None,
+        })
+    }
+
     fn blob_hashes(&self) -> Vec<iroh_blobs::Hash> {
         let Some(body) = &self.body else {
             return Vec::new();
@@ -159,6 +172,51 @@ mod tests {
 
         let hashes = op.blob_hashes();
         assert_eq!(hashes, vec![media_hash]);
+    }
+
+    /// Scrubbing drops the body and nothing else. The header keeps the payload
+    /// hash and size — the signature covers them — so the operation stays
+    /// verifiable with its payload gone.
+    #[test]
+    fn scrubbed_drops_only_the_body() {
+        let topic: TopicId = crate::Topic::<crate::topic::kind::Untyped>::new([9u8; 32]).into();
+        let header = make_header(topic);
+        let body = p2panda_core::Body::new(b"secret");
+        let op = super::MailboxOperation {
+            topic,
+            header: header.clone(),
+            body: Some(body),
+        };
+
+        let scrubbed = op.scrubbed().expect("an op with a body is scrubbable");
+        assert!(scrubbed.body.is_none());
+        assert_eq!(scrubbed.header, header);
+        assert_eq!(scrubbed.topic, topic);
+
+        // Already payload-free: nothing to remove.
+        assert!(scrubbed.scrubbed().is_none());
+    }
+
+    /// A blip's scrub commitment is made by whoever published it and checked
+    /// against bytes submitted later by a different node, possibly running a
+    /// different build. Both sides must encode the payload-free operation
+    /// identically, so this pins the encoding: if `MailboxOperation`'s serde
+    /// representation drifts, blips published by older clients silently become
+    /// unscrubbable, and this test is the warning.
+    #[test]
+    fn scrubbed_operation_encoding_is_pinned() {
+        let topic: TopicId = crate::Topic::<crate::topic::kind::Untyped>::new([9u8; 32]).into();
+        let op = super::MailboxOperation {
+            topic,
+            header: make_header(topic),
+            body: Some(p2panda_core::Body::new(b"secret")),
+        };
+        let encoded = p2panda_core::cbor::encode_cbor(&op.scrubbed().unwrap()).unwrap();
+        assert_eq!(
+            iroh_blobs::Hash::new(&encoded).to_string(),
+            "54fcfcab82239838735b37ddbd5d468ff140f488ca630e3e0b37d3bf5e6ad29b",
+            "the payload-free encoding of a MailboxOperation changed"
+        );
     }
 
     #[test]

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -259,12 +259,37 @@ impl Node {
     ) -> anyhow::Result<bool> {
         let hash = tombstoned_op.hash;
         if self.projection.is_tombstoned(topic, hash).await? {
+            // Capture the operation before dropping the body: the mailboxes
+            // need it with its payload still attached to derive both the
+            // payload-free replacement and the media references to release.
+            self.scrub_mailboxes(topic, tombstoned_op);
             self.unprocess_app(tombstoned_op).await?;
             self.op_store.delete_body(&hash).await?;
             Ok(true)
         } else {
             Ok(false)
         }
+    }
+
+    /// Ask every mailbox to replace its copy of a just-tombstoned operation with
+    /// the payload-free form and drop the media it referenced.
+    ///
+    /// Driven from tombstone enforcement rather than from the delete itself, so
+    /// it covers the author and every recipient alike, and re-fires if a mailbox
+    /// ever serves the payload back to us.
+    ///
+    /// Detached, so a slow or unreachable mailbox can't stall operation
+    /// processing. Nothing waits on the result: if the scrub never lands the
+    /// mailbox keeps serving the payload, the next node to sync it re-enforces
+    /// the tombstone, and the scrub is issued again.
+    fn scrub_mailboxes(&self, topic: TopicId, tombstoned_op: &Operation) {
+        let op = MailboxOperation {
+            topic,
+            header: tombstoned_op.header.clone(),
+            body: tombstoned_op.body.clone(),
+        };
+        let node = self.clone();
+        tokio::spawn(async move { node.mailboxes.scrub_all(vec![op]).await });
     }
 
     /// Filter out operations whose payloads are not able to be deleted.

--- a/crates/dashchat-node/src/unfetched_blobs.rs
+++ b/crates/dashchat-node/src/unfetched_blobs.rs
@@ -65,8 +65,18 @@ pub async fn followup_unfetched_blobs_once(node: &Node) {
         }
         // Re-announce so the mailbox re-registers these hashes for fetching. No
         // upload follows here, so ask it to fetch immediately rather than deferring
-        // by its grace window.
-        match mailbox_client::toy::send_register_hashes(&url, hashes, self_endpoint, false).await {
+        // by its grace window. The empty op_ref marks this as a re-announce: we
+        // track unfetched blobs per mailbox, not per operation, so we have no
+        // reference to offer and must not mint one.
+        match mailbox_client::toy::send_register_hashes(
+            &url,
+            hashes,
+            String::new(),
+            self_endpoint,
+            false,
+        )
+        .await
+        {
             Ok(already_stored) => {
                 if let Err(err) = node
                     .local_store

--- a/crates/dashchat-node/tests/delete_messages.rs
+++ b/crates/dashchat-node/tests/delete_messages.rs
@@ -244,7 +244,7 @@ async fn delete_tombstones_chain_and_hides_payloads_from_new_members() {
         assert!(served.iter().any(|op| op.header.hash() == msg1.hash()));
     }
 
-    if mailbox_scrubbing_implemented() {
+    {
         // The mailbox's own copies were scrubbed: fetching everything it holds for
         // the chat returns the deleted chain body-less.
         let mb_client = mb.client().await;
@@ -304,7 +304,7 @@ async fn delete_tombstones_chain_and_hides_payloads_from_new_members() {
     .await
     .unwrap();
 
-    if mailbox_scrubbing_implemented() {
+    {
         for hash in [msg1.hash(), edit1.hash()] {
             assert_eq!(
                 payload_present(&carol, *chat, alice.device_id(), hash).await,
@@ -318,14 +318,6 @@ async fn delete_tombstones_chain_and_hides_payloads_from_new_members() {
             payload_present(&carol, *chat, alice.device_id(), hash).await,
             Some(true)
         );
-    }
-
-    // When mailbox scrubbing is implemented, we should not wait for consistency.
-    // Until then, carol needs to process the delete message before the deleted conditions are met.
-    if !mailbox_scrubbing_implemented() {
-        poll.consistency([&alice, &bobbi, &carol], &[chat.into()])
-            .await
-            .unwrap();
     }
 
     // Carol sees only the undeleted message (with its edit) and never learns
@@ -350,11 +342,6 @@ async fn delete_tombstones_chain_and_hides_payloads_from_new_members() {
             .await
             .is_empty()
     );
-}
-
-#[deprecated = "this just calls attention to the need for mailbox scrubbing. When that is implemented, replace all calls to this function with `true`."]
-fn mailbox_scrubbing_implemented() -> bool {
-    false
 }
 
 /// Receiver-side validation: a delete injected by someone other than the

--- a/crates/mailbox-client/src/lib.rs
+++ b/crates/mailbox-client/src/lib.rs
@@ -63,6 +63,17 @@ pub trait MailboxClient<Item: MailboxItem>: Send + Sync + 'static {
     async fn report(&self, _request: reporting::ReportRequest) -> Result<(), anyhow::Error> {
         Ok(())
     }
+
+    /// Replace this mailbox's copies of `items` with their payload-free forms
+    /// and release the media blobs they referenced, so a message deleted for
+    /// everyone stops being served to peers who have not synced yet.
+    ///
+    /// `items` must still carry their payloads: the payload-free form and the
+    /// blob references are both derived from them here. Idempotent — every node
+    /// that processes a delete scrubs every mailbox it knows.
+    async fn scrub(&self, _items: Vec<Item>) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -121,6 +132,17 @@ pub trait MailboxItem:
     fn topic(&self) -> Self::Topic;
     fn blob_hashes(&self) -> Vec<iroh_blobs::Hash> {
         Vec::new()
+    }
+
+    /// This item with its payload removed: what a mailbox stores in its place
+    /// once the payload is deleted for everyone.
+    ///
+    /// A mailbox cannot derive this itself — it treats items as opaque bytes —
+    /// so the publisher commits to it up front and the mailbox accepts no other
+    /// replacement. `None` means the item has no payload to remove, which
+    /// leaves it unscrubbable.
+    fn scrubbed(&self) -> Option<Self> {
+        None
     }
 }
 

--- a/crates/mailbox-client/src/manager.rs
+++ b/crates/mailbox-client/src/manager.rs
@@ -353,6 +353,31 @@ where
         succeeded
     }
 
+    /// Ask every registered mailbox to replace its copies of `items` with their
+    /// payload-free forms and release the media they referenced, best-effort.
+    ///
+    /// Fire-and-forget by design: if a scrub doesn't land, the mailbox goes on
+    /// serving the payload, the next node to sync it re-ingests the operation
+    /// and re-enforces the tombstone, and the scrub is issued again.
+    pub async fn scrub_all(&self, items: Vec<Item>) {
+        if items.is_empty() {
+            return;
+        }
+        let mailboxes: Vec<(MailboxId, Arc<TrackedMailbox<Item>>)> = self
+            .mailboxes
+            .lock()
+            .await
+            .iter()
+            .map(|(id, tm)| (id.clone(), tm.clone()))
+            .collect();
+        for (id, tracked_mailbox) in mailboxes {
+            let client = tracked_mailbox.client().await;
+            if let Err(err) = client.scrub(items.clone()).await {
+                tracing::warn!(?err, mailbox = %id, "failed to scrub mailbox");
+            }
+        }
+    }
+
     pub async fn subscribe(
         &self,
         topic: Item::Topic,

--- a/crates/mailbox-client/src/mem.rs
+++ b/crates/mailbox-client/src/mem.rs
@@ -27,10 +27,21 @@ pub type MemMailboxLogs<Item> = HashMap<
     HashMap<<Item as MailboxItem>::Author, BTreeMap<u64, Item>>,
 >;
 
+/// The coordinate of an operation whose payload has been scrubbed.
+type ScrubbedSlot<Item> = (
+    <Item as MailboxItem>::Topic,
+    <Item as MailboxItem>::Author,
+    u64,
+);
+
 #[derive(Clone)]
 pub struct MemMailbox<Item: MailboxItem> {
     id: MailboxId,
     ops: Arc<RwLock<MemMailboxLogs<Item>>>,
+    /// Slots whose payload has been scrubbed. Kept so a republish can't put the
+    /// payload back, mirroring the real mailbox's once-scrubbed-always-scrubbed
+    /// rule.
+    scrubbed: Arc<RwLock<HashSet<ScrubbedSlot<Item>>>>,
 }
 
 impl<Item: MailboxItem> MemMailbox<Item> {
@@ -38,6 +49,7 @@ impl<Item: MailboxItem> MemMailbox<Item> {
         Self {
             id: nanoid::nanoid!(),
             ops: Arc::new(RwLock::new(HashMap::new())),
+            scrubbed: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 
@@ -74,11 +86,16 @@ where
 
     async fn publish(&self, ops: Vec<Item>) -> Result<(), anyhow::Error> {
         let mut store = self.mailbox.ops.write().await;
+        let scrubbed = self.mailbox.scrubbed.read().await;
         // ops.entry(topic).or_insert_with(Vec::new).push(op.into());
         for op in ops {
             let author = op.author();
             let seq_num = op.seq_num();
             let topic = op.topic();
+            if scrubbed.contains(&(topic, author, seq_num)) {
+                tracing::debug!(topic = ?topic, hash = ?op.hash(), "ignoring publish of a scrubbed operation");
+                continue;
+            }
             tracing::info!(topic = ?topic, hash = ?op.hash(), "publishing mailbox operation");
             store
                 .entry(topic)
@@ -86,6 +103,27 @@ where
                 .entry(author)
                 .or_default()
                 .insert(seq_num, op);
+        }
+        Ok(())
+    }
+
+    async fn scrub(&self, items: Vec<Item>) -> Result<(), anyhow::Error> {
+        let mut store = self.mailbox.ops.write().await;
+        let mut scrubbed_slots = self.mailbox.scrubbed.write().await;
+        for item in items {
+            let Some(scrubbed) = item.scrubbed() else {
+                continue;
+            };
+            let (topic, author, seq_num) = (item.topic(), item.author(), item.seq_num());
+            tracing::info!(topic = ?topic, hash = ?item.hash(), "scrubbing mailbox operation");
+            scrubbed_slots.insert((topic, author, seq_num));
+            if let Some(slot) = store
+                .get_mut(&topic)
+                .and_then(|authors| authors.get_mut(&author))
+                .and_then(|seqs| seqs.get_mut(&seq_num))
+            {
+                *slot = scrubbed;
+            }
         }
         Ok(())
     }

--- a/crates/mailbox-client/src/toy.rs
+++ b/crates/mailbox-client/src/toy.rs
@@ -1,6 +1,9 @@
 use std::collections::{BTreeMap, HashMap};
 
-use mailbox_server::{Blip, GetBlipsRequest, GetBlipsResponse, StoreBlipsRequest};
+use mailbox_server::{
+    Blip, BlobRef, GetBlipsRequest, GetBlipsResponse, OpRef, ScrubBlipsRequest, ScrubBlobsRequest,
+    ScrubHash, StoreBlipsRequest, StoredBlip,
+};
 
 use super::*;
 
@@ -54,6 +57,7 @@ fn classify_upload_error(err: reqwest::Error) -> UploadError {
 pub async fn send_register_hashes(
     base_url: &str,
     hashes: Vec<iroh_blobs::Hash>,
+    op_ref: OpRef,
     sender_pubkey: iroh::EndpointId,
     expect_upload: bool,
 ) -> anyhow::Result<Vec<iroh_blobs::Hash>> {
@@ -62,6 +66,7 @@ pub async fn send_register_hashes(
     }
     let request = mailbox_server::RegisterHashesRequest {
         blob_hashes: hashes,
+        op_ref,
         sender_pubkey,
         expect_upload,
         signature: Vec::new(),
@@ -147,28 +152,41 @@ impl<Item: MailboxItem> ToyMailboxClient<Item> {
     /// batch of large blobs never stalls this per-mailbox publish iteration, and
     /// scoped to `not_stored`, so we never re-upload blobs the mailbox already
     /// holds.
-    async fn store_blobs(&self, hashes: Vec<iroh_blobs::Hash>) -> anyhow::Result<()> {
-        if hashes.is_empty() {
-            return Ok(());
-        }
+    /// `blobs_by_op` groups the hashes by the operation that references them.
+    /// The mailbox records a reference per `(blob, operation)` pair, which is
+    /// what makes deletion safe: blob hashes are content-addressed, so two
+    /// messages carrying the same media announce the same hash and deleting one
+    /// must not drop the other's copy.
+    async fn store_blobs(
+        &self,
+        blobs_by_op: Vec<(OpRef, Vec<iroh_blobs::Hash>)>,
+    ) -> anyhow::Result<()> {
         // Tell the mailbox to defer its fetch backstop only when we can actually
         // stream the bytes; a reader-less client never uploads, so the mailbox
         // should fetch from us right away.
         let expect_upload = self.blob_reader.is_some();
-        let already_stored = send_register_hashes(
-            &self.base_url,
-            hashes.clone(),
-            self.sender_pubkey,
-            expect_upload,
-        )
-        .await?;
-        let not_stored: Vec<_> = hashes
-            .into_iter()
-            .filter(|h| !already_stored.contains(h))
-            .collect();
-        self.tracker.record(&self.id, &not_stored).await;
-        self.tracker.remove(&self.id, &already_stored).await;
-        self.spawn_blob_upload(not_stored);
+        let mut all_not_stored = Vec::new();
+        for (op_ref, hashes) in blobs_by_op {
+            if hashes.is_empty() {
+                continue;
+            }
+            let already_stored = send_register_hashes(
+                &self.base_url,
+                hashes.clone(),
+                op_ref,
+                self.sender_pubkey,
+                expect_upload,
+            )
+            .await?;
+            let not_stored: Vec<_> = hashes
+                .into_iter()
+                .filter(|h| !already_stored.contains(h))
+                .collect();
+            self.tracker.record(&self.id, &not_stored).await;
+            self.tracker.remove(&self.id, &already_stored).await;
+            all_not_stored.extend(not_stored);
+        }
+        self.spawn_blob_upload(all_not_stored);
         Ok(())
     }
 
@@ -235,23 +253,29 @@ where
         }
 
         // Group operations by topic -> author -> seq_num
-        let mut blips: BTreeMap<String, BTreeMap<String, BTreeMap<u64, Blip>>> = BTreeMap::new();
+        let mut blips: BTreeMap<String, BTreeMap<String, BTreeMap<u64, StoredBlip>>> =
+            BTreeMap::new();
 
-        let blob_hashes: Vec<iroh_blobs::Hash> =
-            ops.iter().flat_map(|op| op.blob_hashes()).collect();
+        let blobs_by_op: Vec<(OpRef, Vec<iroh_blobs::Hash>)> = ops
+            .iter()
+            .map(|op| (Self::op_ref(op), op.blob_hashes()))
+            .collect();
 
         for op in ops {
             let topic_id = Self::encode_topic_id(&op.topic());
             let log_id = Self::device_id_to_log_id(&op.author());
             let seq_num = op.seq_num();
-            let blip = Self::serialize_operation(&op)?;
+            let stored = StoredBlip {
+                blip: Self::serialize_operation(&op)?,
+                scrub_hash: Self::scrub_hash(&op)?,
+            };
 
             blips
                 .entry(topic_id)
                 .or_default()
                 .entry(log_id)
                 .or_default()
-                .insert(seq_num, blip);
+                .insert(seq_num, stored);
         }
 
         let request = StoreBlipsRequest {
@@ -266,7 +290,7 @@ where
             .await?;
 
         if response.status().is_success() {
-            self.store_blobs(blob_hashes).await?;
+            self.store_blobs(blobs_by_op).await?;
             Ok(())
         } else {
             let status = response.status();
@@ -292,6 +316,39 @@ where
             let body = response.text().await.unwrap_or_default();
             Err(anyhow::anyhow!("Failed to report: {} - {}", status, body))
         }
+    }
+
+    async fn scrub(&self, items: Vec<Item>) -> Result<(), anyhow::Error> {
+        let mut blips: BTreeMap<String, BTreeMap<String, BTreeMap<u64, Blip>>> = BTreeMap::new();
+        let mut refs: Vec<BlobRef> = Vec::new();
+
+        for item in &items {
+            let op_ref = Self::op_ref(item);
+            refs.extend(item.blob_hashes().into_iter().map(|blob_hash| BlobRef {
+                blob_hash,
+                op_ref: op_ref.clone(),
+            }));
+
+            let Some(scrubbed) = item.scrubbed() else {
+                continue;
+            };
+            blips
+                .entry(Self::encode_topic_id(&item.topic()))
+                .or_default()
+                .entry(Self::device_id_to_log_id(&item.author()))
+                .or_default()
+                .insert(item.seq_num(), Self::serialize_operation(&scrubbed)?);
+        }
+
+        if !blips.is_empty() {
+            self.post_scrub("/blips/scrub", &ScrubBlipsRequest { blips })
+                .await?;
+        }
+        if !refs.is_empty() {
+            self.post_scrub("/blobs/scrub", &ScrubBlobsRequest { refs })
+                .await?;
+        }
+        Ok(())
     }
 
     async fn fetch(
@@ -388,6 +445,40 @@ where
         Ok(Blip::new(bytes))
     }
 
+    /// The commitment to `item`'s payload-free form, or `None` when it has no
+    /// payload to remove. This is what the mailbox later checks a scrub against,
+    /// so it must be computed over exactly the bytes [`Self::scrub`] submits.
+    fn scrub_hash(item: &Item) -> Result<Option<ScrubHash>, anyhow::Error> {
+        let Some(scrubbed) = item.scrubbed() else {
+            return Ok(None);
+        };
+        Ok(Some(ScrubHash::new(
+            Self::serialize_operation(&scrubbed)?.as_slice(),
+        )))
+    }
+
+    /// The opaque identifier the mailbox uses to tell two references to the same
+    /// blob apart. Only determinism matters — the mailbox never interprets it.
+    fn op_ref(item: &Item) -> OpRef {
+        stringify(item.hash())
+    }
+
+    async fn post_scrub(&self, path: &str, request: &impl Serialize) -> anyhow::Result<()> {
+        let response = HTTP_CLIENT
+            .post(format!("{}{path}", self.base_url))
+            .json(request)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            return Ok(());
+        }
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        Err(anyhow::anyhow!(
+            "Failed to scrub via {path}: {status} - {body}"
+        ))
+    }
+
     fn deserialize_operation(blip: &Blip) -> Result<Item, anyhow::Error> {
         Ok(p2panda_core::cbor::decode_cbor(blip.as_slice())?)
     }
@@ -449,6 +540,72 @@ mod tests {
         }
     }
 
+    /// An item whose payload-free form is a distinct value, so the commitment
+    /// and the scrub submission can be compared meaningfully.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    struct Parcel {
+        seq: u64,
+        payload: Option<String>,
+    }
+
+    impl MailboxItem for Parcel {
+        type Hash = u64;
+        type Author = char;
+        type Topic = u8;
+
+        fn hash(&self) -> u64 {
+            self.seq
+        }
+        fn author(&self) -> char {
+            'a'
+        }
+        fn seq_num(&self) -> u64 {
+            self.seq
+        }
+        fn topic(&self) -> u8 {
+            1
+        }
+        fn scrubbed(&self) -> Option<Self> {
+            self.payload.as_ref()?;
+            Some(Self {
+                seq: self.seq,
+                payload: None,
+            })
+        }
+    }
+
+    /// The commitment is computed when a blip is published and checked against
+    /// bytes submitted by a later, separate scrub. If those two encodings ever
+    /// disagree the mailbox rejects every scrub, so pin that they match.
+    #[test]
+    fn the_publish_commitment_matches_what_scrub_submits() {
+        let item = Parcel {
+            seq: 7,
+            payload: Some("secret".into()),
+        };
+
+        let committed = ToyMailboxClient::<Parcel>::scrub_hash(&item)
+            .unwrap()
+            .expect("an item with a payload is scrubbable");
+        let submitted =
+            ToyMailboxClient::<Parcel>::serialize_operation(&item.scrubbed().unwrap()).unwrap();
+
+        assert_eq!(committed, ScrubHash::new(submitted.as_slice()));
+    }
+
+    #[test]
+    fn an_item_with_no_payload_commits_to_nothing() {
+        let item = Parcel {
+            seq: 7,
+            payload: None,
+        };
+        assert!(
+            ToyMailboxClient::<Parcel>::scrub_hash(&item)
+                .unwrap()
+                .is_none()
+        );
+    }
+
     #[test]
     fn test_stringify_unstringify() {
         let topic = Abecedarian(10);
@@ -486,6 +643,7 @@ mod tests {
         let already = crate::toy::send_register_hashes(
             &base_url,
             vec![h_stored, h_new],
+            "op-1".to_string(),
             iroh::SecretKey::from_bytes(&[3; 32]).public(),
             false,
         )
@@ -615,7 +773,10 @@ mod tests {
         )
         .with_blob_reader(std::sync::Arc::new(StubReader(data.clone())));
 
-        client.store_blobs(vec![hash]).await.unwrap();
+        client
+            .store_blobs(vec![("op-1".to_string(), vec![hash])])
+            .await
+            .unwrap();
 
         // The upload is spawned, so wait for the detached task to deliver it.
         for _ in 0..100 {

--- a/crates/mailbox-server/src/blob_refs_table.rs
+++ b/crates/mailbox-server/src/blob_refs_table.rs
@@ -4,9 +4,9 @@ use redb::TableDefinition;
 /// blob. The mailbox never interprets it; it only needs it to tell two
 /// references to the same bytes apart.
 ///
-/// The empty string is the reference recorded for a blob announced without one.
-/// It is never tombstoned by a scrub naming a real operation, so such a blob is
-/// simply unscrubbable — the same way a blip stored without a commitment is.
+/// The empty string is not a reference at all: it marks a re-announce of blobs
+/// some other operation already vouched for. See
+/// [`record_blob_refs`](crate::scrub_blobs::record_blob_refs).
 pub type OpRef = String;
 
 /// References from blobs to the operations that carry them.

--- a/crates/mailbox-server/src/blob_refs_table.rs
+++ b/crates/mailbox-server/src/blob_refs_table.rs
@@ -1,0 +1,83 @@
+use redb::TableDefinition;
+
+/// A client-supplied, opaque identifier for the operation that references a
+/// blob. The mailbox never interprets it; it only needs it to tell two
+/// references to the same bytes apart.
+///
+/// The empty string is the reference recorded for a blob announced without one.
+/// It is never tombstoned by a scrub naming a real operation, so such a blob is
+/// simply unscrubbable — the same way a blip stored without a commitment is.
+pub type OpRef = String;
+
+/// References from blobs to the operations that carry them.
+///
+/// Key: `blob_hash` (32 raw bytes) followed by the [`OpRef`]'s UTF-8 bytes.
+/// Value: [`REF_LIVE`] or [`REF_TOMBSTONED`].
+///
+/// Deliberately the flattest thing that works — redb's built-in `&[u8]`/`u8`
+/// impls, so there is no custom `Key`/`Value` to write. The blob hash comes
+/// first and is fixed-width, which makes "every reference to this blob" a plain
+/// prefix scan.
+///
+/// This table exists because blobs are content-addressed over *plaintext* media:
+/// identical bytes collide across chats and users, so deleting by bare hash
+/// would drop media still referenced by live messages elsewhere, and a
+/// permanent bare-hash tombstone would block legitimate re-sends mailbox-wide.
+/// A `(blob, operation)` pair is position-like — a given operation references a
+/// given blob exactly once — which is what makes tombstoning it safe forever.
+pub const BLOB_REFS_TABLE: TableDefinition<&[u8], u8> = TableDefinition::new("blob_refs");
+
+pub const REF_LIVE: u8 = 0;
+pub const REF_TOMBSTONED: u8 = 1;
+
+pub fn blob_ref_key(blob_hash: &iroh_blobs::Hash, op_ref: &str) -> Vec<u8> {
+    let mut key = Vec::with_capacity(32 + op_ref.len());
+    key.extend_from_slice(blob_hash.as_bytes());
+    key.extend_from_slice(op_ref.as_bytes());
+    key
+}
+
+/// Whether `key` is a reference to `blob_hash`, for terminating a prefix scan.
+pub fn key_is_for_blob(key: &[u8], blob_hash: &iroh_blobs::Hash) -> bool {
+    key.starts_with(blob_hash.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_starts_with_the_blob_hash() {
+        let blob = iroh_blobs::Hash::new([3; 32]);
+        let key = blob_ref_key(&blob, "op-1");
+        assert_eq!(&key[..32], blob.as_bytes());
+        assert_eq!(&key[32..], b"op-1");
+        assert!(key_is_for_blob(&key, &blob));
+        assert!(!key_is_for_blob(&key, &iroh_blobs::Hash::new([4; 32])));
+    }
+
+    /// References to one blob must sort together, so a prefix scan sees every
+    /// one of them and stops at the next blob.
+    #[test]
+    fn refs_to_the_same_blob_sort_contiguously() {
+        let blob = iroh_blobs::Hash::new([3; 32]);
+        let other = iroh_blobs::Hash::new([4; 32]);
+        let mut keys = vec![
+            blob_ref_key(&other, "op-1"),
+            blob_ref_key(&blob, "op-2"),
+            blob_ref_key(&blob, "op-1"),
+        ];
+        keys.sort();
+        assert_eq!(keys[0], blob_ref_key(&blob, "op-1"));
+        assert_eq!(keys[1], blob_ref_key(&blob, "op-2"));
+        assert_eq!(keys[2], blob_ref_key(&other, "op-1"));
+    }
+
+    /// An announce with no operation attached must not collide with a real
+    /// reference, or scrubbing one message's media would silently tombstone it.
+    #[test]
+    fn unattributed_ref_is_its_own_key() {
+        let blob = iroh_blobs::Hash::new([3; 32]);
+        assert_ne!(blob_ref_key(&blob, ""), blob_ref_key(&blob, "op-1"));
+    }
+}

--- a/crates/mailbox-server/src/blob_sync.rs
+++ b/crates/mailbox-server/src/blob_sync.rs
@@ -457,6 +457,36 @@ impl BlobSync {
         }
     }
 
+    /// Delete every retention tag protecting `hash`, so iroh's GC reclaims the
+    /// bytes on its next sweep. Called when a blob's last live reference is
+    /// tombstoned by `/blobs/scrub`.
+    pub async fn release_blob(&self, hash: iroh_blobs::Hash) {
+        let tags = self.blobs.store().tags();
+        let mut stream = match tags.list_prefix(BLOB_TAG_PREFIX.as_bytes()).await {
+            Ok(stream) => stream,
+            Err(err) => {
+                tracing::warn!(%hash, ?err, "failed to list blob tags while scrubbing");
+                return;
+            }
+        };
+        let mut to_delete = Vec::new();
+        while let Some(info) = stream.next().await {
+            match info {
+                Ok(info) if tag_names_blob(info.name.as_ref(), &hash) => to_delete.push(info.name),
+                Ok(_) => {}
+                Err(err) => {
+                    tracing::warn!(%hash, ?err, "failed to read blob tag while scrubbing");
+                    return;
+                }
+            }
+        }
+        for name in to_delete {
+            if let Err(err) = tags.delete(name).await {
+                tracing::warn!(%hash, ?err, "failed to delete blob tag while scrubbing");
+            }
+        }
+    }
+
     /// Spawn the loop that expires stored-blob tags past the retention window;
     /// iroh's background GC then reclaims the now-untagged blobs. Returns `None`
     /// when sharing a node's store (the node owns blob lifecycle).
@@ -498,6 +528,16 @@ async fn expire_blob_tags(blobs: &iroh_blobs::BlobsProtocol) -> anyhow::Result<(
         tags.delete(name).await?;
     }
     Ok(())
+}
+
+/// Whether a `mailbox/<secs>/<hash>` tag protects `hash`.
+fn tag_names_blob(name: &[u8], hash: &iroh_blobs::Hash) -> bool {
+    let Ok(name) = std::str::from_utf8(name) else {
+        return false;
+    };
+    name.strip_prefix(BLOB_TAG_PREFIX)
+        .and_then(|rest| rest.split('/').nth(1))
+        .is_some_and(|tagged| tagged == hash.to_string())
 }
 
 /// Parse the embedded fetch time (unix seconds) from a `mailbox/<secs>/<hash>` tag.

--- a/crates/mailbox-server/src/cleanup.rs
+++ b/crates/mailbox-server/src/cleanup.rs
@@ -2,7 +2,7 @@ use redb::{Database, ReadableTable};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::{BlipsKey, BLIPS_TABLE};
+use crate::{scrub_table::SCRUB_TABLE, BlipsKey, BLIPS_TABLE};
 
 const CLEANUP_INTERVAL: Duration = Duration::from_secs(60 * 60); // 1 hour
 const MESSAGE_MAX_AGE: Duration = Duration::from_secs(90 * 24 * 60 * 60); // 90 days
@@ -38,6 +38,10 @@ pub async fn cleanup_old_messages(db: &Database) -> Result<(), Box<dyn std::erro
 
     {
         let mut table = write_txn.open_table(BLIPS_TABLE)?;
+        // A commitment is only meaningful alongside the blip it describes.
+        // (Blob references are deliberately never expired — see
+        // `blob_refs_table`.)
+        let mut scrub_table = write_txn.open_table(SCRUB_TABLE)?;
 
         // Collect keys to delete
         let mut keys_to_delete: Vec<BlipsKey> = Vec::new();
@@ -54,6 +58,7 @@ pub async fn cleanup_old_messages(db: &Database) -> Result<(), Box<dyn std::erro
         // Delete old messages
         for key in &keys_to_delete {
             table.remove(key)?;
+            scrub_table.remove(key)?;
             deleted_count += 1;
         }
     }

--- a/crates/mailbox-server/src/lib.rs
+++ b/crates/mailbox-server/src/lib.rs
@@ -14,6 +14,7 @@ use tower_http::{cors::CorsLayer, trace::TraceLayer};
 
 mod blip;
 mod blips_table;
+mod blob_refs_table;
 mod blob_sync;
 mod cleanup;
 mod get_blips;
@@ -22,6 +23,9 @@ mod register_hashes;
 mod register_peer;
 mod report;
 mod reports_table;
+mod scrub_blips;
+mod scrub_blobs;
+mod scrub_table;
 mod server_key;
 mod store_blips;
 mod watermark;
@@ -47,10 +51,16 @@ pub use register_hashes::{
     record_blob_sources, register_hashes, upload_blob, RegisterHashesRequest,
     RegisterHashesResponse, UploadBlobResponse,
 };
+pub use blob_refs_table::{OpRef, BLOB_REFS_TABLE};
 pub use register_peer::RegisterPeerRequest;
 pub use reports_table::REPORTS_TABLE;
+pub use scrub_blips::{
+    scrub_blips, ScrubBlipsRequest, ScrubBlipsResponse, ScrubbedBlip,
+};
+pub use scrub_blobs::{scrub_blobs, BlobRef, ScrubBlobsRequest, ScrubBlobsResponse};
+pub use scrub_table::{ScrubHash, SCRUB_TABLE};
 pub use server_key::{load_or_create_secret_key, SERVER_KEY_TABLE};
-pub use store_blips::{store_blips, StoreBlipsRequest};
+pub use store_blips::{store_blips, StoreBlipsRequest, StoredBlip};
 pub use watermark::compute_initial_watermarks;
 pub use watermarks_table::{WatermarksKey, WatermarksKeyError, WATERMARKS_TABLE};
 
@@ -185,6 +195,8 @@ pub fn init_db(db_path: PathBuf) -> Result<Database, Box<dyn std::error::Error>>
         let _watermarks_table = write_txn.open_table(WATERMARKS_TABLE)?;
         let _server_key_table = write_txn.open_table(SERVER_KEY_TABLE)?;
         let _reports_table = write_txn.open_table(REPORTS_TABLE)?;
+        let _scrub_table = write_txn.open_table(SCRUB_TABLE)?;
+        let _blob_refs_table = write_txn.open_table(BLOB_REFS_TABLE)?;
     }
     write_txn.commit()?;
 
@@ -218,6 +230,8 @@ pub fn create_app(
         )
         .route("/blobs/upload", post(register_hashes::upload_blob))
         .route("/blips/get", post(get_blips_for_topics))
+        .route("/blips/scrub", post(scrub_blips))
+        .route("/blobs/scrub", post(scrub_blobs))
         .route("/peers/register", post(register_peer::register_peer))
         .route("/report", post(report::report))
         .layer(CorsLayer::permissive())

--- a/crates/mailbox-server/src/lib.rs
+++ b/crates/mailbox-server/src/lib.rs
@@ -41,6 +41,7 @@ const MAX_PAYLOAD_SIZE: usize = 64 * 1024 * 1024; // 64 MB
 
 pub use blip::Blip;
 pub use blips_table::{BlipsKey, BlipsKeyError, BlipsKeyPrefix, BLIPS_TABLE};
+pub use blob_refs_table::{OpRef, BLOB_REFS_TABLE};
 pub use blob_sync::{BlobFetchPool, BlobSync};
 pub use cleanup::{cleanup_old_messages, spawn_cleanup_task};
 pub use dashchat_utils::FetchConfig;
@@ -51,12 +52,9 @@ pub use register_hashes::{
     record_blob_sources, register_hashes, upload_blob, RegisterHashesRequest,
     RegisterHashesResponse, UploadBlobResponse,
 };
-pub use blob_refs_table::{OpRef, BLOB_REFS_TABLE};
 pub use register_peer::RegisterPeerRequest;
 pub use reports_table::REPORTS_TABLE;
-pub use scrub_blips::{
-    scrub_blips, ScrubBlipsRequest, ScrubBlipsResponse, ScrubbedBlip,
-};
+pub use scrub_blips::{scrub_blips, ScrubBlipsRequest, ScrubBlipsResponse, ScrubbedBlip};
 pub use scrub_blobs::{scrub_blobs, BlobRef, ScrubBlobsRequest, ScrubBlobsResponse};
 pub use scrub_table::{ScrubHash, SCRUB_TABLE};
 pub use server_key::{load_or_create_secret_key, SERVER_KEY_TABLE};

--- a/crates/mailbox-server/src/register_hashes.rs
+++ b/crates/mailbox-server/src/register_hashes.rs
@@ -1,7 +1,11 @@
 use axum::{body::Bytes, extract::State, http::StatusCode, Json};
 use serde::{Deserialize, Serialize};
 
-use crate::{AppState, BlobSync};
+use crate::{
+    blob_refs_table::OpRef,
+    scrub_blobs::{blob_is_wanted, record_blob_refs},
+    AppState, BlobSync,
+};
 
 /// A client's request to announce blob hashes to the mailbox. For each hash the
 /// mailbox already holds it reports `already_stored`; every other hash it
@@ -11,6 +15,14 @@ use crate::{AppState, BlobSync};
 #[derive(Serialize, Deserialize)]
 pub struct RegisterHashesRequest {
     pub blob_hashes: Vec<iroh_blobs::Hash>,
+    /// Opaque identifier of the operation these blobs belong to. The mailbox
+    /// records a `(blob, operation)` reference for each hash, which is what
+    /// `/blobs/scrub` later tombstones — blobs are content-addressed over
+    /// plaintext media, so the bare hash is not a safe unit of deletion. An
+    /// announce that omits it records an unattributable reference, leaving the
+    /// blob unscrubbable.
+    #[serde(default)]
+    pub op_ref: OpRef,
     /// The peer the mailbox should dial to fetch any hash it does not already
     /// hold (typically the sending client itself).
     pub sender_pubkey: iroh::EndpointId,
@@ -69,10 +81,34 @@ pub async fn record_blob_sources(
 pub async fn register_hashes(
     State(state): State<AppState>,
     Json(payload): Json<RegisterHashesRequest>,
-) -> Json<RegisterHashesResponse> {
+) -> Result<Json<RegisterHashesResponse>, (StatusCode, String)> {
+    // Record this operation's reference to each blob. Any hash whose reference
+    // is already tombstoned drops out here and is neither stored nor fetched:
+    // a node that has not yet processed the delete must not be able to
+    // resurrect scrubbed media by re-announcing it.
+    let db = state.db.clone();
+    let hashes = payload.blob_hashes.clone();
+    let op_ref = payload.op_ref.clone();
+    let wanted = tokio::task::spawn_blocking(move || record_blob_refs(&db, &hashes, &op_ref))
+        .await
+        .map_err(|e| {
+            tracing::error!("Task join error: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal server error".to_string(),
+            )
+        })?
+        .map_err(|e| {
+            tracing::error!("{}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal server error".to_string(),
+            )
+        })?;
+
     let mut already_stored = Vec::new();
     let mut to_fetch = Vec::new();
-    for hash in payload.blob_hashes {
+    for hash in wanted {
         if state.blob_sync.blobs.has(hash).await.unwrap_or(false) {
             already_stored.push(hash);
         } else {
@@ -86,7 +122,7 @@ pub async fn register_hashes(
         payload.expect_upload,
     )
     .await;
-    Json(RegisterHashesResponse { already_stored })
+    Ok(Json(RegisterHashesResponse { already_stored }))
 }
 
 /// Handle `POST /blobs/upload`: store the raw blob bytes in the request body and
@@ -99,6 +135,32 @@ pub async fn upload_blob(
     State(state): State<AppState>,
     body: Bytes,
 ) -> Result<Json<UploadBlobResponse>, (StatusCode, String)> {
+    // Refuse bytes whose every reference has been scrubbed, so an upload racing
+    // a delete can't put the media back. Checked before storing, since the
+    // upload carries no reference of its own to record.
+    let offered = iroh_blobs::Hash::new(&body);
+    let db = state.db.clone();
+    let wanted = tokio::task::spawn_blocking(move || blob_is_wanted(&db, &offered))
+        .await
+        .map_err(|e| {
+            tracing::error!("Task join error: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal server error".to_string(),
+            )
+        })?
+        .map_err(|e| {
+            tracing::error!("{}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal server error".to_string(),
+            )
+        })?;
+    if !wanted {
+        tracing::debug!(hash = %offered, "rejecting upload of a scrubbed blob");
+        return Ok(Json(UploadBlobResponse { hash: offered }));
+    }
+
     let hash = state
         .blob_sync
         .store_pushed_blob(body)

--- a/crates/mailbox-server/src/register_hashes.rs
+++ b/crates/mailbox-server/src/register_hashes.rs
@@ -18,9 +18,10 @@ pub struct RegisterHashesRequest {
     /// Opaque identifier of the operation these blobs belong to. The mailbox
     /// records a `(blob, operation)` reference for each hash, which is what
     /// `/blobs/scrub` later tombstones — blobs are content-addressed over
-    /// plaintext media, so the bare hash is not a safe unit of deletion. An
-    /// announce that omits it records an unattributable reference, leaving the
-    /// blob unscrubbable.
+    /// plaintext media, so the bare hash is not a safe unit of deletion. Left
+    /// empty for a re-announce of blobs already vouched for by an earlier
+    /// request, which refreshes the mailbox's fetch intent without minting a
+    /// new reference.
     #[serde(default)]
     pub op_ref: OpRef,
     /// The peer the mailbox should dial to fetch any hash it does not already

--- a/crates/mailbox-server/src/scrub_blips.rs
+++ b/crates/mailbox-server/src/scrub_blips.rs
@@ -120,10 +120,7 @@ fn scrub_blips_inner(
         scrubbed.len(),
         rejected.len()
     );
-    Ok(ScrubBlipsResponse {
-        scrubbed,
-        rejected,
-    })
+    Ok(ScrubBlipsResponse { scrubbed, rejected })
 }
 
 /// The stored rows at `topic:author:seq` whose commitment the submitted bytes

--- a/crates/mailbox-server/src/scrub_blips.rs
+++ b/crates/mailbox-server/src/scrub_blips.rs
@@ -1,0 +1,159 @@
+use axum::{extract::State, http::StatusCode, Json};
+use redb::{Database, ReadableTable};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+use crate::{
+    scrub_table::{decode_commitment, ScrubHash, SCRUB_TABLE},
+    AppState, Author, Blip, BlipsKey, BlipsKeyPrefix, SequenceNumber, TopicId, BLIPS_TABLE,
+};
+
+/// A request to replace stored blips with their payload-free forms.
+///
+/// The submitted bytes are the replacement itself: the mailbox accepts them
+/// only where they hash to the commitment the blip's publisher supplied at
+/// store time.
+#[derive(Serialize, Deserialize)]
+pub struct ScrubBlipsRequest {
+    pub blips: BTreeMap<TopicId, BTreeMap<Author, BTreeMap<SequenceNumber, Blip>>>,
+}
+
+/// A single blip coordinate, as reported back in the response.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScrubbedBlip {
+    pub topic_id: TopicId,
+    pub author: Author,
+    pub sequence_number: SequenceNumber,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ScrubBlipsResponse {
+    /// Coordinates whose stored blip is now payload-free.
+    pub scrubbed: Vec<ScrubbedBlip>,
+    /// Coordinates left untouched: no blip stored there, no commitment recorded
+    /// for it, or the submitted bytes did not match the commitment.
+    pub rejected: Vec<ScrubbedBlip>,
+}
+
+pub async fn scrub_blips(
+    State(state): State<AppState>,
+    Json(payload): Json<ScrubBlipsRequest>,
+) -> Result<Json<ScrubBlipsResponse>, (StatusCode, String)> {
+    let db = state.db.clone();
+    // spawn_blocking for the same reason as store_blips: redb's begin_write()
+    // blocks waiting for exclusive write access.
+    tokio::task::spawn_blocking(move || scrub_blips_inner(&db, &payload))
+        .await
+        .map_err(|e| {
+            tracing::error!("Task join error: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal server error".to_string(),
+            )
+        })?
+        .map(Json)
+        .map_err(|e| {
+            tracing::error!("{}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal server error".to_string(),
+            )
+        })
+}
+
+fn scrub_blips_inner(
+    db: &Database,
+    request: &ScrubBlipsRequest,
+) -> Result<ScrubBlipsResponse, String> {
+    let write_txn = db
+        .begin_write()
+        .map_err(|e| format!("Failed to begin transaction: {}", e))?;
+
+    let mut scrubbed = Vec::new();
+    let mut rejected = Vec::new();
+
+    {
+        let mut blips_table = write_txn
+            .open_table(BLIPS_TABLE)
+            .map_err(|e| format!("Failed to open blips table: {}", e))?;
+        let scrub_table = write_txn
+            .open_table(SCRUB_TABLE)
+            .map_err(|e| format!("Failed to open scrub table: {}", e))?;
+
+        for (topic_id, authors) in &request.blips {
+            for (author, sequences) in authors {
+                for (seq_num, submitted) in sequences {
+                    let coordinate = ScrubbedBlip {
+                        topic_id: topic_id.clone(),
+                        author: author.clone(),
+                        sequence_number: *seq_num,
+                    };
+                    let keys = matching_keys(
+                        &blips_table,
+                        &scrub_table,
+                        topic_id,
+                        author,
+                        *seq_num,
+                        submitted,
+                    )?;
+                    if keys.is_empty() {
+                        rejected.push(coordinate);
+                        continue;
+                    }
+                    for key in keys {
+                        blips_table
+                            .insert(&key, submitted.as_slice())
+                            .map_err(|e| format!("Failed to scrub blip: {}", e))?;
+                    }
+                    scrubbed.push(coordinate);
+                }
+            }
+        }
+    }
+
+    write_txn
+        .commit()
+        .map_err(|e| format!("Failed to commit transaction: {}", e))?;
+
+    tracing::debug!(
+        "Scrubbed {} blips ({} rejected)",
+        scrubbed.len(),
+        rejected.len()
+    );
+    Ok(ScrubBlipsResponse {
+        scrubbed,
+        rejected,
+    })
+}
+
+/// The stored rows at `topic:author:seq` whose commitment the submitted bytes
+/// satisfy. A coordinate can hold more than one row — `store_blips` inserts
+/// under a fresh UUID each time — and each row carries its own commitment.
+fn matching_keys(
+    blips_table: &redb::Table<BlipsKey, &[u8]>,
+    scrub_table: &redb::Table<BlipsKey, &[u8]>,
+    topic_id: &str,
+    author: &str,
+    seq_num: SequenceNumber,
+    submitted: &Blip,
+) -> Result<Vec<BlipsKey>, String> {
+    let submitted_hash = ScrubHash::new(submitted.as_slice());
+    let prefix = BlipsKeyPrefix::TopicAuthorSeq(topic_id.to_string(), author.to_string(), seq_num);
+
+    let mut keys = Vec::new();
+    for entry in blips_table
+        .range(prefix.range_start()..=prefix.range_end())
+        .map_err(|e| format!("Failed to create iterator: {}", e))?
+    {
+        let (key, _) = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
+        let key = key.value();
+        let commitment = scrub_table
+            .get(&key)
+            .map_err(|e| format!("Failed to read commitment: {}", e))?
+            .and_then(|v| decode_commitment(v.value()));
+        if commitment == Some(submitted_hash) {
+            keys.push(key);
+        }
+    }
+    Ok(keys)
+}

--- a/crates/mailbox-server/src/scrub_blobs.rs
+++ b/crates/mailbox-server/src/scrub_blobs.rs
@@ -1,0 +1,205 @@
+use axum::{extract::State, http::StatusCode, Json};
+use redb::{Database, ReadableDatabase, ReadableTable};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    blob_refs_table::{
+        blob_ref_key, key_is_for_blob, OpRef, BLOB_REFS_TABLE, REF_LIVE, REF_TOMBSTONED,
+    },
+    AppState, BlobSync,
+};
+
+/// One operation's reference to one blob.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BlobRef {
+    pub blob_hash: iroh_blobs::Hash,
+    /// Opaque identifier of the referencing operation. Two messages carrying
+    /// identical media are distinct references, so deleting one leaves the
+    /// other's copy alone.
+    pub op_ref: OpRef,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ScrubBlobsRequest {
+    pub refs: Vec<BlobRef>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ScrubBlobsResponse {
+    /// Blobs whose last live reference this request tombstoned, and whose bytes
+    /// the mailbox has therefore dropped.
+    pub removed: Vec<iroh_blobs::Hash>,
+}
+
+/// Handle `POST /blobs/scrub`: tombstone the given `(blob, operation)`
+/// references, then drop the bytes of any blob left with no live reference.
+///
+/// A tombstoned reference stays tombstoned permanently — `register_hashes`
+/// refuses to re-record it — so a node that has not yet processed the delete
+/// cannot resurrect the blob by re-announcing it.
+pub async fn scrub_blobs(
+    State(state): State<AppState>,
+    Json(payload): Json<ScrubBlobsRequest>,
+) -> Result<Json<ScrubBlobsResponse>, (StatusCode, String)> {
+    let db = state.db.clone();
+    let refs = payload.refs.clone();
+    let orphaned = tokio::task::spawn_blocking(move || tombstone_refs(&db, &refs))
+        .await
+        .map_err(|e| {
+            tracing::error!("Task join error: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal server error".to_string(),
+            )
+        })?
+        .map_err(|e| {
+            tracing::error!("{}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal server error".to_string(),
+            )
+        })?;
+
+    for hash in &orphaned {
+        drop_blob(&state.blob_sync, *hash).await;
+    }
+
+    tracing::debug!("Scrubbed {} blobs", orphaned.len());
+    Ok(Json(ScrubBlobsResponse { removed: orphaned }))
+}
+
+/// Mark each reference tombstoned, returning the blobs left with no live
+/// reference.
+fn tombstone_refs(db: &Database, refs: &[BlobRef]) -> Result<Vec<iroh_blobs::Hash>, String> {
+    let write_txn = db
+        .begin_write()
+        .map_err(|e| format!("Failed to begin transaction: {}", e))?;
+
+    let mut orphaned = Vec::new();
+    {
+        let mut table = write_txn
+            .open_table(BLOB_REFS_TABLE)
+            .map_err(|e| format!("Failed to open blob refs table: {}", e))?;
+
+        for blob_ref in refs {
+            let key = blob_ref_key(&blob_ref.blob_hash, &blob_ref.op_ref);
+            table
+                .insert(key.as_slice(), REF_TOMBSTONED)
+                .map_err(|e| format!("Failed to tombstone blob ref: {}", e))?;
+
+            if !has_live_ref(&table, &blob_ref.blob_hash)? && !orphaned.contains(&blob_ref.blob_hash)
+            {
+                orphaned.push(blob_ref.blob_hash);
+            }
+        }
+    }
+
+    write_txn
+        .commit()
+        .map_err(|e| format!("Failed to commit transaction: {}", e))?;
+
+    Ok(orphaned)
+}
+
+/// Whether any operation still holds a live reference to `blob_hash`.
+fn has_live_ref(
+    table: &redb::Table<&[u8], u8>,
+    blob_hash: &iroh_blobs::Hash,
+) -> Result<bool, String> {
+    let start = blob_hash.as_bytes().to_vec();
+    for entry in table
+        .range(start.as_slice()..)
+        .map_err(|e| format!("Failed to create iterator: {}", e))?
+    {
+        let (key, value) = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
+        if !key_is_for_blob(key.value(), blob_hash) {
+            break;
+        }
+        if value.value() == REF_LIVE {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Record a live reference from `op_ref` to each blob, skipping any reference
+/// already tombstoned. Returns the hashes that are still wanted, i.e. those the
+/// mailbox should go on to store or fetch.
+pub fn record_blob_refs(
+    db: &Database,
+    hashes: &[iroh_blobs::Hash],
+    op_ref: &str,
+) -> Result<Vec<iroh_blobs::Hash>, String> {
+    let write_txn = db
+        .begin_write()
+        .map_err(|e| format!("Failed to begin transaction: {}", e))?;
+
+    let mut wanted = Vec::new();
+    {
+        let mut table = write_txn
+            .open_table(BLOB_REFS_TABLE)
+            .map_err(|e| format!("Failed to open blob refs table: {}", e))?;
+
+        for hash in hashes {
+            let key = blob_ref_key(hash, op_ref);
+            let tombstoned = table
+                .get(key.as_slice())
+                .map_err(|e| format!("Failed to read blob ref: {}", e))?
+                .is_some_and(|v| v.value() == REF_TOMBSTONED);
+            if tombstoned {
+                tracing::debug!(%hash, op_ref, "ignoring re-announce of a scrubbed blob reference");
+                continue;
+            }
+            table
+                .insert(key.as_slice(), REF_LIVE)
+                .map_err(|e| format!("Failed to record blob ref: {}", e))?;
+            wanted.push(*hash);
+        }
+    }
+
+    write_txn
+        .commit()
+        .map_err(|e| format!("Failed to commit transaction: {}", e))?;
+
+    Ok(wanted)
+}
+
+/// Whether the mailbox still wants `hash` at all, i.e. whether any live
+/// reference to it remains. Used by the upload path, which carries no reference
+/// of its own.
+pub fn blob_is_wanted(db: &Database, hash: &iroh_blobs::Hash) -> Result<bool, String> {
+    let read_txn = db
+        .begin_read()
+        .map_err(|e| format!("Failed to begin transaction: {}", e))?;
+    let table = read_txn
+        .open_table(BLOB_REFS_TABLE)
+        .map_err(|e| format!("Failed to open blob refs table: {}", e))?;
+
+    let start = hash.as_bytes().to_vec();
+    let mut saw_ref = false;
+    for entry in table
+        .range(start.as_slice()..)
+        .map_err(|e| format!("Failed to create iterator: {}", e))?
+    {
+        let (key, value) = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
+        if !key_is_for_blob(key.value(), hash) {
+            break;
+        }
+        saw_ref = true;
+        if value.value() == REF_LIVE {
+            return Ok(true);
+        }
+    }
+    // A blob nobody has announced is not refused: uploads may legitimately
+    // arrive before their announce. Only a blob whose every reference is
+    // tombstoned is unwanted.
+    Ok(!saw_ref)
+}
+
+/// Drop a blob the mailbox no longer has any live reference to: take it out of
+/// the fetch pool (or it would be pulled back from a peer that still holds it)
+/// and delete its retention tags so iroh's GC reclaims the bytes.
+async fn drop_blob(blob_sync: &BlobSync, hash: iroh_blobs::Hash) {
+    blob_sync.fetch_pool().remove(hash).await;
+    blob_sync.release_blob(hash).await;
+}

--- a/crates/mailbox-server/src/scrub_blobs.rs
+++ b/crates/mailbox-server/src/scrub_blobs.rs
@@ -87,7 +87,8 @@ fn tombstone_refs(db: &Database, refs: &[BlobRef]) -> Result<Vec<iroh_blobs::Has
                 .insert(key.as_slice(), REF_TOMBSTONED)
                 .map_err(|e| format!("Failed to tombstone blob ref: {}", e))?;
 
-            if !has_live_ref(&table, &blob_ref.blob_hash)? && !orphaned.contains(&blob_ref.blob_hash)
+            if !has_live_ref(&table, &blob_ref.blob_hash)?
+                && !orphaned.contains(&blob_ref.blob_hash)
             {
                 orphaned.push(blob_ref.blob_hash);
             }
@@ -125,6 +126,13 @@ fn has_live_ref(
 /// Record a live reference from `op_ref` to each blob, skipping any reference
 /// already tombstoned. Returns the hashes that are still wanted, i.e. those the
 /// mailbox should go on to store or fetch.
+///
+/// An empty `op_ref` marks a *re-announce* rather than a new reference: it
+/// records nothing and merely reports which blobs still have a live reference
+/// from some operation. Clients re-announcing blobs the mailbox never fetched
+/// have only a per-mailbox hash list to work from, no originating operation, so
+/// letting them mint a reference would leave every re-announced blob holding an
+/// unattributable one that no scrub could ever tombstone.
 pub fn record_blob_refs(
     db: &Database,
     hashes: &[iroh_blobs::Hash],
@@ -141,6 +149,15 @@ pub fn record_blob_refs(
             .map_err(|e| format!("Failed to open blob refs table: {}", e))?;
 
         for hash in hashes {
+            if op_ref.is_empty() {
+                if has_live_ref(&table, hash)? {
+                    wanted.push(*hash);
+                } else {
+                    tracing::debug!(%hash, "ignoring re-announce of a blob with no live reference");
+                }
+                continue;
+            }
+
             let key = blob_ref_key(hash, op_ref);
             let tombstoned = table
                 .get(key.as_slice())

--- a/crates/mailbox-server/src/scrub_table.rs
+++ b/crates/mailbox-server/src/scrub_table.rs
@@ -1,0 +1,60 @@
+use redb::TableDefinition;
+
+use crate::BlipsKey;
+
+/// blake3 hash of a blip's *payload-free* form, committed by the publisher at
+/// store time.
+///
+/// The mailbox cannot decode a blip, so it has no way of deciding for itself
+/// what a legitimate payload-free version of one looks like. This commitment is
+/// the whole of the scrub validation: the only replacement `/blips/scrub`
+/// accepts for a blip is the one its own publisher pre-authorized here.
+pub type ScrubHash = iroh_blobs::Hash;
+
+/// Scrub commitments, keyed by the same [`BlipsKey`] as the blip they describe.
+///
+/// A separate table rather than a wider `BLIPS_TABLE` value, which would be a
+/// redb schema change requiring migration of existing databases.
+pub const SCRUB_TABLE: TableDefinition<BlipsKey, &[u8]> =
+    TableDefinition::new("scrub_commitments");
+
+/// Whether a stored blip is already in its scrubbed form.
+///
+/// Derived rather than flagged: a blip is scrubbed exactly when its own bytes
+/// hash to its commitment, so there is no separate state that can fall out of
+/// sync. An operation published without a body is trivially "already scrubbed",
+/// which is correct — there is nothing to remove.
+pub fn is_scrubbed(blip_bytes: &[u8], commitment: &ScrubHash) -> bool {
+    ScrubHash::new(blip_bytes) == *commitment
+}
+
+/// Decode a commitment from its stored 32 raw bytes.
+pub fn decode_commitment(bytes: &[u8]) -> Option<ScrubHash> {
+    let arr: [u8; 32] = bytes.try_into().ok()?;
+    Some(ScrubHash::from_bytes(arr))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn commitment_round_trips_through_storage_bytes() {
+        let commitment = ScrubHash::new(b"payload-free blip");
+        let decoded = decode_commitment(commitment.as_bytes()).unwrap();
+        assert_eq!(decoded, commitment);
+    }
+
+    #[test]
+    fn decode_commitment_rejects_wrong_length() {
+        assert!(decode_commitment(b"too short").is_none());
+    }
+
+    #[test]
+    fn a_blip_matching_its_own_commitment_is_scrubbed() {
+        let scrubbed = b"payload-free blip";
+        let commitment = ScrubHash::new(scrubbed);
+        assert!(is_scrubbed(scrubbed, &commitment));
+        assert!(!is_scrubbed(b"blip with a payload", &commitment));
+    }
+}

--- a/crates/mailbox-server/src/scrub_table.rs
+++ b/crates/mailbox-server/src/scrub_table.rs
@@ -15,8 +15,7 @@ pub type ScrubHash = iroh_blobs::Hash;
 ///
 /// A separate table rather than a wider `BLIPS_TABLE` value, which would be a
 /// redb schema change requiring migration of existing databases.
-pub const SCRUB_TABLE: TableDefinition<BlipsKey, &[u8]> =
-    TableDefinition::new("scrub_commitments");
+pub const SCRUB_TABLE: TableDefinition<BlipsKey, &[u8]> = TableDefinition::new("scrub_commitments");
 
 /// Whether a stored blip is already in its scrubbed form.
 ///

--- a/crates/mailbox-server/src/store_blips.rs
+++ b/crates/mailbox-server/src/store_blips.rs
@@ -4,13 +4,28 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::{
-    notify_topics_subscribers::notify_topics_subscribers, AppState, Author, Blip, BlipsKey,
-    BlipsKeyPrefix, SequenceNumber, TopicId, WatermarksKey, BLIPS_TABLE, WATERMARKS_TABLE,
+    notify_topics_subscribers::notify_topics_subscribers,
+    scrub_table::{decode_commitment, is_scrubbed, ScrubHash, SCRUB_TABLE},
+    AppState, Author, Blip, BlipsKey, BlipsKeyPrefix, SequenceNumber, TopicId, WatermarksKey,
+    BLIPS_TABLE, WATERMARKS_TABLE,
 };
+
+/// A blip together with the publisher's commitment to what it looks like once
+/// its payload is removed.
+///
+/// The mailbox treats a blip as opaque bytes, so it cannot derive the
+/// payload-free form itself; `scrub_hash` is what later lets it recognize a
+/// legitimate replacement. `None` leaves the blip unscrubbable — correct for
+/// item types that have no payload to remove.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StoredBlip {
+    pub blip: Blip,
+    pub scrub_hash: Option<ScrubHash>,
+}
 
 #[derive(Serialize, Deserialize)]
 pub struct StoreBlipsRequest {
-    pub blips: BTreeMap<TopicId, BTreeMap<Author, BTreeMap<SequenceNumber, Blip>>>,
+    pub blips: BTreeMap<TopicId, BTreeMap<Author, BTreeMap<SequenceNumber, StoredBlip>>>,
     #[serde(default)]
     pub sender_pubkey: Option<iroh::EndpointId>,
     #[serde(default)]
@@ -71,6 +86,10 @@ fn store_blips_inner(
             .open_table(WATERMARKS_TABLE)
             .map_err(|e| format!("Failed to open watermarks table: {}", e))?;
 
+        let mut scrub_table = write_txn
+            .open_table(SCRUB_TABLE)
+            .map_err(|e| format!("Failed to open scrub table: {}", e))?;
+
         for (topic_id, authors) in &request.blips {
             for (author, sequences) in authors {
                 let watermarks_key = WatermarksKey::new(topic_id.clone(), author.clone())
@@ -85,13 +104,32 @@ fn store_blips_inner(
                 // Collect sequence numbers being stored (BTreeMap is already sorted)
                 let mut stored_seqs: BTreeSet<SequenceNumber> = BTreeSet::new();
 
-                for (seq_num, blip) in sequences {
+                for (seq_num, stored) in sequences {
+                    // Once a payload has been scrubbed it must stay scrubbed:
+                    // a node that has not yet processed the delete would
+                    // otherwise put the body back at a fresh key.
+                    if seq_is_scrubbed(&blips_table, &scrub_table, topic_id, author, *seq_num)? {
+                        tracing::debug!(
+                            topic_id,
+                            author,
+                            seq_num,
+                            "ignoring store of an already-scrubbed blip"
+                        );
+                        stored_seqs.insert(*seq_num);
+                        continue;
+                    }
+
                     let key = BlipsKey::new_now(topic_id.clone(), author.clone(), *seq_num)
                         .map_err(|e| e.to_string())?;
 
                     blips_table
-                        .insert(&key, blip.as_slice())
+                        .insert(&key, stored.blip.as_slice())
                         .map_err(|e| format!("Failed to insert blip: {}", e))?;
+                    if let Some(scrub_hash) = &stored.scrub_hash {
+                        scrub_table
+                            .insert(&key, scrub_hash.as_bytes().as_slice())
+                            .map_err(|e| format!("Failed to insert scrub commitment: {}", e))?;
+                    }
                     stored_seqs.insert(*seq_num);
                     blip_count += 1;
                 }
@@ -135,6 +173,32 @@ fn store_blips_inner(
 
     tracing::debug!("Stored {} blips", blip_count);
     Ok(topics_with_new_blips)
+}
+
+/// Whether any blip already stored at `topic:author:seq` is in its scrubbed
+/// form, meaning its payload has been deleted for everyone.
+fn seq_is_scrubbed(
+    blips_table: &redb::Table<BlipsKey, &[u8]>,
+    scrub_table: &redb::Table<BlipsKey, &[u8]>,
+    topic_id: &str,
+    author: &str,
+    seq_num: SequenceNumber,
+) -> Result<bool, String> {
+    let prefix = BlipsKeyPrefix::TopicAuthorSeq(topic_id.to_string(), author.to_string(), seq_num);
+    for entry in blips_table
+        .range(prefix.range_start()..=prefix.range_end())
+        .map_err(|e| format!("Failed to create iterator: {}", e))?
+    {
+        let (key, value) = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
+        let commitment = scrub_table
+            .get(&key.value())
+            .map_err(|e| format!("Failed to read commitment: {}", e))?
+            .and_then(|v| decode_commitment(v.value()));
+        if commitment.is_some_and(|c| is_scrubbed(value.value(), &c)) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 /// Computes the new watermark after storing blips.

--- a/crates/mailbox-server/src/test_utils.rs
+++ b/crates/mailbox-server/src/test_utils.rs
@@ -5,7 +5,9 @@ use redb::Database;
 use tempfile::NamedTempFile;
 use tokio::task::JoinSet;
 
-use crate::{create_app, BlobSync, BLIPS_TABLE, WATERMARKS_TABLE};
+use crate::{
+    create_app, BlobSync, ScrubHash, BLIPS_TABLE, BLOB_REFS_TABLE, SCRUB_TABLE, WATERMARKS_TABLE,
+};
 
 pub const LONG_AGO: Duration = Duration::from_hours(100 * 24); // 100 days
 
@@ -17,10 +19,25 @@ pub fn create_test_db() -> (Database, NamedTempFile) {
     {
         let _blips_table = write_txn.open_table(BLIPS_TABLE).unwrap();
         let _watermarks_table = write_txn.open_table(WATERMARKS_TABLE).unwrap();
+        let _scrub_table = write_txn.open_table(SCRUB_TABLE).unwrap();
+        let _blob_refs_table = write_txn.open_table(BLOB_REFS_TABLE).unwrap();
     }
     write_txn.commit().unwrap();
 
     (db, temp_file)
+}
+
+/// A `/blips/store` blip entry with no scrub commitment, i.e. one that can
+/// never be scrubbed. The shape most tests want, since they care about storage
+/// and sync rather than deletion.
+pub fn stored_blip(blip_b64: &str) -> serde_json::Value {
+    serde_json::json!({ "blip": blip_b64, "scrub_hash": null })
+}
+
+/// A `/blips/store` blip entry committing to `scrubbed` as its payload-free
+/// form, which is the only replacement `/blips/scrub` will later accept for it.
+pub fn committed_blip(blip_b64: &str, scrubbed: &[u8]) -> serde_json::Value {
+    serde_json::json!({ "blip": blip_b64, "scrub_hash": ScrubHash::new(scrubbed) })
 }
 
 pub async fn test_blob_sync() -> BlobSync {

--- a/crates/mailbox-server/tests/integration.rs
+++ b/crates/mailbox-server/tests/integration.rs
@@ -1,6 +1,6 @@
 use mailbox_server::{
     encode_mailbox_id,
-    test_utils::{create_test_server, test_blob_sync},
+    test_utils::{committed_blip, create_test_server, stored_blip, test_blob_sync},
     GetBlipsResponse,
 };
 use serde_json::json;
@@ -53,7 +53,7 @@ async fn test_store_and_retrieve_single_message() {
             "blips": {
                 "test-topic-1": {
                     "author-a": {
-                        "0": message_b64
+                        "0": stored_blip(&message_b64)
                     }
                 }
             }
@@ -97,9 +97,9 @@ async fn test_store_and_retrieve_multiple_messages_same_topic() {
             "blips": {
                 "test-topic-multi": {
                     "author-1": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"First message".to_vec()),
-                        "1": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Second message".to_vec()),
-                        "2": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Third message".to_vec()),
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"First message".to_vec())),
+                        "1": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Second message".to_vec())),
+                        "2": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Third message".to_vec())),
                     }
                 }
             }
@@ -143,12 +143,12 @@ async fn test_retrieve_messages_from_multiple_topics() {
             "blips": {
                 "topic-a": {
                     "author-1": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, topic1_msg)
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, topic1_msg))
                     }
                 },
                 "topic-b": {
                     "author-1": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, topic2_msg)
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, topic2_msg))
                     }
                 }
             }
@@ -223,12 +223,12 @@ async fn test_topic_isolation() {
             "blips": {
                 "isolated-topic-1": {
                     "author-1": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 1")
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 1"))
                     }
                 },
                 "isolated-topic-2": {
                     "author-1": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 2")
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 2"))
                     }
                 }
             }
@@ -265,11 +265,11 @@ async fn test_sequence_number_filtering() {
             "blips": {
                 "test-topic": {
                     "author-x": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 0"),
-                        "1": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 1"),
-                        "2": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 2"),
-                        "3": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 3"),
-                        "4": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 4")
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 0")),
+                        "1": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 1")),
+                        "2": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 2")),
+                        "3": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 3")),
+                        "4": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 4"))
                     }
                 }
             }
@@ -324,16 +324,16 @@ async fn test_get_returns_all_authors_for_topic() {
             "blips": {
                 "test-topic": {
                     "author-a": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"author A - Message 0"),
-                        "1": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"author A - Message 1"),
-                        "2": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"author A - Message 2")
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"author A - Message 0")),
+                        "1": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"author A - Message 1")),
+                        "2": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"author A - Message 2"))
                     },
                     "author-b": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"author B - Message 0"),
-                        "1": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"author B - Message 1")
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"author B - Message 0")),
+                        "1": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"author B - Message 1"))
                     },
                     "author-c": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"author C - Message 0")
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"author C - Message 0"))
                     }
                 }
             }
@@ -405,9 +405,9 @@ async fn test_missing_blips_server_behind() {
             "blips": {
                 "test-topic": {
                     "author-x": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 0"),
-                        "1": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 1"),
-                        "2": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 2")
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 0")),
+                        "1": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 1")),
+                        "2": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 2"))
                     }
                 }
             }
@@ -490,8 +490,8 @@ async fn test_missing_blips_multiple_authors() {
             "blips": {
                 "test-topic": {
                     "author-a": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"author A - 0"),
-                        "1": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"author A - 1")
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"author A - 0")),
+                        "1": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"author A - 1"))
                     }
                 }
             }
@@ -540,12 +540,12 @@ async fn test_no_missing_when_server_is_ahead() {
             "blips": {
                 "test-topic": {
                     "author-x": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 0"),
-                        "1": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 1"),
-                        "2": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 2"),
-                        "3": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 3"),
-                        "4": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 4"),
-                        "5": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 5")
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 0")),
+                        "1": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 1")),
+                        "2": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 2")),
+                        "3": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 3")),
+                        "4": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 4")),
+                        "5": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 5"))
                     }
                 }
             }

--- a/crates/mailbox-server/tests/push_integration.rs
+++ b/crates/mailbox-server/tests/push_integration.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use axum::http::StatusCode;
 use axum_test::{TestServer, TestServerConfig, Transport};
-use mailbox_server::test_utils::create_test_db;
+use mailbox_server::test_utils::{create_test_db, stored_blip};
 use push_notifications_client::client::PushNotificationsClient;
 use push_notifications_client::requests::{AddTopicSubscriptionsRequest, RegisterFcmTokenRequest};
 use push_notifications_client::types::{FcmToken, TopicId, VerifyingKey};
@@ -135,7 +135,7 @@ async fn mailbox_store_triggers_push_notification() {
             "blips": {
                 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
                     "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {
-                        "0": blip_data
+                        "0": stored_blip(&blip_data)
                     }
                 }
             }
@@ -167,7 +167,7 @@ async fn mailbox_store_no_subscribers_no_push() {
             "blips": {
                 "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd": {
                     "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {
-                        "0": blip_data
+                        "0": stored_blip(&blip_data)
                     }
                 }
             }
@@ -233,7 +233,7 @@ async fn mailbox_store_duplicate_blip_no_second_push() {
         "blips": {
             "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc": {
                 "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {
-                    "0": blip_data
+                    "0": stored_blip(&blip_data)
                 }
             }
         }

--- a/crates/mailbox-server/tests/scrub.rs
+++ b/crates/mailbox-server/tests/scrub.rs
@@ -1,0 +1,350 @@
+//! Scrubbing: replacing a stored blip with its payload-free form, and dropping
+//! the media blobs a deleted message referenced.
+
+use base64::Engine as _;
+use mailbox_server::{
+    test_utils::{committed_blip, create_test_server, stored_blip},
+    GetBlipsResponse, ScrubBlipsResponse, ScrubBlobsResponse,
+};
+use serde_json::json;
+
+const TOPIC: &str = "scrub-topic";
+const AUTHOR: &str = "author-a";
+
+fn b64(data: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(data)
+}
+
+/// A blip and the payload-free form its publisher commits to.
+fn message() -> (Vec<u8>, Vec<u8>) {
+    (b"header+payload".to_vec(), b"header".to_vec())
+}
+
+fn store_request(blip: serde_json::Value) -> serde_json::Value {
+    json!({ "blips": { TOPIC: { AUTHOR: { "0": blip } } } })
+}
+
+fn scrub_request(scrubbed: &[u8]) -> serde_json::Value {
+    json!({ "blips": { TOPIC: { AUTHOR: { "0": b64(scrubbed) } } } })
+}
+
+async fn stored_bytes(server: &axum_test::TestServer) -> Option<Vec<u8>> {
+    let response = server
+        .post("/blips/get")
+        .json(&json!({ "topics": { TOPIC: {} } }))
+        .await;
+    response.assert_status_ok();
+    let body: GetBlipsResponse = response.json();
+    Some(
+        body.blips_by_topic
+            .get(TOPIC)?
+            .blips
+            .get(AUTHOR)?
+            .get(&0)?
+            .as_ref()
+            .to_vec(),
+    )
+}
+
+#[tokio::test]
+async fn scrub_replaces_the_stored_blip_with_its_committed_form() {
+    let (server, _temp) = create_test_server().await;
+    let (full, scrubbed) = message();
+
+    server
+        .post("/blips/store")
+        .json(&store_request(committed_blip(&b64(&full), &scrubbed)))
+        .await
+        .assert_status(axum::http::StatusCode::CREATED);
+    assert_eq!(stored_bytes(&server).await.unwrap(), full);
+
+    let response = server.post("/blips/scrub").json(&scrub_request(&scrubbed)).await;
+    response.assert_status_ok();
+    let body: ScrubBlipsResponse = response.json();
+    assert_eq!(body.scrubbed.len(), 1);
+    assert!(body.rejected.is_empty());
+
+    assert_eq!(stored_bytes(&server).await.unwrap(), scrubbed);
+}
+
+/// The commitment is the entire validation: bytes that don't match it are
+/// refused, so a stored blip can never be replaced with arbitrary content.
+#[tokio::test]
+async fn scrub_with_bytes_that_miss_the_commitment_is_rejected() {
+    let (server, _temp) = create_test_server().await;
+    let (full, scrubbed) = message();
+
+    server
+        .post("/blips/store")
+        .json(&store_request(committed_blip(&b64(&full), &scrubbed)))
+        .await
+        .assert_status(axum::http::StatusCode::CREATED);
+
+    let response = server
+        .post("/blips/scrub")
+        .json(&scrub_request(b"forged replacement"))
+        .await;
+    response.assert_status_ok();
+    let body: ScrubBlipsResponse = response.json();
+    assert!(body.scrubbed.is_empty());
+    assert_eq!(body.rejected.len(), 1);
+
+    assert_eq!(stored_bytes(&server).await.unwrap(), full);
+}
+
+/// A blip stored without a commitment has authorized no replacement at all.
+#[tokio::test]
+async fn scrub_of_an_uncommitted_blip_is_rejected() {
+    let (server, _temp) = create_test_server().await;
+    let (full, scrubbed) = message();
+
+    server
+        .post("/blips/store")
+        .json(&store_request(stored_blip(&b64(&full))))
+        .await
+        .assert_status(axum::http::StatusCode::CREATED);
+
+    let response = server.post("/blips/scrub").json(&scrub_request(&scrubbed)).await;
+    response.assert_status_ok();
+    let body: ScrubBlipsResponse = response.json();
+    assert!(body.scrubbed.is_empty());
+    assert_eq!(body.rejected.len(), 1);
+
+    assert_eq!(stored_bytes(&server).await.unwrap(), full);
+}
+
+/// Every node that processes a delete scrubs every mailbox it knows, so the
+/// same scrub arrives repeatedly and must stay a no-op after the first.
+#[tokio::test]
+async fn scrubbing_twice_is_idempotent() {
+    let (server, _temp) = create_test_server().await;
+    let (full, scrubbed) = message();
+
+    server
+        .post("/blips/store")
+        .json(&store_request(committed_blip(&b64(&full), &scrubbed)))
+        .await
+        .assert_status(axum::http::StatusCode::CREATED);
+
+    for _ in 0..2 {
+        let response = server.post("/blips/scrub").json(&scrub_request(&scrubbed)).await;
+        response.assert_status_ok();
+        let body: ScrubBlipsResponse = response.json();
+        assert_eq!(body.scrubbed.len(), 1);
+    }
+    assert_eq!(stored_bytes(&server).await.unwrap(), scrubbed);
+}
+
+/// A node that has not yet processed the delete must not be able to put the
+/// payload back by re-publishing the operation.
+#[tokio::test]
+async fn a_scrubbed_blip_cannot_be_resurrected_by_storing_it_again() {
+    let (server, _temp) = create_test_server().await;
+    let (full, scrubbed) = message();
+
+    server
+        .post("/blips/store")
+        .json(&store_request(committed_blip(&b64(&full), &scrubbed)))
+        .await
+        .assert_status(axum::http::StatusCode::CREATED);
+    server
+        .post("/blips/scrub")
+        .json(&scrub_request(&scrubbed))
+        .await
+        .assert_status_ok();
+
+    server
+        .post("/blips/store")
+        .json(&store_request(committed_blip(&b64(&full), &scrubbed)))
+        .await
+        .assert_status(axum::http::StatusCode::CREATED);
+
+    assert_eq!(stored_bytes(&server).await.unwrap(), scrubbed);
+}
+
+/// Scrubbing replaces the value in place rather than removing the row, so the
+/// log stays dense and the mailbox does not start asking for the operation
+/// again.
+#[tokio::test]
+async fn scrubbing_leaves_the_watermark_alone() {
+    let (server, _temp) = create_test_server().await;
+    let (full, scrubbed) = message();
+
+    server
+        .post("/blips/store")
+        .json(&store_request(committed_blip(&b64(&full), &scrubbed)))
+        .await
+        .assert_status(axum::http::StatusCode::CREATED);
+    server
+        .post("/blips/scrub")
+        .json(&scrub_request(&scrubbed))
+        .await
+        .assert_status_ok();
+
+    let response = server
+        .post("/blips/get")
+        .json(&json!({ "topics": { TOPIC: { AUTHOR: 0 } } }))
+        .await;
+    response.assert_status_ok();
+    let body: GetBlipsResponse = response.json();
+    assert!(
+        body.blips_by_topic[TOPIC].missing.is_empty(),
+        "the mailbox should still consider the scrubbed operation present"
+    );
+}
+
+/// Blob hashes are blake3 over plaintext media, so two messages carrying the
+/// same photo announce the same hash. Deleting one must leave the other's copy
+/// alone.
+#[tokio::test]
+async fn scrubbing_one_reference_leaves_the_blob_for_other_referrers() {
+    let (server, _temp) = create_test_server().await;
+    let data = bytes::Bytes::from_static(b"shared media");
+    let hash = iroh_blobs::Hash::new(&data);
+    let sender = iroh::SecretKey::from_bytes(&[7; 32]).public();
+
+    for op_ref in ["op-1", "op-2"] {
+        server
+            .post("/blobs/register-hashes")
+            .json(&json!({
+                "blob_hashes": [hash],
+                "sender_pubkey": sender,
+                "op_ref": op_ref,
+            }))
+            .await
+            .assert_status_ok();
+    }
+    server
+        .post("/blobs/upload")
+        .bytes(data.clone())
+        .await
+        .assert_status_ok();
+
+    // Deleting the first message drops only its reference.
+    let response = server
+        .post("/blobs/scrub")
+        .json(&json!({ "refs": [{ "blob_hash": hash, "op_ref": "op-1" }] }))
+        .await;
+    response.assert_status_ok();
+    let body: ScrubBlobsResponse = response.json();
+    assert!(
+        body.removed.is_empty(),
+        "a blob still referenced elsewhere must be kept"
+    );
+
+    // Deleting the second drops the bytes.
+    let response = server
+        .post("/blobs/scrub")
+        .json(&json!({ "refs": [{ "blob_hash": hash, "op_ref": "op-2" }] }))
+        .await;
+    response.assert_status_ok();
+    let body: ScrubBlobsResponse = response.json();
+    assert_eq!(body.removed, vec![hash]);
+}
+
+/// A tombstoned reference stays tombstoned, so a node racing the delete cannot
+/// re-announce or re-upload the media back into the mailbox.
+#[tokio::test]
+async fn a_scrubbed_blob_reference_is_never_accepted_again() {
+    let (server, _temp) = create_test_server().await;
+    let data = bytes::Bytes::from_static(b"deleted media");
+    let hash = iroh_blobs::Hash::new(&data);
+    let sender = iroh::SecretKey::from_bytes(&[7; 32]).public();
+    let announce = json!({
+        "blob_hashes": [hash],
+        "sender_pubkey": sender,
+        "op_ref": "op-1",
+    });
+
+    server
+        .post("/blobs/register-hashes")
+        .json(&announce)
+        .await
+        .assert_status_ok();
+    server
+        .post("/blobs/upload")
+        .bytes(data.clone())
+        .await
+        .assert_status_ok();
+    server
+        .post("/blobs/scrub")
+        .json(&json!({ "refs": [{ "blob_hash": hash, "op_ref": "op-1" }] }))
+        .await
+        .assert_status_ok();
+
+    // Re-announcing the same reference is ignored: the mailbox neither reports
+    // it stored nor queues a fetch for it.
+    let response = server
+        .post("/blobs/register-hashes")
+        .json(&announce)
+        .await;
+    response.assert_status_ok();
+    let body: mailbox_server::RegisterHashesResponse = response.json();
+    assert!(
+        body.already_stored.is_empty(),
+        "a scrubbed reference must not be revived by a re-announce"
+    );
+
+    // And a re-upload of the bytes is refused.
+    server
+        .post("/blobs/upload")
+        .bytes(data)
+        .await
+        .assert_status_ok();
+    let response = server
+        .post("/blobs/register-hashes")
+        .json(&announce)
+        .await;
+    response.assert_status_ok();
+    let body: mailbox_server::RegisterHashesResponse = response.json();
+    assert!(
+        body.already_stored.is_empty(),
+        "a re-uploaded scrubbed blob must not be stored"
+    );
+}
+
+/// A different message carrying the same bytes is a distinct reference, so it
+/// stores normally even after the first was scrubbed. This is why blob
+/// tombstones are keyed on the reference rather than the bare hash.
+#[tokio::test]
+async fn the_same_media_can_be_sent_again_in_a_new_message() {
+    let (server, _temp) = create_test_server().await;
+    let data = bytes::Bytes::from_static(b"re-sent media");
+    let hash = iroh_blobs::Hash::new(&data);
+    let sender = iroh::SecretKey::from_bytes(&[7; 32]).public();
+
+    server
+        .post("/blobs/register-hashes")
+        .json(&json!({ "blob_hashes": [hash], "sender_pubkey": sender, "op_ref": "op-1" }))
+        .await
+        .assert_status_ok();
+    server
+        .post("/blobs/scrub")
+        .json(&json!({ "refs": [{ "blob_hash": hash, "op_ref": "op-1" }] }))
+        .await
+        .assert_status_ok();
+
+    // A new message referencing the same bytes.
+    server
+        .post("/blobs/register-hashes")
+        .json(&json!({ "blob_hashes": [hash], "sender_pubkey": sender, "op_ref": "op-2" }))
+        .await
+        .assert_status_ok();
+    server
+        .post("/blobs/upload")
+        .bytes(data)
+        .await
+        .assert_status_ok();
+
+    let response = server
+        .post("/blobs/register-hashes")
+        .json(&json!({ "blob_hashes": [hash], "sender_pubkey": sender, "op_ref": "op-2" }))
+        .await;
+    response.assert_status_ok();
+    let body: mailbox_server::RegisterHashesResponse = response.json();
+    assert_eq!(
+        body.already_stored,
+        vec![hash],
+        "media re-sent under a new operation must be stored"
+    );
+}

--- a/crates/mailbox-server/tests/scrub.rs
+++ b/crates/mailbox-server/tests/scrub.rs
@@ -58,7 +58,10 @@ async fn scrub_replaces_the_stored_blip_with_its_committed_form() {
         .assert_status(axum::http::StatusCode::CREATED);
     assert_eq!(stored_bytes(&server).await.unwrap(), full);
 
-    let response = server.post("/blips/scrub").json(&scrub_request(&scrubbed)).await;
+    let response = server
+        .post("/blips/scrub")
+        .json(&scrub_request(&scrubbed))
+        .await;
     response.assert_status_ok();
     let body: ScrubBlipsResponse = response.json();
     assert_eq!(body.scrubbed.len(), 1);
@@ -104,7 +107,10 @@ async fn scrub_of_an_uncommitted_blip_is_rejected() {
         .await
         .assert_status(axum::http::StatusCode::CREATED);
 
-    let response = server.post("/blips/scrub").json(&scrub_request(&scrubbed)).await;
+    let response = server
+        .post("/blips/scrub")
+        .json(&scrub_request(&scrubbed))
+        .await;
     response.assert_status_ok();
     let body: ScrubBlipsResponse = response.json();
     assert!(body.scrubbed.is_empty());
@@ -127,7 +133,10 @@ async fn scrubbing_twice_is_idempotent() {
         .assert_status(axum::http::StatusCode::CREATED);
 
     for _ in 0..2 {
-        let response = server.post("/blips/scrub").json(&scrub_request(&scrubbed)).await;
+        let response = server
+            .post("/blips/scrub")
+            .json(&scrub_request(&scrubbed))
+            .await;
         response.assert_status_ok();
         let body: ScrubBlipsResponse = response.json();
         assert_eq!(body.scrubbed.len(), 1);
@@ -274,10 +283,7 @@ async fn a_scrubbed_blob_reference_is_never_accepted_again() {
 
     // Re-announcing the same reference is ignored: the mailbox neither reports
     // it stored nor queues a fetch for it.
-    let response = server
-        .post("/blobs/register-hashes")
-        .json(&announce)
-        .await;
+    let response = server.post("/blobs/register-hashes").json(&announce).await;
     response.assert_status_ok();
     let body: mailbox_server::RegisterHashesResponse = response.json();
     assert!(
@@ -291,10 +297,7 @@ async fn a_scrubbed_blob_reference_is_never_accepted_again() {
         .bytes(data)
         .await
         .assert_status_ok();
-    let response = server
-        .post("/blobs/register-hashes")
-        .json(&announce)
-        .await;
+    let response = server.post("/blobs/register-hashes").json(&announce).await;
     response.assert_status_ok();
     let body: mailbox_server::RegisterHashesResponse = response.json();
     assert!(

--- a/crates/mailbox-server/tests/stress.rs
+++ b/crates/mailbox-server/tests/stress.rs
@@ -1,6 +1,6 @@
 use futures::future::join_all;
 use mailbox_server::{
-    test_utils::create_test_server, Author, GetBlipsResponse, SequenceNumber, TopicId,
+    test_utils::{create_test_server, stored_blip}, Author, GetBlipsResponse, SequenceNumber, TopicId,
 };
 use serde_json::json;
 use serial_test::serial;
@@ -21,7 +21,7 @@ fn create_store_request(
         "blips": {
             topic_id: {
                 "author-1": {
-                    seq_num.to_string(): message_b64
+                    seq_num.to_string(): stored_blip(&message_b64)
                 }
             }
         }

--- a/crates/mailbox-server/tests/stress.rs
+++ b/crates/mailbox-server/tests/stress.rs
@@ -1,6 +1,7 @@
 use futures::future::join_all;
 use mailbox_server::{
-    test_utils::{create_test_server, stored_blip}, Author, GetBlipsResponse, SequenceNumber, TopicId,
+    test_utils::{create_test_server, stored_blip},
+    Author, GetBlipsResponse, SequenceNumber, TopicId,
 };
 use serde_json::json;
 use serial_test::serial;

--- a/crates/mailbox-server/tests/watermark.rs
+++ b/crates/mailbox-server/tests/watermark.rs
@@ -1,4 +1,7 @@
-use mailbox_server::{test_utils::{create_test_server, stored_blip}, GetBlipsResponse};
+use mailbox_server::{
+    test_utils::{create_test_server, stored_blip},
+    GetBlipsResponse,
+};
 use serde_json::json;
 
 #[tokio::test]

--- a/crates/mailbox-server/tests/watermark.rs
+++ b/crates/mailbox-server/tests/watermark.rs
@@ -1,4 +1,4 @@
-use mailbox_server::{test_utils::create_test_server, GetBlipsResponse};
+use mailbox_server::{test_utils::{create_test_server, stored_blip}, GetBlipsResponse};
 use serde_json::json;
 
 #[tokio::test]
@@ -12,9 +12,9 @@ async fn test_watermark_contiguous_store() {
             "blips": {
                 "test-topic": {
                     "log-x": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 0"),
-                        "1": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 1"),
-                        "2": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 2")
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 0")),
+                        "1": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 1")),
+                        "2": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 2"))
                     }
                 }
             }
@@ -57,10 +57,10 @@ async fn test_watermark_with_gap_does_not_advance() {
             "blips": {
                 "test-topic": {
                     "log-x": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 0"),
-                        "1": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 1"),
-                        "3": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 3"),
-                        "4": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 4")
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 0")),
+                        "1": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 1")),
+                        "3": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 3")),
+                        "4": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 4"))
                     }
                 }
             }
@@ -103,10 +103,10 @@ async fn test_watermark_gap_fill_extends_watermark() {
             "blips": {
                 "test-topic": {
                     "log-x": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 0"),
-                        "1": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 1"),
-                        "3": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 3"),
-                        "4": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 4")
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 0")),
+                        "1": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 1")),
+                        "3": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 3")),
+                        "4": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 4"))
                     }
                 }
             }
@@ -121,7 +121,7 @@ async fn test_watermark_gap_fill_extends_watermark() {
             "blips": {
                 "test-topic": {
                     "log-x": {
-                        "2": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 2")
+                        "2": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 2"))
                     }
                 }
             }
@@ -164,9 +164,9 @@ async fn test_watermark_no_seq_zero() {
             "blips": {
                 "test-topic": {
                     "log-x": {
-                        "1": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 1"),
-                        "2": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 2"),
-                        "3": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 3")
+                        "1": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 1")),
+                        "2": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 2")),
+                        "3": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Message 3"))
                     }
                 }
             }
@@ -211,14 +211,14 @@ async fn test_watermark_independent_per_log() {
             "blips": {
                 "test-topic": {
                     "log-a": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Log A - 0"),
-                        "1": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Log A - 1"),
-                        "2": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Log A - 2")
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Log A - 0")),
+                        "1": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Log A - 1")),
+                        "2": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Log A - 2"))
                     },
                     "log-b": {
-                        "0": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Log B - 0"),
-                        "1": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Log B - 1"),
-                        "5": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Log B - 5")
+                        "0": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Log B - 0")),
+                        "1": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Log B - 1")),
+                        "5": stored_blip(&base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"Log B - 5"))
                     }
                 }
             }

--- a/docs/mailbox-scrubbing.md
+++ b/docs/mailbox-scrubbing.md
@@ -1,0 +1,220 @@
+# Mailbox scrubbing
+
+Follow-up to delete-for-everyone. When a message is deleted for everyone, every
+node that processes the delete drops the payload locally and never transmits it
+again. The mailboxes, however, keep serving the original operation — body and
+all — until the retention window expires (90 days for blips, 7 days for blobs).
+A recipient that syncs from a mailbox before it has processed the delete still
+receives the payload, and a late joiner receives it indefinitely.
+
+Scrubbing closes that gap: as soon as a delete is processed, the mailbox copy of
+each deleted operation is replaced with the same operation minus its payload,
+and the associated media blobs are dropped from blob storage.
+
+## Current state
+
+- A **blip** is `cbor(MailboxOperation { topic, header, body })` — see
+  `crates/dashchat-node/src/mailbox.rs`. The mailbox treats it as opaque bytes.
+- Blips live in `BLIPS_TABLE`, keyed by `BlipsKey { topic_id, author,
+  sequence_number, uuid }`. `author` is the p2panda device public key.
+- Media blobs are stored separately, announced by hash via
+  `/blobs/register-hashes` and either uploaded inline or fetched by the mailbox.
+  **The mailbox has no association between a blob and the blip that references
+  it** — the blip body is encrypted, so it cannot learn one.
+- Node-side, `enforce_tombstone` already drops the body of a tombstoned op, and
+  `OpStore`'s `MailboxStore::get_log` serves tombstoned ops body-less. So every
+  node that has seen a deleted op can already produce its payload-free form
+  byte-for-byte.
+- The mailbox is unauthenticated: `/blips/store`, `/blips/get`, `/blobs/*` are
+  callable by anyone. `StoreBlipsRequest` carries `sender_pubkey` and
+  `signature` fields that are currently ignored.
+
+`crates/dashchat-node/tests/delete_messages.rs` already contains the acceptance
+assertions behind a `mailbox_scrubbing_implemented()` stub returning `false`.
+
+## Validation model
+
+The mailbox cannot decode a blip, so it cannot decide for itself what a
+"payload-free version" of one looks like. Instead the publisher commits to it up
+front:
+
+> When storing a blip, the client also sends `scrub_hash` — the blake3 hash of
+> the *same operation with its body removed*. Later, anyone may present those
+> payload-free bytes to a scrub endpoint; the mailbox accepts the replacement
+> only if it hashes to the committed value.
+
+This gives one invariant, enforced without the mailbox understanding anything
+about the payload:
+
+**The only mutation a stored blip can undergo is the one its own publisher
+pre-authorized — replacement by its payload-free form.**
+
+An attacker cannot forge, alter, or substitute content. Scrubbing is idempotent
+(the scrubbed bytes still hash to the commitment) and order-independent, so any
+number of nodes can scrub the same blip concurrently.
+
+### What this does not defend against
+
+Constructing the payload-free bytes requires the operation's header, which
+anyone who can fetch the topic's blips already has. So **scrub authority is
+equivalent to read authority**: anyone who can read a topic from the mailbox can
+also censor it there. Likewise, `/blobs/scrub` can carry no validation at all —
+the mailbox has no idea which blip a blob belongs to — so **anyone who knows a
+blob hash can delete it from the mailbox**, which again is the same capability
+required to read it.
+
+The damage is bounded: payloads are E2E encrypted, recipients who already synced
+keep their copies, and the loss is availability for not-yet-synced recipients
+only. For an unauthenticated toy mailbox this is an acceptable trade; it should
+be revisited when the mailbox gains real authentication.
+
+**Optional strengthening** (see open questions): `BlipsKey.author` *is* the
+authoring device's public key, so the mailbox could additionally require an
+ed25519 signature over the scrubbed bytes verifiable under that key. That
+restricts scrubbing to the operation's author, at the cost of preventing
+recipients — and the author's other devices — from scrubbing on their behalf.
+
+## Design
+
+### 1. Commitment at store time
+
+`StoreBlipsRequest` gains a second map, mirroring the shape of `blips`:
+
+```rust
+pub struct StoreBlipsRequest {
+    pub blips: BTreeMap<TopicId, BTreeMap<Author, BTreeMap<SequenceNumber, Blip>>>,
+    #[serde(default)]
+    pub scrub_hashes: BTreeMap<TopicId, BTreeMap<Author, BTreeMap<SequenceNumber, ScrubHash>>>,
+    // ... existing sender_pubkey, signature
+}
+```
+
+A parallel optional map rather than changing the `Blip` value type, so the wire
+format stays compatible in *both* directions: an old client's request still
+deserializes on a new server, and a new client's request still deserializes on
+an old server (which ignores the commitment, leaving the blip unscrubbable
+rather than failing the store outright). Given that mailbox servers and clients
+update independently, a store request that hard-fails against a lagging server
+would stop message delivery entirely — not worth the tidier shape.
+
+`ScrubHash` is blake3 (`iroh_blobs::Hash`, already in both crates' dependency
+graphs).
+
+Commitments are stored in a new table, keyed by the same `BlipsKey` as the blip
+itself:
+
+```rust
+pub const SCRUB_TABLE: TableDefinition<BlipsKey, &[u8]> =
+    TableDefinition::new("scrub_commitments");
+```
+
+A separate table rather than widening `BLIPS_TABLE`'s value type, which would be
+a redb schema change requiring migration of existing databases. `cleanup.rs`
+deletes from both tables in the same pass.
+
+Blips stored without a commitment (old clients, or rows predating this change)
+are simply unscrubbable. Bounded by the retention window.
+
+### 2. `POST /blips/scrub`
+
+```jsonc
+// request
+{ "blips": { "<topic>": { "<author>": { "<seq>": "<base64 payload-free blip>" } } } }
+
+// response 200
+{ "scrubbed": [["<topic>", "<author>", 7]], "rejected": [["<topic>", "<author>", 9]] }
+```
+
+Per `(topic, author, seq)`:
+
+1. Range `BLIPS_TABLE` over the `TopicAuthorSeq` prefix (a seq can hold more
+   than one row — `store_blips` inserts a fresh UUID each time).
+2. For each row, read its `SCRUB_TABLE` commitment. No commitment → skip.
+3. `blake3(submitted_bytes) == commitment` → overwrite the row's value with the
+   submitted bytes. Otherwise → reject that entry.
+
+The key is left in place, so watermarks and the `missing` computation in
+`/blips/get` are untouched — this is why scrubbing replaces rather than deletes.
+No push notifications are emitted.
+
+### 3. Once scrubbed, always scrubbed
+
+`store_blips` must not let a node that has not yet processed the delete
+resurrect a payload. Before inserting at `(topic, author, seq)`, it checks
+whether an existing row there is already scrubbed and skips the insert if so.
+
+"Already scrubbed" is *derived*, not flagged: a row is scrubbed exactly when its
+stored bytes hash to its own commitment. No extra state to keep in sync, and an
+op that never had a body is trivially and harmlessly "already scrubbed".
+
+In practice this path is rarely hit — the mailbox reports the seq as present, so
+clients do not republish it — but it closes the race.
+
+### 4. `POST /blobs/scrub`
+
+```jsonc
+{ "blob_hashes": ["<hash>", "..."] }
+```
+
+Two endpoints rather than one: blips and blobs live in different storage
+subsystems (redb vs. the iroh blob store), have different request shapes, and
+have different validation stories. The node-side call site issues both together.
+
+Per hash: remove it from the `BlobFetchPool` (otherwise the mailbox re-fetches
+it from a peer that still holds it), and delete its `mailbox/<secs>/<hash>`
+retention tags so iroh's GC reclaims the bytes on its next sweep.
+
+### 5. Node-side triggering
+
+- `MailboxItem` gains `fn scrubbed(&self) -> Option<Self> { None }`;
+  `MailboxOperation` overrides it with `Self { topic, header, body: None }`. The
+  default keeps in-memory and test item types untouched.
+- `MailboxClient` gains `scrub_blips` / `scrub_blobs`, defaulting to `Ok(())` so
+  the in-memory client is unaffected. `ToyMailboxClient` implements both.
+- `Mailboxes` gains a `scrub` method fanning out to every tracked mailbox.
+- The trigger is `enforce_tombstone`: whenever it returns `true`, the node has
+  just dropped a body, so it holds exactly the op needed to scrub and (via
+  `unprocess_app`, which already extracts them) the media hashes to release.
+  Every node that processes the delete scrubs every mailbox it knows —
+  consistent with the existing "every node keeps every mailbox in sync"
+  philosophy, and idempotent, so redundancy is free.
+- Because the author's own delete flows through the same `enforce_tombstone`
+  path, author-side scrubbing needs no separate call site.
+
+**Retry story:** fire-and-forget, self-healing. If a scrub does not land, the
+mailbox keeps serving the body; the next node to sync it re-ingests the op,
+`enforce_tombstone` fires again, and the scrub is re-issued. No new persistence.
+Retention is the ultimate backstop.
+
+A node that only ever saw the delete, never the deleted op, cannot scrub — it
+has no header to submit. That is fine; nodes that did see it will.
+
+## Testing
+
+- **mailbox-server** (`tests/integration.rs`): store-with-commitment then scrub;
+  scrub with wrong bytes rejected; scrub of an uncommitted blip rejected; scrub
+  twice is idempotent; re-store after scrub does not resurrect the payload;
+  `/blips/get` returns the blip body-less afterwards; watermarks unchanged.
+- **blob**: after `/blobs/scrub` the mailbox no longer serves the blob and does
+  not re-fetch it.
+- **dashchat-node**: delete `mailbox_scrubbing_implemented()` and its
+  `#[deprecated]` marker in `tests/delete_messages.rs`, enabling the three
+  already-written blocks — including the late-joiner (carol) assertion that a
+  node syncing purely from the mailbox never receives a deleted payload.
+
+## Open questions
+
+1. **Author signature?** Require an ed25519 signature over the scrubbed bytes
+   under `BlipsKey.author`, or accept that read authority implies scrub
+   authority? Signing blocks third-party censorship but also blocks recipients
+   and the author's other devices from scrubbing.
+2. **Re-fetch suppression for blobs.** A node racing the delete can re-announce
+   a scrubbed blob's hash via `/blobs/register-hashes` and the mailbox will
+   fetch it again. Add a short-lived "recently scrubbed" set the announce path
+   consults, or rely on the next scrub to clean it up?
+3. **Wire compatibility.** Is the parallel `scrub_hashes` map the right call, or
+   is a cleaner value type worth a coordinated client/server rollout?
+4. **Determinism.** Publisher and scrubber must produce byte-identical CBOR for
+   the payload-free operation. Any change to `MailboxOperation`'s serde
+   representation silently makes in-flight blips unscrubbable (bounded by
+   retention). Worth a round-trip test pinning the encoding?

--- a/docs/mailbox-scrubbing.md
+++ b/docs/mailbox-scrubbing.md
@@ -150,19 +150,59 @@ op that never had a body is trivially and harmlessly "already scrubbed".
 In practice this path is rarely hit — the mailbox reports the seq as present, so
 clients do not republish it — but it closes the race.
 
-### 4. `POST /blobs/scrub`
-
-```jsonc
-{ "blob_hashes": ["<hash>", "..."] }
-```
+### 4. `POST /blobs/scrub`, and why blobs need reference counting
 
 Two endpoints rather than one: blips and blobs live in different storage
 subsystems (redb vs. the iroh blob store), have different request shapes, and
 have different validation stories. The node-side call site issues both together.
 
-Per hash: remove it from the `BlobFetchPool` (otherwise the mailbox re-fetches
-it from a peer that still holds it), and delete its `mailbox/<secs>/<hash>`
-retention tags so iroh's GC reclaims the bytes on its next sweep.
+The obvious shape — `{ "blob_hashes": [...] }`, drop each hash — is wrong, for a
+reason that also settles how permanent the tombstone can be.
+
+**Blips are addressed by log position; blobs are addressed by content.** A
+`(topic, author, seq)` coordinate is append-only and can never legitimately be
+reused, which is what makes the blip rule in §3 safe to enforce *forever*. A
+blob hash is blake3 of the plaintext media (`Node::send_message` hands
+`photo.data` straight to `store_blob`; nothing encrypts it), so identical bytes
+collide globally, across chats and users. Deleting or tombstoning a bare hash
+therefore:
+
+- **over-deletes** — a delete in chat A drops media still referenced by a live
+  message in chat B, and
+- **cannot be made permanent** — a permanent bare-hash tombstone would block a
+  legitimate re-send of the same photo, by anyone, anywhere on that mailbox,
+  forever. Anyone who learned a popular image's hash could poison it mailbox-wide.
+
+The fix is to make the reference, not the hash, the unit of deletion.
+`RegisterHashesRequest` carries the **referencing operation hash** alongside each
+blob hash, and the mailbox keeps a reference table:
+
+```rust
+pub const BLOB_REFS_TABLE: TableDefinition<BlobRefKey, u8> =
+    TableDefinition::new("blob_refs");   // key: (blob_hash, op_hash); value: live | tombstoned
+```
+
+- `/blobs/register-hashes` records a live `(blob, op)` ref — unless that exact
+  ref is already tombstoned, in which case it is ignored **permanently**. This is
+  the true tombstone you're after, and it is safe because the coordinate is
+  position-like again: a given operation references a given blob exactly once.
+- `/blobs/scrub` takes `(blob_hash, op_hash)` pairs and marks those refs
+  tombstoned. When a blob has no live refs left, the mailbox removes it from the
+  `BlobFetchPool` (otherwise it re-fetches from a peer that still holds it) and
+  deletes its `mailbox/<secs>/<hash>` retention tags so iroh's GC reclaims the
+  bytes. Refs are expired alongside blips in `cleanup.rs`.
+- A re-send of the same media in another message is a *different* ref, so it
+  stores and serves normally.
+
+This costs no new metadata. The blip's header is plaintext CBOR (only the body
+payload is encrypted) and the blip key already carries the topic, so a mailbox
+that wanted the blob↔operation association could already derive every operation
+hash from the headers it stores. Sending the op hash explicitly tells it nothing
+it could not compute.
+
+The node already has what it needs: `ToyMailboxClient::publish` currently
+flattens `op.blob_hashes()` across all ops, discarding the association; it just
+has to keep it.
 
 ### 5. Node-side triggering
 
@@ -208,10 +248,11 @@ has no header to submit. That is fine; nodes that did see it will.
    under `BlipsKey.author`, or accept that read authority implies scrub
    authority? Signing blocks third-party censorship but also blocks recipients
    and the author's other devices from scrubbing.
-2. **Re-fetch suppression for blobs.** A node racing the delete can re-announce
-   a scrubbed blob's hash via `/blobs/register-hashes` and the mailbox will
-   fetch it again. Add a short-lived "recently scrubbed" set the announce path
-   consults, or rely on the next scrub to clean it up?
+2. **Blob ref granularity.** §4 keys refs on `(blob_hash, op_hash)`. Is
+   per-operation the right unit, or should an edit chain share one ref? Per-op
+   is simpler and over-retains at worst (an edit that keeps the same media holds
+   a second live ref until it too is deleted — and a delete-for-everyone
+   tombstones the whole chain anyway, so both refs drop together).
 3. **Wire compatibility.** Is the parallel `scrub_hashes` map the right call, or
    is a cleaner value type worth a coordinated client/server rollout?
 4. **Determinism.** Publisher and scrubber must produce byte-identical CBOR for

--- a/docs/mailbox-scrubbing.md
+++ b/docs/mailbox-scrubbing.md
@@ -83,24 +83,19 @@ fire-and-forget retry story in §5 work.
 
 ### 1. Commitment at store time
 
-`StoreBlipsRequest` gains a second map, mirroring the shape of `blips`:
+`StoreBlipsRequest`'s blip value carries the commitment with it:
 
 ```rust
-pub struct StoreBlipsRequest {
-    pub blips: BTreeMap<TopicId, BTreeMap<Author, BTreeMap<SequenceNumber, Blip>>>,
-    #[serde(default)]
-    pub scrub_hashes: BTreeMap<TopicId, BTreeMap<Author, BTreeMap<SequenceNumber, ScrubHash>>>,
-    // ... existing sender_pubkey, signature
+pub struct StoredBlip {
+    pub blip: Blip,
+    pub scrub_hash: Option<ScrubHash>,
 }
 ```
 
-A parallel optional map rather than changing the `Blip` value type, so the wire
-format stays compatible in *both* directions: an old client's request still
-deserializes on a new server, and a new client's request still deserializes on
-an old server (which ignores the commitment, leaving the blip unscrubbable
-rather than failing the store outright). Given that mailbox servers and clients
-update independently, a store request that hard-fails against a lagging server
-would stop message delivery entirely — not worth the tidier shape.
+This is a breaking wire change — an old client's bare-base64 blip no longer
+deserializes — which is the right trade while we are not yet holding to
+backward compatibility. `None` is not a compatibility shim but a real case:
+item types with no payload to remove commit to nothing and are unscrubbable.
 
 `ScrubHash` is blake3 (`iroh_blobs::Hash`, already in both crates' dependency
 graphs).
@@ -204,9 +199,13 @@ this blob" a plain prefix range.
   iroh's GC reclaims the bytes.
 - A re-send of the same media in another message is a *different* ref, so it
   stores and serves normally.
-- A legacy announce carrying no op hash gets a ref under an all-zero op hash. It
-  behaves as a permanently live ref — such a blob is simply unscrubbable, matching
-  how uncommitted blips behave.
+- An announce with an **empty** op ref is a *re-announce*, not a new reference:
+  it records nothing and merely reports which blobs still have a live reference.
+  The node's unfetched-blob followup re-announces from a per-mailbox hash list
+  with no originating operation, and letting it mint a reference would leave
+  every re-announced blob holding an unattributable one that no scrub could ever
+  tombstone — quietly defeating blob scrubbing for exactly the blobs that needed
+  a retry.
 
 **Refs are never expired.** A permanent tombstone set is unbounded by
 definition, so there is nothing to garbage collect: dropping a tombstone would
@@ -229,9 +228,12 @@ has to keep it.
 - `MailboxItem` gains `fn scrubbed(&self) -> Option<Self> { None }`;
   `MailboxOperation` overrides it with `Self { topic, header, body: None }`. The
   default keeps in-memory and test item types untouched.
-- `MailboxClient` gains `scrub_blips` / `scrub_blobs`, defaulting to `Ok(())` so
-  the in-memory client is unaffected. `ToyMailboxClient` implements both.
-- `Mailboxes` gains a `scrub` method fanning out to every tracked mailbox.
+- `MailboxClient` gains a single `scrub(items)`, defaulting to `Ok(())`. The
+  items still carry their payloads; the client derives both the payload-free
+  replacement and the blob references from them. `ToyMailboxClient` posts to
+  both endpoints; `MemMailboxClient` implements it too, since the node's
+  delete tests run against the in-memory mailbox by default.
+- `Mailboxes` gains `scrub_all`, fanning out to every tracked mailbox.
 - The trigger is `enforce_tombstone`: whenever it returns `true`, the node has
   just dropped a body, so it holds exactly the op needed to scrub and (via
   `unprocess_app`, which already extracts them) the media hashes to release.
@@ -241,26 +243,34 @@ has to keep it.
 - Because the author's own delete flows through the same `enforce_tombstone`
   path, author-side scrubbing needs no separate call site.
 
-**Retry story:** fire-and-forget, self-healing. If a scrub does not land, the
-mailbox keeps serving the body; the next node to sync it re-ingests the op,
-`enforce_tombstone` fires again, and the scrub is re-issued. No new persistence.
-Retention is the ultimate backstop.
+**Retry story:** fire-and-forget, self-healing. The fan-out runs in a detached
+task so a slow or unreachable mailbox never stalls operation processing. If a
+scrub does not land, the mailbox keeps serving the body; the next node to sync
+it re-ingests the op, `enforce_tombstone` fires again, and the scrub is
+re-issued. No new persistence. Retention is the ultimate backstop.
 
 A node that only ever saw the delete, never the deleted op, cannot scrub — it
 has no header to submit. That is fine; nodes that did see it will.
 
 ## Testing
 
-- **mailbox-server** (`tests/integration.rs`): store-with-commitment then scrub;
-  scrub with wrong bytes rejected; scrub of an uncommitted blip rejected; scrub
-  twice is idempotent; re-store after scrub does not resurrect the payload;
-  `/blips/get` returns the blip body-less afterwards; watermarks unchanged.
-- **blob**: after `/blobs/scrub` the mailbox no longer serves the blob and does
-  not re-fetch it.
-- **dashchat-node**: delete `mailbox_scrubbing_implemented()` and its
-  `#[deprecated]` marker in `tests/delete_messages.rs`, enabling the three
-  already-written blocks — including the late-joiner (carol) assertion that a
-  node syncing purely from the mailbox never receives a deleted payload.
+- **mailbox-server** (`tests/scrub.rs`): store-with-commitment then scrub; scrub
+  with wrong bytes rejected; scrub of an uncommitted blip rejected; scrub twice
+  is idempotent; re-store after scrub does not resurrect the payload; watermarks
+  unchanged. For blobs: one reference scrubbed leaves the blob for its other
+  referrer, a tombstoned reference is never accepted again (announce or upload),
+  and the same media re-sent under a new operation still stores.
+- **Determinism** — the two halves of the commitment contract, since a mismatch
+  would silently reject every scrub:
+  - `mailbox-client`: the commitment computed at publish equals the hash of the
+    bytes `scrub` submits.
+  - `dashchat-node`: the payload-free encoding of a `MailboxOperation` is pinned
+    to a known hash, so serde drift fails loudly instead of quietly stranding
+    blips published by older clients.
+- **dashchat-node** (`tests/delete_messages.rs`): `mailbox_scrubbing_implemented()`
+  and its `#[deprecated]` marker are gone, enabling the three already-written
+  blocks — including the late-joiner (carol) assertion that a node syncing purely
+  from the mailbox never receives a deleted payload.
 
 ## Settled
 
@@ -269,12 +279,6 @@ has no header to submit. That is fine; nodes that did see it will.
   authorship over time, not take new dependencies on it.
 - **Blob refs are per `(blob_hash, op_hash)`**, tracked in the flattest table
   that works and never expired.
-
-## Open questions
-
-1. **Wire compatibility.** Is the parallel `scrub_hashes` map the right call, or
-   is a cleaner value type worth a coordinated client/server rollout?
-2. **Determinism.** Publisher and scrubber must produce byte-identical CBOR for
-   the payload-free operation. Any change to `MailboxOperation`'s serde
-   representation silently makes in-flight blips unscrubbable (bounded by
-   retention). Worth a round-trip test pinning the encoding?
+- **A clean value type over wire compatibility**, which we are not yet holding
+  to.
+- **The payload-free encoding is pinned by test**, on both sides.

--- a/docs/mailbox-scrubbing.md
+++ b/docs/mailbox-scrubbing.md
@@ -68,11 +68,16 @@ keep their copies, and the loss is availability for not-yet-synced recipients
 only. For an unauthenticated toy mailbox this is an acceptable trade; it should
 be revisited when the mailbox gains real authentication.
 
-**Optional strengthening** (see open questions): `BlipsKey.author` *is* the
-authoring device's public key, so the mailbox could additionally require an
-ed25519 signature over the scrubbed bytes verifiable under that key. That
-restricts scrubbing to the operation's author, at the cost of preventing
-recipients — and the author's other devices — from scrubbing on their behalf.
+**Rejected: author signatures.** `BlipsKey.author` *is* the authoring device's
+public key, so the mailbox could cheaply require an ed25519 signature over the
+scrubbed bytes verifiable under it, restricting scrubbing to the operation's
+author. We are not doing this. The direction of travel is for the mailbox to
+know *less* about authorship, not more — so new checks that take a dependency on
+it are moving the wrong way. Hash-only validation is indifferent to who the
+author is and stays correct if the author column later becomes opaque; a
+signature check would have to be torn out again. It also keeps scrubbing open to
+recipients and to the author's other devices, which is what makes the
+fire-and-forget retry story in §5 work.
 
 ## Design
 
@@ -178,21 +183,36 @@ The fix is to make the reference, not the hash, the unit of deletion.
 blob hash, and the mailbox keeps a reference table:
 
 ```rust
-pub const BLOB_REFS_TABLE: TableDefinition<BlobRefKey, u8> =
-    TableDefinition::new("blob_refs");   // key: (blob_hash, op_hash); value: live | tombstoned
+// key: blob_hash (32B) ++ op_hash (32B)   value: 0 = live, 1 = tombstoned
+pub const BLOB_REFS_TABLE: TableDefinition<&[u8], u8> =
+    TableDefinition::new("blob_refs");
 ```
+
+Deliberately the dumbest thing that works: a flat concatenated byte key using
+redb's built-in `&[u8]` and `u8` impls, so there is no custom `Key`/`Value` impl
+to write (contrast `BlipsKey`). Putting the blob hash first makes "all refs for
+this blob" a plain prefix range.
 
 - `/blobs/register-hashes` records a live `(blob, op)` ref — unless that exact
   ref is already tombstoned, in which case it is ignored **permanently**. This is
   the true tombstone you're after, and it is safe because the coordinate is
   position-like again: a given operation references a given blob exactly once.
 - `/blobs/scrub` takes `(blob_hash, op_hash)` pairs and marks those refs
-  tombstoned. When a blob has no live refs left, the mailbox removes it from the
-  `BlobFetchPool` (otherwise it re-fetches from a peer that still holds it) and
-  deletes its `mailbox/<secs>/<hash>` retention tags so iroh's GC reclaims the
-  bytes. Refs are expired alongside blips in `cleanup.rs`.
+  tombstoned. If a prefix scan then finds no live refs for that blob, the mailbox
+  removes it from the `BlobFetchPool` (otherwise it re-fetches from a peer that
+  still holds it) and deletes its `mailbox/<secs>/<hash>` retention tags so
+  iroh's GC reclaims the bytes.
 - A re-send of the same media in another message is a *different* ref, so it
   stores and serves normally.
+- A legacy announce carrying no op hash gets a ref under an all-zero op hash. It
+  behaves as a permanently live ref — such a blob is simply unscrubbable, matching
+  how uncommitted blips behave.
+
+**Refs are never expired.** A permanent tombstone set is unbounded by
+definition, so there is nothing to garbage collect: dropping a tombstone would
+re-open the hole it exists to close. Growth is ~65 bytes per (blob, message)
+pair, forever, which is the honest price of the guarantee. If that ever matters,
+the lever is capping the table, not aging it.
 
 This costs no new metadata. The blip's header is plaintext CBOR (only the body
 payload is encrypted) and the blip key already carries the topic, so a mailbox
@@ -242,20 +262,19 @@ has no header to submit. That is fine; nodes that did see it will.
   already-written blocks — including the late-joiner (carol) assertion that a
   node syncing purely from the mailbox never receives a deleted payload.
 
+## Settled
+
+- **No author signatures.** Hash-only validation, for the reasons in
+  "What this does not defend against" — the mailbox should learn less about
+  authorship over time, not take new dependencies on it.
+- **Blob refs are per `(blob_hash, op_hash)`**, tracked in the flattest table
+  that works and never expired.
+
 ## Open questions
 
-1. **Author signature?** Require an ed25519 signature over the scrubbed bytes
-   under `BlipsKey.author`, or accept that read authority implies scrub
-   authority? Signing blocks third-party censorship but also blocks recipients
-   and the author's other devices from scrubbing.
-2. **Blob ref granularity.** §4 keys refs on `(blob_hash, op_hash)`. Is
-   per-operation the right unit, or should an edit chain share one ref? Per-op
-   is simpler and over-retains at worst (an edit that keeps the same media holds
-   a second live ref until it too is deleted — and a delete-for-everyone
-   tombstones the whole chain anyway, so both refs drop together).
-3. **Wire compatibility.** Is the parallel `scrub_hashes` map the right call, or
+1. **Wire compatibility.** Is the parallel `scrub_hashes` map the right call, or
    is a cleaner value type worth a coordinated client/server rollout?
-4. **Determinism.** Publisher and scrubber must produce byte-identical CBOR for
+2. **Determinism.** Publisher and scrubber must produce byte-identical CBOR for
    the payload-free operation. Any change to `MailboxOperation`'s serde
    representation silently makes in-flight blips unscrubbable (bounded by
    retention). Worth a round-trip test pinning the encoding?


### PR DESCRIPTION
Design for the delete-for-everyone follow-up: publishing payload-free replacements of deleted operations to all mailboxes and dropping their media blobs.

Validation rests on a commitment supplied at store time — the blake3 hash of the operation with its body removed — so the only mutation a stored blip can undergo is the one its publisher pre-authorized.
