### PR TITLE
Refactor: Remove ShareIntent from qr code

### DIFF
--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -3,7 +3,6 @@ use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use chrono::{DateTime, Utc};
 use p2panda_core::cbor::{decode_cbor, encode_cbor};
 use serde::{Deserialize, Serialize};
-use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::str::FromStr;
 
 use crate::{DeviceId, Topic, topic::kind};
@@ -48,13 +47,6 @@ pub struct AddDeviceQrCode {
     pub device_pubkey: DeviceId,
     /// 8-byte nonce used with `derive_inbox_topic` to reconstruct the inbox topic.
     pub inbox_nonce: InboxNonce,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize_repr, Deserialize_repr)]
-#[repr(u8)]
-pub enum ShareIntent {
-    AddDevice = 0,
-    AddContact = 1,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -40,15 +40,6 @@ pub struct AddContactQrCode {
     pub inbox_nonce: InboxNonce,
 }
 
-/// The content for a QR code or deep link for adding a device.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct AddDeviceQrCode {
-    /// Pubkey of this node: allows adding this node to groups.
-    pub device_pubkey: DeviceId,
-    /// 8-byte nonce used with `derive_inbox_topic` to reconstruct the inbox topic.
-    pub inbox_nonce: InboxNonce,
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct InboxTopic {
     // NOTE: order of these fields matters! expires_at, then topic.

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -32,13 +32,20 @@ pub fn derive_inbox_topic(device_pubkey: &DeviceId, nonce: &[u8; 8]) -> [u8; 32]
     *hasher.finalize().as_bytes()
 }
 
-/// The content for a QR code or deep link.
+/// The content for a QR code or deep link for adding a contact.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct QrCode {
+pub struct AddContactQrCode {
     /// Pubkey of this node: allows adding this node to groups.
     pub device_pubkey: DeviceId,
-    /// The intent of the QR code: whether to add this node as a contact or a device.
-    pub share_intent: ShareIntent,
+    /// 8-byte nonce used with `derive_inbox_topic` to reconstruct the inbox topic.
+    pub inbox_nonce: InboxNonce,
+}
+
+/// The content for a QR code or deep link for adding a device.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AddDeviceQrCode {
+    /// Pubkey of this node: allows adding this node to groups.
+    pub device_pubkey: DeviceId,
     /// 8-byte nonce used with `derive_inbox_topic` to reconstruct the inbox topic.
     pub inbox_nonce: InboxNonce,
 }
@@ -102,50 +109,45 @@ mod expires_at_minutes {
     }
 }
 
-impl std::fmt::Display for QrCode {
+impl std::fmt::Display for AddContactQrCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let bytes = encode_cbor(&(
             serde_bytes::Bytes::new(self.device_pubkey.as_bytes()),
             serde_bytes::Bytes::new(&self.inbox_nonce.as_bytes()),
-            &self.share_intent,
         ))
         .map_err(|_| std::fmt::Error)?;
         write!(f, "{}", QR_CODE_ENCODING_ENGINE.encode(bytes))
     }
 }
 
