### PR TITLE
Add profile name to qr code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2034,6 +2034,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/crates/dashchat-node/Cargo.toml
+++ b/crates/dashchat-node/Cargo.toml
@@ -39,6 +39,7 @@ blake3 = "1.8.2"
 chrono = { version = "0.4.42", features = ["serde"] }
 hex = { version = "0.4.3", features = ["serde"] }
 rand = "0.9.2"
+unicode-segmentation = "1"
 tokio-stream = "0.1.17"
 tokio-util = "0.7"
 tracing = "0.1.41"

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -197,15 +197,15 @@ mod tests {
         let short = AddContactQrCode::new(device_pubkey, InboxNonce(nonce), "short");
         assert_eq!(short.profile_name, "short");
 
-        let exact = AddContactQrCode::new(device_pubkey, InboxNonce(nonce), "exactlyseventeen!");
-        assert_eq!(exact.profile_name, "exactlyseventeen!");
+        let exact = AddContactQrCode::new(device_pubkey, InboxNonce(nonce), "exactlysixteen!!");
+        assert_eq!(exact.profile_name, "exactlysixteen!!");
 
         let long = AddContactQrCode::new(
             device_pubkey,
             InboxNonce(nonce),
             "this is a very long name indeed",
         );
-        assert_eq!(long.profile_name, "this is a very lo");
+        assert_eq!(long.profile_name, "this is a very l");
     }
 
     #[test]

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -76,8 +76,8 @@ pub struct AddContactQrCode {
 }
 
 impl AddContactQrCode {
-    /// Create a new contact QR code. `profile_name` is truncated to
-    /// [`PROFILE_NAME_MAX_LENGTH`] characters before being stored.
+    /// Create a new contact QR code. `profile_name` is truncated avoid the code
+    /// being too large.
     pub fn new(
         device_pubkey: DeviceId,
         inbox_nonce: InboxNonce,

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -10,9 +10,8 @@ use crate::{DeviceId, Topic, topic::kind};
 const QR_CODE_ENCODING_ENGINE: base64::engine::GeneralPurpose = URL_SAFE_NO_PAD;
 
 /// Maximum number of characters stored in an [`AddContactQrCode`]'s
-/// `profile_name`. When the displayed value reaches this length the receiver
-/// knows it was truncated and can show an ellipsis.
-const PROFILE_NAME_MAX_LENGTH: usize = 17;
+/// `profile_name`.
+const PROFILE_NAME_MAX_LENGTH: usize = 16;
 
 /// Truncate a visible profile name for inclusion in an [`AddContactQrCode`].
 fn truncate_profile_name(name: &str) -> String {

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -172,7 +172,7 @@ impl FromStr for AddContactQrCode {
         Ok(AddContactQrCode {
             device_pubkey,
             inbox_nonce: InboxNonce(inbox_nonce),
-            profile_name,
+            profile_name: truncate_profile_name(&profile_name),
         })
     }
 }
@@ -257,6 +257,22 @@ mod tests {
         // "Åström" plus " is my" fits exactly in 16 bytes; truncation should
         // not leave a bare combining mark.
         assert_eq!(combining.profile_name, "A\u{030A}stro\u{0308}m is my");
+    }
+
+    #[test]
+    fn test_from_str_truncates_profile_name() {
+        let pubkey = VerifyingKey::from_bytes(&[22; 32]).unwrap();
+        let device_pubkey = DeviceId::from(pubkey);
+        let nonce: [u8; 8] = [8, 7, 6, 5, 4, 3, 2, 1];
+
+        let mut code = AddContactQrCode::new(device_pubkey, InboxNonce(nonce), "short");
+        code.profile_name = "this is a very long name indeed".to_string();
+
+        let encoded = code.to_string();
+        let decoded = AddContactQrCode::from_str(&encoded).unwrap();
+
+        assert_eq!(decoded.profile_name, "this is a very l");
+        assert_eq!(decoded.profile_name.len(), PROFILE_NAME_MAX_BYTES);
     }
 
     #[test]

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -9,6 +9,20 @@ use crate::{DeviceId, Topic, topic::kind};
 
 const QR_CODE_ENCODING_ENGINE: base64::engine::GeneralPurpose = URL_SAFE_NO_PAD;
 
+/// Maximum number of characters stored in an [`AddContactQrCode`]'s
+/// `profile_name`. When the displayed value reaches this length the receiver
+/// knows it was truncated and can show an ellipsis.
+const PROFILE_NAME_MAX_LENGTH: usize = 17;
+
+/// Truncate a visible profile name for inclusion in an [`AddContactQrCode`].
+fn truncate_profile_name(name: &str) -> String {
+    if name.chars().count() <= PROFILE_NAME_MAX_LENGTH {
+        name.to_string()
+    } else {
+        name.chars().take(PROFILE_NAME_MAX_LENGTH).collect()
+    }
+}
+
 /// An 8-byte nonce used to derive an inbox topic ID.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct InboxNonce(pub [u8; 8]);
@@ -38,6 +52,24 @@ pub struct AddContactQrCode {
     pub device_pubkey: DeviceId,
     /// 8-byte nonce used with `derive_inbox_topic` to reconstruct the inbox topic.
     pub inbox_nonce: InboxNonce,
+    /// Visible profile name of the code owner, truncated for compactness.
+    pub profile_name: String,
+}
+
+impl AddContactQrCode {
+    /// Create a new contact QR code. `profile_name` is truncated to
+    /// [`PROFILE_NAME_MAX_LENGTH`] characters before being stored.
+    pub fn new(
+        device_pubkey: DeviceId,
+        inbox_nonce: InboxNonce,
+        profile_name: impl AsRef<str>,
+    ) -> Self {
+        Self {
+            device_pubkey,
+            inbox_nonce,
+            profile_name: truncate_profile_name(profile_name.as_ref()),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -97,6 +129,7 @@ impl std::fmt::Display for AddContactQrCode {
         let bytes = encode_cbor(&(
             serde_bytes::Bytes::new(self.device_pubkey.as_bytes()),
             serde_bytes::Bytes::new(&self.inbox_nonce.as_bytes()),
+            self.profile_name.as_str(),
         ))
         .map_err(|_| std::fmt::Error)?;
         write!(f, "{}", QR_CODE_ENCODING_ENGINE.encode(bytes))
@@ -108,8 +141,11 @@ impl FromStr for AddContactQrCode {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use p2panda::VerifyingKey;
         let bytes = QR_CODE_ENCODING_ENGINE.decode(s)?;
-        let (device_pubkey_bytes, inbox_nonce_bytes): (serde_bytes::ByteBuf, serde_bytes::ByteBuf) =
-            decode_cbor(bytes.as_slice())?;
+        let (device_pubkey_bytes, inbox_nonce_bytes, profile_name): (
+            serde_bytes::ByteBuf,
+            serde_bytes::ByteBuf,
+            String,
+        ) = decode_cbor(bytes.as_slice())?;
         let device_pubkey = DeviceId::from(VerifyingKey::from_bytes(
             device_pubkey_bytes.as_ref().try_into()?,
         )?);
@@ -117,6 +153,7 @@ impl FromStr for AddContactQrCode {
         Ok(AddContactQrCode {
             device_pubkey,
             inbox_nonce: InboxNonce(inbox_nonce),
+            profile_name,
         })
     }
 }
@@ -146,13 +183,30 @@ mod tests {
         let pubkey = VerifyingKey::from_bytes(&[22; 32]).unwrap();
         let device_pubkey = DeviceId::from(pubkey);
         let nonce: [u8; 8] = [8, 7, 6, 5, 4, 3, 2, 1];
-        let contact = AddContactQrCode {
-            device_pubkey,
-            inbox_nonce: InboxNonce(nonce),
-        };
+        let contact = AddContactQrCode::new(device_pubkey, InboxNonce(nonce), "Ada Lovelace");
         let encoded = contact.to_string();
         let decoded = AddContactQrCode::from_str(&encoded).unwrap();
         assert_eq!(contact, decoded);
+    }
+
+    #[test]
+    fn test_constructor_truncates_profile_name() {
+        let pubkey = VerifyingKey::from_bytes(&[22; 32]).unwrap();
+        let device_pubkey = DeviceId::from(pubkey);
+        let nonce: [u8; 8] = [8, 7, 6, 5, 4, 3, 2, 1];
+
+        let short = AddContactQrCode::new(device_pubkey, InboxNonce(nonce), "short");
+        assert_eq!(short.profile_name, "short");
+
+        let exact = AddContactQrCode::new(device_pubkey, InboxNonce(nonce), "exactlyseventeen!");
+        assert_eq!(exact.profile_name, "exactlyseventeen!");
+
+        let long = AddContactQrCode::new(
+            device_pubkey,
+            InboxNonce(nonce),
+            "this is a very long name indeed",
+        );
+        assert_eq!(long.profile_name, "this is a very lo");
     }
 
     #[test]

--- a/crates/dashchat-node/src/contact.rs
+++ b/crates/dashchat-node/src/contact.rs
@@ -4,22 +4,42 @@ use chrono::{DateTime, Utc};
 use p2panda_core::cbor::{decode_cbor, encode_cbor};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{DeviceId, Topic, topic::kind};
 
 const QR_CODE_ENCODING_ENGINE: base64::engine::GeneralPurpose = URL_SAFE_NO_PAD;
 
-/// Maximum number of characters stored in an [`AddContactQrCode`]'s
+/// Maximum number of UTF-8 bytes stored in an [`AddContactQrCode`]'s
 /// `profile_name`.
-const PROFILE_NAME_MAX_LENGTH: usize = 16;
+const PROFILE_NAME_MAX_BYTES: usize = 16;
 
 /// Truncate a visible profile name for inclusion in an [`AddContactQrCode`].
+///
+/// Truncation is done on Unicode grapheme clusters, not scalar values, and
+/// stops before the next grapheme would exceed [`PROFILE_NAME_MAX_BYTES`]
+/// UTF-8 bytes. The first grapheme is always kept, even if it alone exceeds
+/// the budget, so the result is never empty for a non-empty name.
 fn truncate_profile_name(name: &str) -> String {
-    if name.chars().count() <= PROFILE_NAME_MAX_LENGTH {
-        name.to_string()
-    } else {
-        name.chars().take(PROFILE_NAME_MAX_LENGTH).collect()
+    if name.len() <= PROFILE_NAME_MAX_BYTES {
+        return name.to_string();
     }
+
+    let mut budget = PROFILE_NAME_MAX_BYTES;
+    let mut result = String::new();
+    let mut first = true;
+
+    for grapheme in name.graphemes(true) {
+        let len = grapheme.len();
+        if !first && budget < len {
+            break;
+        }
+        result.push_str(grapheme);
+        budget = budget.saturating_sub(len);
+        first = false;
+    }
+
+    result
 }
 
 /// An 8-byte nonce used to derive an inbox topic ID.
@@ -206,6 +226,37 @@ mod tests {
             "this is a very long name indeed",
         );
         assert_eq!(long.profile_name, "this is a very l");
+        assert_eq!(long.profile_name.len(), PROFILE_NAME_MAX_BYTES);
+
+        let family_emoji = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}";
+        let emoji = AddContactQrCode::new(
+            device_pubkey,
+            InboxNonce(nonce),
+            format!("{family_emoji}{family_emoji}"),
+        );
+        // Each ZWJ family emoji is 25 UTF-8 bytes, larger than the budget.
+        // The first grapheme is still kept, so we get one intact family emoji.
+        assert_eq!(emoji.profile_name, family_emoji);
+        assert_eq!(emoji.profile_name.graphemes(true).count(), 1);
+
+        let astronaut = "\u{1F469}\u{200D}\u{1F680}";
+        let mixed = AddContactQrCode::new(
+            device_pubkey,
+            InboxNonce(nonce),
+            format!("Ada {astronaut} Lovelace"),
+        );
+        // "Ada " is 4 bytes; the ZWJ astronaut is 11 bytes; the trailing space
+        // is 1 byte. All 16 bytes fit exactly, so "Lovelace" is omitted.
+        assert_eq!(mixed.profile_name, format!("Ada {astronaut} "));
+
+        let combining = AddContactQrCode::new(
+            device_pubkey,
+            InboxNonce(nonce),
+            "A\u{030A}stro\u{0308}m is my name",
+        );
+        // "Åström" plus " is my" fits exactly in 16 bytes; truncation should
+        // not leave a bare combining mark.
+        assert_eq!(combining.profile_name, "A\u{030A}stro\u{0308}m is my");
     }
 
     #[test]

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -461,10 +461,15 @@ impl Node {
             .await
             .map_err(|err| crate::Error::AddActiveInbox(format!("{err}")))?;
 
-        Ok(AddContactQrCode {
-            device_pubkey: self.device_id(),
-            inbox_nonce: nonce,
-        })
+        let profile_name = self
+            .my_profile()
+            .await
+            .ok()
+            .flatten()
+            .map(|profile| profile.full_name())
+            .unwrap_or_default();
+
+        Ok(AddContactQrCode::new(self.device_id(), nonce, profile_name))
     }
 
     pub fn agent_id(&self) -> AgentId {

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -1495,6 +1495,7 @@ impl Node {
             self.device_group_topic(),
             Payload::DeviceGroup(DeviceGroupPayload::PendingContactRequest {
                 device_pubkey: contact.device_pubkey,
+                profile_name: contact.profile_name,
             }),
             Some(&format!(
                 "add_contact/pending({:?})",

--- a/crates/dashchat-node/src/payload.rs
+++ b/crates/dashchat-node/src/payload.rs
@@ -21,6 +21,17 @@ pub struct Profile {
     pub about: Option<String>,
 }
 
+impl Profile {
+    /// Return the display name as "<name> <surname>" when a non-empty surname
+    /// exists, otherwise just "<name>".
+    pub fn full_name(&self) -> String {
+        match self.surname {
+            Some(ref surname) if !surname.is_empty() => format!("{} {}", self.name, surname),
+            _ => self.name.clone(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload")]
 pub enum AnnouncementsPayload {

--- a/crates/dashchat-node/src/payload.rs
+++ b/crates/dashchat-node/src/payload.rs
@@ -161,7 +161,7 @@ pub enum DeviceGroupPayload {
     /// the device -> agent mapping is known.
     PendingContactRequest {
         device_pubkey: DeviceId,
-
+        #[serde(default)]
         profile_name: String,
     },
     RejectContactRequest(AgentId),

--- a/crates/dashchat-node/src/payload.rs
+++ b/crates/dashchat-node/src/payload.rs
@@ -161,6 +161,8 @@ pub enum DeviceGroupPayload {
     /// the device -> agent mapping is known.
     PendingContactRequest {
         device_pubkey: DeviceId,
+
+        profile_name: String,
     },
     RejectContactRequest(AgentId),
     BlockAgent(AgentId),

--- a/e2e-tests/specs/waiting-profile.spec.ts
+++ b/e2e-tests/specs/waiting-profile.spec.ts
@@ -34,7 +34,10 @@ describe('Waiting-for-profile placeholder', () => {
 		// The placeholder window only exists while the mailbox is suspended,
 		// which is impossible against a remote environment mailbox.
 		if (isRemoteMailbox()) this.skip();
-		[agent1, agent2] = await setupAgents(this, [{ platform: 'any' }, { platform: 'any' }]);
+		[agent1, agent2] = await setupAgents(this, [
+			{ platform: 'any' },
+			{ platform: 'any' },
+		]);
 		await Promise.all([
 			agent1.createProfilePage.createProfile('Alice', 'Test'),
 			agent2.createProfilePage.createProfile('Bob', 'Test'),
@@ -91,11 +94,11 @@ describe('Waiting-for-profile placeholder', () => {
 		);
 	});
 
-	it('shows the placeholder on the home chat-list row', async () => {
+	it('shows the QR code profile name on the home chat-list row', async () => {
 		await agent2.chatSettingsPage.back.click();
 		await agent2.directChatPage.ready();
 		await agent2.directChatPage.back.click();
 		await agent2.homePage.ready();
-		await waitForTextContent(agent2, tid('all-chats-row'), waitingText);
+		await waitForTextContent(agent2, tid('all-chats-row'), 'Alice Test');
 	});
 });

--- a/packages/stores/src/chats/chats-store.ts
+++ b/packages/stores/src/chats/chats-store.ts
@@ -156,7 +156,7 @@ export class ChatsStore {
 			return pending.map(request => ({
 				type: 'DirectChat',
 				chatId: pendingChatKey(request.devicePubkey),
-				name: '',
+				name: request.profileName,
 				avatar: undefined,
 				waitingForProfile: true as const,
 				lastEvent: {

--- a/packages/stores/src/contacts/contacts-store.ts
+++ b/packages/stores/src/contacts/contacts-store.ts
@@ -23,6 +23,7 @@ export interface ContactRequest {
 export interface OutgoingContactRequest {
 	devicePubkey: DeviceId;
 	timestamp: number;
+	profileName: string;
 }
 
 export class ContactsStore {
@@ -122,14 +123,23 @@ export class ContactsStore {
 	outgoingPendingRequests = reactive(async () => {
 		const myDeviceGroupTopic = await this.devicesStore.myDeviceGroupTopic();
 
-		const latestByDevice: Record<DeviceId, number> = {};
+		const latestByDevice: Record<
+			DeviceId,
+			{ timestamp: number; profileName: string }
+		> = {};
 		for (const [_, ops] of Object.entries(myDeviceGroupTopic)) {
 			for (const op of ops) {
 				if (op.body?.payload?.type !== 'PendingContactRequest') continue;
-				const { device_pubkey } = op.body.payload.payload;
+				const { device_pubkey, profile_name } = op.body.payload.payload;
 				const existing = latestByDevice[device_pubkey];
-				if (existing === undefined || op.header.timestamp > existing) {
-					latestByDevice[device_pubkey] = op.header.timestamp;
+				if (
+					existing === undefined ||
+					op.header.timestamp > existing.timestamp
+				) {
+					latestByDevice[device_pubkey] = {
+						timestamp: op.header.timestamp,
+						profileName: profile_name ?? '',
+					};
 				}
 			}
 		}
@@ -144,7 +154,8 @@ export class ContactsStore {
 			if (resolved[i] !== undefined) continue;
 			pending.push({
 				devicePubkey: devices[i],
-				timestamp: latestByDevice[devices[i]],
+				timestamp: latestByDevice[devices[i]].timestamp,
+				profileName: latestByDevice[devices[i]].profileName,
 			});
 		}
 		return pending;

--- a/packages/stores/src/direct-chats/direct-chat-store.ts
+++ b/packages/stores/src/direct-chats/direct-chat-store.ts
@@ -119,10 +119,16 @@ export class DirectChatStore {
 						(await this.contactsStore.contactAddedTimestamp(this.peer)) ?? 0,
 				};
 
+		const pendingName = this.isPending
+			? (await this.contactsStore.outgoingPendingRequests()).find(
+					request => request.devicePubkey === pendingChatKeyDevice(this.peer),
+				)?.profileName
+			: undefined;
+
 		return {
 			type: 'DirectChat',
 			chatId: this.peer,
-			name: profile ? fullName(profile) : '',
+			name: profile ? fullName(profile) : (pendingName ?? ''),
 			avatar: profile?.avatar,
 			lastEvent,
 			unreadMessages: unreadCount,

--- a/packages/stores/src/types.ts
+++ b/packages/stores/src/types.ts
@@ -178,7 +178,10 @@ export interface ReadMessagesPayload {
 
 export type DeviceGroupPayload =
 	| { type: 'AddContact'; payload: { agent_id: AgentId } }
-	| { type: 'PendingContactRequest'; payload: { device_pubkey: DeviceId } }
+	| {
+			type: 'PendingContactRequest';
+			payload: { device_pubkey: DeviceId; profile_name: string };
+	  }
 	| { type: 'RejectContactRequest'; payload: AgentId }
 	| { type: 'BlockAgent'; payload: AgentId }
 	| { type: 'UnblockAgent'; payload: AgentId }

--- a/src-tauri/src/commands/redact_log.rs
+++ b/src-tauri/src/commands/redact_log.rs
@@ -43,6 +43,8 @@ pub static REDACTION_REGEXES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
         r#"emoji:\s*Some\("[^"]*"\)"#,
         // JSON format: "name":"...", "surname":"...", "about":"...", "description":"..."
         r#""(name|surname|about|description)"\s*:\s*"[^"]*""#,
+        // JSON format: "profile_name":"..." — contact request QR placeholder.
+        r#""profile_name"\s*:\s*"[^"]*""#,
         // JSON format: "content":"..."
         r#""content"\s*:\s*"[^"]*""#,
         // JSON format: "message":"..." — chat message text and edit text
@@ -199,6 +201,26 @@ mod tests {
         assert!(
             !result.contains("Hello world"),
             "about not redacted: {result}"
+        );
+    }
+
+    #[test]
+    fn redacts_profile_name_field_debug() {
+        let input = r#"PendingContactRequest { device_pubkey: VerifyingKey([1, 2, 3]), profile_name: "Alice" }"#;
+        let result = redact(input);
+        assert!(
+            !result.contains("Alice"),
+            "profile_name not redacted: {result}"
+        );
+    }
+
+    #[test]
+    fn redacts_profile_name_field_json() {
+        let input = r#"{"type":"PendingContactRequest","payload":{"device_pubkey":[1,2,3],"profile_name":"Alice"}}"#;
+        let result = redact(input);
+        assert!(
+            !result.contains("Alice"),
+            "profile_name not redacted: {result}"
         );
     }
 

--- a/ui/src/lib/components/chats/ChatSummary.svelte
+++ b/ui/src/lib/components/chats/ChatSummary.svelte
@@ -37,6 +37,8 @@
 			? `/group-chat/${s.chatId}`
 			: `/direct-chats/${s.chatId}`;
 
+	const title = $derived(summary.name || m.waitingForProfile());
+
 	function summarizeMessage(content: {
 		message: string;
 		media: MediaAttachment | null;
@@ -50,7 +52,7 @@
 </script>
 
 <TitleTruncatedListItem
-	title={summary.name}
+	{title}
 	link
 	class={active ? 'active' : ''}
 	linkProps={{ href: chatHref(summary) }}

--- a/ui/src/lib/components/chats/ChatSummary.svelte
+++ b/ui/src/lib/components/chats/ChatSummary.svelte
@@ -50,8 +50,7 @@
 </script>
 
 <TitleTruncatedListItem
-	title={summary.waitingForProfile ? m.waitingForProfile() : summary.name}
-	titleWrapClass={summary.waitingForProfile ? 'quiet' : ''}
+	title={summary.name}
 	link
 	class={active ? 'active' : ''}
 	linkProps={{ href: chatHref(summary) }}
@@ -59,7 +58,11 @@
 	data-testid="all-chats-row"
 >
 	{#snippet media()}
-		<Avatar image={summary.avatar} initials={summary.name.slice(0, 2)} />
+		<Avatar
+			image={summary.avatar}
+			initials={summary.name.slice(0, 2)}
+			waitingForProfile={summary.waitingForProfile}
+		/>
 	{/snippet}
 	{#snippet after()}
 		<span class="text-xs">

--- a/ui/src/lib/components/profiles/Avatar.svelte
+++ b/ui/src/lib/components/profiles/Avatar.svelte
@@ -35,7 +35,9 @@
 		image?.startsWith('data:image') ? image : undefined,
 	);
 	const avatarInitials = $derived(
-		textAvatarData?.text || initials || undefined,
+		waitingForProfile
+			? undefined
+			: textAvatarData?.text || initials || undefined,
 	);
 	const sizeValue = $derived(
 		size !== undefined


### PR DESCRIPTION
This PR adds 16 bytes of the user's profile name to the QR code. Doing this means that when you add a user, you can see a profile name in the temporary item in your chat list telling you that you're waiting for the result of your add request.

This link isn't signed in any way, so this can be spoofed. 