-impl FromStr for QrCode {
+impl FromStr for AddContactQrCode {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use p2panda::VerifyingKey;
         let bytes = QR_CODE_ENCODING_ENGINE.decode(s)?;
-        let (device_pubkey_bytes, inbox_nonce_bytes, share_intent): (
-            serde_bytes::ByteBuf,
-            serde_bytes::ByteBuf,
-            ShareIntent,
-        ) = decode_cbor(bytes.as_slice())?;
+        let (device_pubkey_bytes, inbox_nonce_bytes): (serde_bytes::ByteBuf, serde_bytes::ByteBuf) =
+            decode_cbor(bytes.as_slice())?;
         let device_pubkey = DeviceId::from(VerifyingKey::from_bytes(
             device_pubkey_bytes.as_ref().try_into()?,
         )?);
         let inbox_nonce: [u8; 8] = inbox_nonce_bytes.as_ref().try_into()?;
-        Ok(QrCode {
+        Ok(AddContactQrCode {
             device_pubkey,
-            share_intent,
             inbox_nonce: InboxNonce(inbox_nonce),
         })
     }
 }
 
-impl From<QrCode> for String {
-    fn from(code: QrCode) -> Self {
+impl From<AddContactQrCode> for String {
+    fn from(code: AddContactQrCode) -> Self {
         code.to_string()
     }
 }
 
-impl TryFrom<String> for QrCode {
+impl TryFrom<String> for AddContactQrCode {
     type Error = anyhow::Error;
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        QrCode::from_str(&value)
+        AddContactQrCode::from_str(&value)
     }
 }
 
@@ -157,39 +159,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_contact_roundtrip_add_device() {
-        let pubkey = VerifyingKey::from_bytes(&[11; 32]).unwrap();
-        let device_pubkey = DeviceId::from(pubkey);
-        let nonce: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
-        let contact = QrCode {
-            device_pubkey,
-            share_intent: ShareIntent::AddDevice,
-            inbox_nonce: InboxNonce(nonce),
-        };
-        let encoded = contact.to_string();
-        let decoded = QrCode::from_str(&encoded).unwrap();
-        assert_eq!(contact, decoded);
-    }
-
-    #[test]
     fn test_contact_roundtrip_add_contact() {
         let pubkey = VerifyingKey::from_bytes(&[22; 32]).unwrap();
         let device_pubkey = DeviceId::from(pubkey);
         let nonce: [u8; 8] = [8, 7, 6, 5, 4, 3, 2, 1];
-        let contact = QrCode {
+        let contact = AddContactQrCode {
             device_pubkey,
-            share_intent: ShareIntent::AddContact,
             inbox_nonce: InboxNonce(nonce),
         };
         let encoded = contact.to_string();
-        let decoded = QrCode::from_str(&encoded).unwrap();
+        let decoded = AddContactQrCode::from_str(&encoded).unwrap();
         assert_eq!(contact, decoded);
     }
 
     #[test]
     fn test_from_str_rejects_garbage() {
-        assert!(QrCode::from_str("not-a-valid-code").is_err());
-        assert!(QrCode::from_str("").is_err());
-        assert!(QrCode::from_str("!!!").is_err());
+        assert!(AddContactQrCode::from_str("not-a-valid-code").is_err());
+        assert!(AddContactQrCode::from_str("").is_err());
+        assert!(AddContactQrCode::from_str("!!!").is_err());
     }
 }

--- a/crates/dashchat-node/src/lib.rs
+++ b/crates/dashchat-node/src/lib.rs
@@ -21,7 +21,7 @@ pub mod testing;
 pub use aliased::Aliasing;
 
 pub use chat::*;
-pub use contact::{AddContactQrCode, ShareIntent};
+pub use contact::AddContactQrCode;
 pub use error::{
     AddContactError, DeleteMessageError, EditMessageError, Error, RemoveGroupMemberError,
 };

--- a/crates/dashchat-node/src/lib.rs
+++ b/crates/dashchat-node/src/lib.rs
@@ -21,7 +21,7 @@ pub mod testing;
 pub use aliased::Aliasing;
 
 pub use chat::*;
-pub use contact::{QrCode, ShareIntent};
+pub use contact::{AddContactQrCode, ShareIntent};
 pub use error::{
     AddContactError, DeleteMessageError, EditMessageError, Error, RemoveGroupMemberError,
 };

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -2,6 +2,7 @@ pub(crate) mod actor;
 mod app_processing;
 pub(crate) mod publish;
 
+use core::panic;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -32,7 +33,7 @@ use crate::chat::{
     ChatMessageContent, ChatOp, ChatOpKind, EditCandidate, ValidChatOps,
     collect_deletable_edit_chain,
 };
-use crate::contact::{InboxTopic, QrCode, ShareIntent};
+use crate::contact::{AddContactQrCode, AddDeviceQrCode, InboxTopic};
 use crate::mailbox::MailboxOperation;
 use crate::payload::{AnnouncementsPayload, ChatPayload, InboxPayload, Payload, Profile};
 use crate::stores::{GroupStore, LocalStore, NodeKeys, OpProjection, OpStore};
@@ -448,7 +449,7 @@ impl Node {
 
     /// Create a new contact QR code with configured expiry time,
     /// subscribe to the inbox topic for it, and register the topic as active.
-    pub async fn new_qr_code(&self, share_intent: ShareIntent) -> Result<QrCode, crate::Error> {
+    pub async fn create_add_contact_qr_code(&self) -> Result<AddContactQrCode, crate::Error> {
         let (inbox_topic, nonce) = InboxTopic::new_random(
             &self.device_id(),
             Utc::now() + self.config.contact_code_expiry,
@@ -461,11 +462,14 @@ impl Node {
             .await
             .map_err(|err| crate::Error::AddActiveInbox(format!("{err}")))?;
 
-        Ok(QrCode {
+        Ok(AddContactQrCode {
             device_pubkey: self.device_id(),
-            share_intent,
             inbox_nonce: nonce,
         })
+    }
+
+    pub async fn create_add_device_qr_code(&self) -> Result<AddDeviceQrCode, crate::Error> {
+        panic!("AddDeviceQrCode is not yet implemented");
     }
 
     pub fn agent_id(&self) -> AgentId {
@@ -1370,7 +1374,7 @@ impl Node {
     /// - store them in the contacts map
     /// - send an invitation to them to do the same
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all, fields(me = ?self.device_id().aliased())))]
-    pub async fn add_contact(&self, contact: QrCode) -> Result<(), AddContactError> {
+    pub async fn add_contact(&self, contact: AddContactQrCode) -> Result<(), AddContactError> {
         tracing::debug!(
             device_pub_key = ?contact.device_pubkey.aliased(),
             "adding contact",

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -2,7 +2,6 @@ pub(crate) mod actor;
 mod app_processing;
 pub(crate) mod publish;
 
-use core::panic;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -33,7 +33,7 @@ use crate::chat::{
     ChatMessageContent, ChatOp, ChatOpKind, EditCandidate, ValidChatOps,
     collect_deletable_edit_chain,
 };
-use crate::contact::{AddContactQrCode, AddDeviceQrCode, InboxTopic};
+use crate::contact::{AddContactQrCode, InboxTopic};
 use crate::mailbox::MailboxOperation;
 use crate::payload::{AnnouncementsPayload, ChatPayload, InboxPayload, Payload, Profile};
 use crate::stores::{GroupStore, LocalStore, NodeKeys, OpProjection, OpStore};
@@ -466,10 +466,6 @@ impl Node {
             device_pubkey: self.device_id(),
             inbox_nonce: nonce,
         })
-    }
-
-    pub async fn create_add_device_qr_code(&self) -> Result<AddDeviceQrCode, crate::Error> {
-        panic!("AddDeviceQrCode is not yet implemented");
     }
 
     pub fn agent_id(&self) -> AgentId {

--- a/crates/dashchat-node/src/testing/behavior.rs
+++ b/crates/dashchat-node/src/testing/behavior.rs
@@ -22,11 +22,7 @@ impl Behavior {
     /// Simulate sending a contact a QR code and them using it to add me as a contact,
     /// and sending me an Inbox message with their contact info so I can add them too.
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all, fields(me = ?self.node.device_id().aliased())))]
-    pub async fn initiate_and_establish_contact(
-        &mut self,
-        other: &TestNode,
-        share_intent: ShareIntent,
-    ) -> anyhow::Result<()> {
+    pub async fn initiate_and_establish_contact(&mut self, other: &TestNode) -> anyhow::Result<()> {
         let qr = self.create_add_contact_qr_code().await?;
         other.add_contact(qr).await?;
         self.accept_next_contact().await?;

--- a/crates/dashchat-node/src/testing/behavior.rs
+++ b/crates/dashchat-node/src/testing/behavior.rs
@@ -27,7 +27,7 @@ impl Behavior {
         other: &TestNode,
         share_intent: ShareIntent,
     ) -> anyhow::Result<()> {
-        let qr = self.new_qr_code(share_intent).await?;
+        let qr = self.create_add_contact_qr_code().await?;
         other.add_contact(qr).await?;
         self.accept_next_contact().await?;
 

--- a/crates/dashchat-node/tests/blob_sync.rs
+++ b/crates/dashchat-node/tests/blob_sync.rs
@@ -23,7 +23,7 @@ async fn media_blob_syncs_between_nodes() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 
@@ -110,7 +110,7 @@ async fn blob_fetch_pool_hydrates_stored_media_on_restart() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 

--- a/crates/dashchat-node/tests/blocking.rs
+++ b/crates/dashchat-node/tests/blocking.rs
@@ -73,7 +73,7 @@ async fn test_block_and_unblock_contact() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 
@@ -235,12 +235,12 @@ async fn test_blocked_group_member_control_and_info_still_apply() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
     alice
         .behavior()
-        .initiate_and_establish_contact(&cammy, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&cammy)
         .await
         .unwrap();
 

--- a/crates/dashchat-node/tests/bootstrap.rs
+++ b/crates/dashchat-node/tests/bootstrap.rs
@@ -26,7 +26,7 @@ async fn test_mailbox_bootstrap() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 

--- a/crates/dashchat-node/tests/contacts.rs
+++ b/crates/dashchat-node/tests/contacts.rs
@@ -30,7 +30,7 @@ async fn test_reject_contact_request() {
     println!("bobbi: {}", bobbi.device_id());
 
     // Alice generates a QR code with inbox
-    let qr = alice.new_qr_code(ShareIntent::AddContact).await.unwrap();
+    let qr = alice.create_add_contact_qr_code().await.unwrap();
 
     // Bobbi scans the QR code and sends a contact request to Alice's inbox
     bobbi.add_contact(qr).await.unwrap();
@@ -88,8 +88,8 @@ async fn test_reject_multiple_contact_requests() {
     println!("### {:3.1?} alice creating QR codes", start.elapsed());
 
     // Alice generates QR codes for both Bobbi and Carol
-    let qr_for_bobbi = alice.new_qr_code(ShareIntent::AddContact).await.unwrap();
-    let qr_for_carol = alice.new_qr_code(ShareIntent::AddContact).await.unwrap();
+    let qr_for_bobbi = alice.create_add_contact_qr_code().await.unwrap();
+    let qr_for_carol = alice.create_add_contact_qr_code().await.unwrap();
 
     println!(
         "### {:3.1?} bobbi and carol scanning QR codes",
@@ -169,7 +169,7 @@ async fn test_inbox_two_way_flow() {
 
     // Alice generates a QR code with an inbox and Bobbi scans it, sending his
     // contact request to Alice's inbox.
-    let qr = alice.new_qr_code(ShareIntent::AddContact).await.unwrap();
+    let qr = alice.create_add_contact_qr_code().await.unwrap();
     bobbi.add_contact(qr).await.unwrap();
 
     // Alice waits for Bobbi's contact request and explicitly accepts it. Since
@@ -217,7 +217,7 @@ async fn test_cannot_add_self_as_contact() {
 
     let alice = TestNode::new(NodeConfig::testing(), "alice").await;
 
-    let qr = alice.new_qr_code(ShareIntent::AddContact).await.unwrap();
+    let qr = alice.create_add_contact_qr_code().await.unwrap();
     let result = alice.add_contact(qr).await;
 
     assert!(matches!(result, Err(AddContactError::CannotAddSelf)));

--- a/crates/dashchat-node/tests/delete_messages.rs
+++ b/crates/dashchat-node/tests/delete_messages.rs
@@ -109,7 +109,7 @@ async fn delete_tombstones_chain_and_hides_payloads_from_new_members() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 
@@ -268,7 +268,7 @@ async fn delete_tombstones_chain_and_hides_payloads_from_new_members() {
         .await;
     carol
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
     bobbi
@@ -373,7 +373,7 @@ async fn invalid_deletes_are_rejected() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
     let chat = alice.direct_chat_topic(bobbi.agent_id());
@@ -451,7 +451,7 @@ async fn mixed_hash_delete_cannot_censor_another_author() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
     let chat = alice.direct_chat_topic(bobbi.agent_id());
@@ -523,7 +523,7 @@ async fn delete_cannot_censor_unsynced_message_from_another_author() {
     for peer in [&bobbi, &mallory] {
         alice
             .behavior()
-            .initiate_and_establish_contact(peer, ShareIntent::AddContact)
+            .initiate_and_establish_contact(peer)
             .await
             .unwrap();
     }
@@ -650,7 +650,7 @@ async fn junk_hash_in_payload_cannot_disable_delete_chain_validation() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
     let chat = alice.direct_chat_topic(bobbi.agent_id());

--- a/crates/dashchat-node/tests/device_groups.rs
+++ b/crates/dashchat-node/tests/device_groups.rs
@@ -32,10 +32,10 @@ async fn device_group_solo() {
 
     println!("peers see each other");
 
-    alice
-        .add_contact(alicia.new_qr_code(ShareIntent::AddDevice).await.unwrap())
-        .await
-        .unwrap();
+    // alice
+    //     .add_device(alicia.create_add_device_qr_code().await.unwrap())
+    //     .await
+    //     .unwrap();
 
     todo!("accept");
 }

--- a/crates/dashchat-node/tests/edit_messages.rs
+++ b/crates/dashchat-node/tests/edit_messages.rs
@@ -24,7 +24,7 @@ async fn two_friends(mailbox: &MemMailbox<MailboxOperation>) -> (TestNode, TestN
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 

--- a/crates/dashchat-node/tests/group_chats.rs
+++ b/crates/dashchat-node/tests/group_chats.rs
@@ -100,7 +100,7 @@ async fn test_direct_chat() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 
@@ -158,7 +158,7 @@ async fn test_p2p_direct_chat() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 
@@ -196,12 +196,12 @@ async fn test_group_chat() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
     cammy
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 
@@ -348,7 +348,7 @@ async fn test_group_chat_registered_in_op_projection() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 
@@ -413,7 +413,7 @@ async fn test_admin_removes_themself_there_is_another_admin() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 
@@ -463,7 +463,7 @@ async fn test_admin_cant_remove_themself_when_they_are_the_only_admin() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 
@@ -494,7 +494,7 @@ async fn test_non_admin_removes_themself() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 
@@ -546,7 +546,7 @@ async fn test_admin_removes_non_admin() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 
@@ -598,12 +598,12 @@ async fn test_non_admin_cannot_remove_admin() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&andi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&andi)
         .await
         .unwrap();
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 

--- a/crates/dashchat-node/tests/inbox.rs
+++ b/crates/dashchat-node/tests/inbox.rs
@@ -32,7 +32,7 @@ async fn test_inbox_2() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 
@@ -61,7 +61,7 @@ async fn test_p2p_inbox_2() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 

--- a/crates/dashchat-node/tests/mailbox_blob_sync.rs
+++ b/crates/dashchat-node/tests/mailbox_blob_sync.rs
@@ -91,7 +91,7 @@ async fn media_blob_relays_through_mailbox_when_sender_offline() {
     // Establish contact while both are online (no media exchanged yet).
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 
@@ -296,7 +296,7 @@ async fn recovers_unfetched_blob_after_source_restart() {
     // Establish contact while both are online (no media yet), then bobbi leaves.
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
     let chat = alice.direct_chat_topic(bobbi.agent_id());

--- a/crates/dashchat-node/tests/mailboxes.rs
+++ b/crates/dashchat-node/tests/mailboxes.rs
@@ -25,7 +25,7 @@ async fn mailbox_late_join() {
     let alice = TestNode::new(config.clone(), "alice").await;
     let bobbi = TestNode::new(config.clone(), "bobbi").await;
 
-    let qr = alice.new_qr_code(ShareIntent::AddContact).await.unwrap();
+    let qr = alice.create_add_contact_qr_code().await.unwrap();
     bobbi.add_contact(qr).await.unwrap();
 
     alice.add_mailbox(&mailbox).await;
@@ -97,7 +97,7 @@ async fn test_mailbox_restart_relay() {
     let alice_agent_id = alice.agent_id();
     let bobbi_agent_id = bobbi.agent_id();
 
-    let qr = alice.new_qr_code(ShareIntent::AddContact).await.unwrap();
+    let qr = alice.create_add_contact_qr_code().await.unwrap();
     bobbi.add_contact(qr).await.unwrap();
 
     let dummy_key = || iroh::SecretKey::generate().public();

--- a/crates/dashchat-node/tests/mailboxes.rs
+++ b/crates/dashchat-node/tests/mailboxes.rs
@@ -40,7 +40,7 @@ async fn mailbox_late_join() {
     //
     // alice
     //     .behavior()
-    //     .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+    //     .initiate_and_establish_contact(&bobbi)
     //     .await
     //     .unwrap();
 
@@ -229,13 +229,13 @@ async fn test_multiple_mailboxes_group_pivot() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 
     carol
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 

--- a/crates/dashchat-node/tests/no_p2p.rs
+++ b/crates/dashchat-node/tests/no_p2p.rs
@@ -26,7 +26,7 @@ async fn no_p2p_cannot_sync_after_mailbox_removed() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 
@@ -132,7 +132,7 @@ async fn no_p2p_exchanges_media_through_mailbox_only() {
     // Establish contact while both are online (no media exchanged yet).
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 
@@ -285,7 +285,7 @@ async fn stale_mailbox_addr_is_refreshed_on_reregister() {
 
     alice
         .behavior()
-        .initiate_and_establish_contact(&bobbi, ShareIntent::AddContact)
+        .initiate_and_establish_contact(&bobbi)
         .await
         .unwrap();
 

--- a/crates/dashchat-node/tests/profiles.rs
+++ b/crates/dashchat-node/tests/profiles.rs
@@ -97,7 +97,7 @@ async fn test_profiles_sync_between_contacts() {
         .unwrap();
 
     alice
-        .add_contact(bobbi.new_qr_code(ShareIntent::AddContact).await.unwrap())
+        .add_contact(bobbi.create_add_contact_qr_code().await.unwrap())
         .await
         .unwrap();
 

--- a/packages/stores/src/contacts/errors.ts
+++ b/packages/stores/src/contacts/errors.ts
@@ -7,7 +7,6 @@ export type AddContactError =
 	| { kind: 'ProfileNotCreated'; message: null }
 	| { kind: 'CannotAddSelf'; message: null }
 	| { kind: 'InvalidContactCode'; message: string }
-	| { kind: 'AddDeviceNotSupported'; message: null }
 	| { kind: 'CreateQrCode'; message: string }
 	| { kind: 'CreateDirectChat'; message: string }
 	| { kind: 'StoreContact'; message: string }

--- a/src-tauri/src/commands/contacts.rs
+++ b/src-tauri/src/commands/contacts.rs
@@ -1,4 +1,4 @@
-use dashchat_node::{topic::kind::Inbox, AgentId, DeviceId, QrCode, ShareIntent, Topic};
+use dashchat_node::{topic::kind::Inbox, AddContactQrCode, AgentId, DeviceId, Topic};
 use std::{collections::BTreeSet, str::FromStr};
 use tauri::State;
 
@@ -8,7 +8,7 @@ use crate::error::Error;
 #[tauri::command]
 pub async fn create_contact_code(app_node: State<'_, AppNode>) -> Result<String, Error> {
     let node = app_node.get().await?;
-    Ok(node.new_qr_code(ShareIntent::AddContact).await?.to_string())
+    Ok(node.create_add_contact_qr_code().await?.to_string())
 }
 
 #[tauri::command]
@@ -40,11 +40,8 @@ pub async fn add_contact(
     contact_code: String,
     app_node: State<'_, AppNode>,
 ) -> Result<DeviceId, Error> {
-    let qr = QrCode::from_str(&contact_code)
+    let qr = AddContactQrCode::from_str(&contact_code)
         .map_err(|e| dashchat_node::AddContactError::InvalidContactCode(e.to_string()))?;
-    if qr.share_intent == ShareIntent::AddDevice {
-        return Err(Error::AddDeviceNotSupported);
-    }
     let device_pubkey = qr.device_pubkey;
     let node = app_node.get().await?;
     node.add_contact(qr).await?;

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -8,9 +8,6 @@ pub enum Error {
     #[error("NodeNotReady")]
     NodeNotReady,
 
-    #[error("Device linking is not yet supported")]
-    AddDeviceNotSupported,
-
     #[error(transparent)]
     #[serde(untagged)]
     Node(#[from] dashchat_node::Error),

--- a/ui/src/lib/deep-links/add-contact.ts
+++ b/ui/src/lib/deep-links/add-contact.ts
@@ -66,9 +66,6 @@ export async function addContactFromCode(
 			case 'InvalidContactCode':
 				showToast(m.errorAddContactInvalidLink(), 'error');
 				break;
-			case 'AddDeviceNotSupported':
-				showToast(m.errorAddContactDeviceLinkingNotSupported(), 'error');
-				break;
 			case 'InitializeTopic':
 			case 'AuthorOperation':
 			case 'CreateQrCode':


### PR DESCRIPTION
We were attempting to use the QrCode as a polymorphic struct to handle either "adding a contact" or "adding a device". In doing so, it contained a ShareEvent enum to differentiate. 

In preparation for adding the user name to the AddContact QRCode, it is increasingly clear that the two use cases need too have their own data. Additionally, now that we are using links, the link itself specifies what sort of code it is, so the difference isn't needed.

I started by splitting QrCode into AddContactQrCode and AddDeviceQrCode, but it quickly became clear that the AddDeviceQrCode is only used in one test that really just tests that it exists. While I'm aware that device groups are functionality that has a bit of a scaffold in place even though we don't have that feature yet, having a structure for a device QR code seems a bit much at this stage, as it's so easy to add later. If there's shared functionality that powers the two types of QR codes (when we have them) it'll be easier to factor out the duplication when we have two real use cases. So for now, AddDeviceQrCode has been removed.