### PR TITLE
Refactor media types

### DIFF
--- a/crates/dashchat-node/src/blob_sync.rs
+++ b/crates/dashchat-node/src/blob_sync.rs
@@ -438,7 +438,7 @@ impl BlobFetchPool {
                             continue;
                         };
                         for item in media {
-                            s.push((topic, item.hash));
+                            s.push((topic, item.hash()));
                         }
                     }
                 }

--- a/crates/dashchat-node/src/chat/message.rs
+++ b/crates/dashchat-node/src/chat/message.rs
@@ -62,20 +62,38 @@ pub enum OutgoingMedia {
 pub type MediaBundle = Vec<MediaMetadata>;
 
 /// The metadata to refer to a media blob, which appears in the message content.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, From)]
-pub struct MediaMetadata {
-    pub name: String,
-    pub mime_type: String,
-    pub size: u64,
-    pub kind: MediaMetaKind,
-    // Serialize as a CBOR byte string. `iroh_blobs::Hash`'s own non-human-readable
-    // impl encodes a 32-element array, which serde's untagged-enum buffering (used
-    // by `dashchat_compat::Compat`) cannot reconstruct from CBOR.
-    //
-    // TODO: consider reworking Compat to remove this complexity, since we're
-    //       not really getting what we want from Compat anyway.
-    #[serde(with = "hash_bytes")]
-    pub hash: iroh_blobs::Hash,
+/// Each variant carries only what its kind needs
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum MediaMetadata {
+    Photo {
+        name: String,
+        mime_type: String,
+        size: u64,
+        // Serialize as a CBOR byte string. `iroh_blobs::Hash`'s own non-human-readable
+        // impl encodes a 32-element array, which serde's untagged-enum buffering (used
+        // by `dashchat_compat::Compat`) cannot reconstruct from CBOR.
+        //
+        // TODO: consider reworking Compat to remove this complexity, since we're
+        //       not really getting what we want from Compat anyway.
+        #[serde(with = "hash_bytes")]
+        hash: iroh_blobs::Hash,
+    },
+    File {
+        name: String,
+        mime_type: String,
+        size: u64,
+        #[serde(with = "hash_bytes")]
+        hash: iroh_blobs::Hash,
+    },
+}
+
+impl MediaMetadata {
+    pub fn hash(&self) -> iroh_blobs::Hash {
+        match self {
+            MediaMetadata::Photo { hash, .. } | MediaMetadata::File { hash, .. } => *hash,
+        }
+    }
 }
 
 mod hash_bytes {
@@ -135,12 +153,6 @@ mod hash_bytes {
 
         deserializer.deserialize_any(HashVisitor)
     }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub enum MediaMetaKind {
-    Photo,
-    File,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Deref, From)]

--- a/crates/dashchat-node/src/mailbox.rs
+++ b/crates/dashchat-node/src/mailbox.rs
@@ -46,7 +46,7 @@ impl MailboxItem for MailboxOperation {
         match payload {
             crate::Payload::Chat(crate::ChatPayload::Message(m)) => m
                 .media()
-                .map(|items| items.iter().map(|item| item.hash).collect())
+                .map(|items| items.iter().map(|item| item.hash()).collect())
                 .unwrap_or_default(),
             _ => Vec::new(),
         }
@@ -140,11 +140,10 @@ mod tests {
 
         let content = ChatMessageContent::new(
             "hello",
-            Some(vec![MediaMetadata {
+            Some(vec![MediaMetadata::Photo {
                 name: "photo.jpg".into(),
                 mime_type: "image/jpeg".into(),
                 size: 1024,
-                kind: MediaMetaKind::Photo,
                 hash: media_hash,
             }]),
         );

--- a/crates/dashchat-node/src/node.rs
+++ b/crates/dashchat-node/src/node.rs
@@ -40,8 +40,8 @@ use crate::stores::{GroupStore, LocalStore, NodeKeys, OpProjection, OpStore};
 use crate::topic::{Topic, TopicId, kind};
 use crate::{
     AgentId, AsBody, ChatId, ChatReaction, DeleteCandidate, DeleteMessageError, DeviceGroupId,
-    DeviceGroupPayload, DeviceId, DirectChatId, EditMessageError, MediaBundle, MediaMetaKind,
-    MediaMetadata, OutgoingFile, OutgoingMedia,
+    DeviceGroupPayload, DeviceId, DirectChatId, EditMessageError, MediaBundle, MediaMetadata,
+    OutgoingFile, OutgoingMedia,
 };
 use dashchat_utils::{NETWORK_ID, RELAY_URL};
 
@@ -976,7 +976,7 @@ impl Node {
             for item in bundle.iter() {
                 if let Err(err) = self
                     .require_blob_sync()?
-                    .retag_blob(topic_id, self.device_id(), header.hash(), item.hash)
+                    .retag_blob(topic_id, self.device_id(), header.hash(), item.hash())
                     .await
                 {
                     tracing::warn!(?err, "failed to retag blob after operation creation");
@@ -1834,12 +1834,11 @@ impl Node {
                         .require_blob_sync()?
                         .store_blob(topic, self.device_id(), operation_hash, photo.data)
                         .await?;
-                    items.push(MediaMetadata {
+                    items.push(MediaMetadata::Photo {
                         name: photo.name,
                         mime_type: photo.mime_type,
                         size,
                         hash,
-                        kind: MediaMetaKind::Photo,
                     });
                 }
             }
@@ -1850,12 +1849,11 @@ impl Node {
                     .require_blob_sync()?
                     .store_blob(topic, self.device_id(), operation_hash, file.data)
                     .await?;
-                items.push(MediaMetadata {
+                items.push(MediaMetadata::File {
                     name: file.name,
                     mime_type: file.mime_type,
                     size,
                     hash,
-                    kind: MediaMetaKind::File,
                 });
             }
         }
@@ -1911,44 +1909,46 @@ impl Node {
             let data = self
                 .require_blob_sync()?
                 .blobs
-                .get_bytes(item.hash)
+                .get_bytes(item.hash())
                 .await
                 .context(format!("failed to load blob: {item:?}"))?;
             items.push((item, data));
         }
 
-        let (photos, mut other): (Vec<_>, Vec<_>) = items
-            .into_iter()
-            .partition(|(item, _)| item.kind == MediaMetaKind::Photo);
-
-        if other.len() > 1 {
-            return Err(anyhow::anyhow!(
-                "multiple files are not supported. photos: {photos:?}, other: {other:?}",
-            ));
-        } else if photos.len() >= 1 && other.len() == 1 {
-            return Err(anyhow::anyhow!(
-                "photos and other media in the same message are not supported. photos: {photos:?}, other: {other:?}",
-            ));
-        } else if other.len() == 1 {
-            let (item, data) = other.pop().unwrap();
+        // A file is always a single-item bundle; photos may be many.
+        if items.len() == 1 && matches!(items[0].0, MediaMetadata::File { .. }) {
+            let (item, data) = items.pop().unwrap();
+            let MediaMetadata::File {
+                name, mime_type, ..
+            } = item
+            else {
+                unreachable!()
+            };
             return Ok(OutgoingMedia::File {
                 file: OutgoingFile {
                     data: data.to_vec(),
-                    name: item.name,
-                    mime_type: item.mime_type,
+                    name,
+                    mime_type,
                 },
             });
-        } else {
-            let photos = photos
-                .into_iter()
-                .map(|(item, data)| crate::chat::OutgoingPhoto {
-                    data: data.to_vec(),
-                    name: item.name,
-                    mime_type: item.mime_type,
-                })
-                .collect();
-            return Ok(OutgoingMedia::Photos { photos });
         }
+
+        let photos = items
+            .into_iter()
+            .map(|(item, data)| match item {
+                MediaMetadata::Photo {
+                    name, mime_type, ..
+                } => Ok(crate::chat::OutgoingPhoto {
+                    data: data.to_vec(),
+                    name,
+                    mime_type,
+                }),
+                other => Err(anyhow::anyhow!(
+                    "unsupported media combination in a single message: {other:?}"
+                )),
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(OutgoingMedia::Photos { photos })
     }
 }
 

--- a/crates/dashchat-node/src/node/app_processing.rs
+++ b/crates/dashchat-node/src/node/app_processing.rs
@@ -426,7 +426,7 @@ impl Node {
                         })?;
 
                     if let (Some(media), Some(blob_sync)) = (m.media(), &self.blob_sync) {
-                        let hashes: Vec<_> = media.iter().map(|item| item.hash).collect();
+                        let hashes: Vec<_> = media.iter().map(|item| item.hash()).collect();
                         let is_own = DeviceId::from(author) == self.device_id();
                         if let Err(err) = self
                             .local_store
@@ -609,7 +609,7 @@ impl Node {
                 if let (Some(media), Some(blob_sync)) = (m.media(), &self.blob_sync) {
                     for item in media.iter() {
                         blob_sync
-                            .add_to_fetch_pool(topic.into(), author, hash, item.hash)
+                            .add_to_fetch_pool(topic.into(), author, hash, item.hash())
                             .await?;
                     }
                 }

--- a/crates/dashchat-node/tests/blob_sync.rs
+++ b/crates/dashchat-node/tests/blob_sync.rs
@@ -151,7 +151,7 @@ async fn blob_fetch_pool_hydrates_stored_media_on_restart() {
         .into_iter()
         .find_map(|m| m.content.media().cloned())
         .expect("media metadata present on bobbi's copy of the message");
-    let hash = meta.first().expect("at least one media item").hash;
+    let hash = meta.first().expect("at least one media item").hash();
 
     // Restart Bobbi from the same store. The media op is already persisted and
     // is not re-delivered, so only startup hydration can re-queue its blob.

--- a/crates/dashchat-node/tests/blocking.rs
+++ b/crates/dashchat-node/tests/blocking.rs
@@ -46,7 +46,7 @@ async fn media_hash(node: &TestNode, chat: ChatId, text: &str) -> iroh_blobs::Ha
         .unwrap()
         .into_iter()
         .find(|m| m.content.message() == text)
-        .and_then(|m| m.content.media().and_then(|b| b.first()).map(|i| i.hash))
+        .and_then(|m| m.content.media().and_then(|b| b.first()).map(|i| i.hash()))
         .expect("media hash for message")
 }
 

--- a/crates/dashchat-node/tests/delete_messages.rs
+++ b/crates/dashchat-node/tests/delete_messages.rs
@@ -82,7 +82,7 @@ async fn media_hash_of(node: &TestNode, chat: ChatId, text: &str) -> iroh_blobs:
         .expect("message carries media")
         .first()
         .expect("at least one media item")
-        .hash
+        .hash()
 }
 
 /// The full flow from the spec: two nodes connected only through a mailbox

--- a/crates/dashchat-node/tests/mailbox_blob_sync.rs
+++ b/crates/dashchat-node/tests/mailbox_blob_sync.rs
@@ -124,7 +124,7 @@ async fn media_blob_relays_through_mailbox_when_sender_offline() {
         .into_iter()
         .find_map(|m| m.content.media().cloned())
         .expect("alice's message carries media metadata");
-    let hash = meta.first().expect("at least one media item").hash;
+    let hash = meta.first().expect("at least one media item").hash();
 
     poll.wait_for(|| async {
         relay
@@ -325,7 +325,7 @@ async fn recovers_unfetched_blob_after_source_restart() {
         .into_iter()
         .find_map(|m| m.content.media().cloned())
         .expect("alice's message carries media metadata");
-    let hash = meta.first().expect("at least one media item").hash;
+    let hash = meta.first().expect("at least one media item").hash();
 
     // Alice's mailbox sync runs `publish` on a background task; `publish`
     // announces the blob via `/blobs/store` and, because the mailbox does not

--- a/crates/dashchat-node/tests/no_p2p.rs
+++ b/crates/dashchat-node/tests/no_p2p.rs
@@ -163,7 +163,7 @@ async fn no_p2p_exchanges_media_through_mailbox_only() {
         .into_iter()
         .find_map(|m| m.content.media().cloned())
         .expect("alice's message carries media metadata");
-    let hash = meta.first().expect("at least one media item").hash;
+    let hash = meta.first().expect("at least one media item").hash();
 
     // The mailbox must fetch the blob from Alice. With mDNS off this only works
     // if the mailbox has learned Alice's iroh address — the behavior under test.
@@ -314,7 +314,7 @@ async fn stale_mailbox_addr_is_refreshed_on_reregister() {
         .into_iter()
         .find_map(|m| m.content.media().cloned())
         .expect("alice's message carries media metadata");
-    let hash = meta.first().expect("at least one media item").hash;
+    let hash = meta.first().expect("at least one media item").hash();
 
     poll.wait_for(|| async {
         relay

--- a/packages/stores/src/chats/messages-store.ts
+++ b/packages/stores/src/chats/messages-store.ts
@@ -14,7 +14,6 @@ import {
 	Payload,
 	Tombstone,
 	hasBody,
-	mediaBundleToAttachment,
 } from '../types';
 import { type IMessagesClient } from './messages-client';
 
@@ -218,7 +217,7 @@ function collectMessageActionsByType(
 					hash: operation.hash,
 					content: {
 						message: body.payload.payload.message,
-						media: mediaBundleToAttachment(body.payload.payload.media),
+						media: body.payload.payload.media,
 						reactions: {},
 						editHistory: [],
 					},

--- a/packages/stores/src/types.ts
+++ b/packages/stores/src/types.ts
@@ -47,15 +47,6 @@ export interface FileAttachment {
 }
 
 /**
- * Renderable media attached to a chat message. A message has either a set of
- * photos or a single file — not both. Built from a log's `MediaMetaCollection`
- * via `mediaMetaToMedia`; carries hashes, not bytes.
- */
-export type MediaAttachment =
-	| { kind: 'photos'; photos: PhotoAttachment[] }
-	| { kind: 'file'; file: FileAttachment };
-
-/**
  * Raw bytes leaving the composer for the backend to store. `data` carries raw
  * bytes — NOT base64; in-process it is a `Uint8Array`, and over Tauri JSON IPC
  * a `Vec<u8>` arrives as `number[]`. This is the *only* media shape that holds
@@ -78,54 +69,18 @@ export interface OutgoingFile {
 	mime_type: string;
 }
 
-export type MediaMetaKind = 'Photo' | 'File';
-
 /**
  * Metadata for a single stored blob. A message log carries these in place of
  * the raw bytes; the bytes live in the iroh-blobs store and are fetched lazily
- * via the `irohblob://` URI scheme. Matches `dashchat_node::MediaMetaItem`.
+ * via the `irohblob://` URI scheme. Mirrors the `#[serde(tag = "kind")]` enum
+ * `dashchat_node::MediaMetadata`: each variant carries only what its kind needs.
  */
-export interface MediaMetadata {
-	name: string;
-	mime_type: string;
-	size: number;
-	kind: MediaMetaKind;
-	hash: Hash;
-}
+export type MediaMetadata =
+	| { kind: 'Photo'; name: string; mime_type: string; size: number; hash: Hash }
+	| { kind: 'File'; name: string; mime_type: string; size: number; hash: Hash };
 
 /** Matches `dashchat_node::MediaBundle`, which serializes as a flat array. */
 export type MediaBundle = MediaMetadata[];
-
-/**
- * Convert the blob metadata stored in a message log into the renderable
- * `MediaAttachment` shape. Mirrors `Node::load_media`: a lone file becomes a `file`
- * attachment, otherwise the items become `photos`. The resulting photos/file
- * carry only a `hash` (no bytes).
- */
-export function mediaBundleToAttachment(
-	meta: MediaBundle | null | undefined,
-): MediaAttachment | null {
-	if (!meta || meta.length === 0) return null;
-	const file = meta.find(item => item.kind === 'File');
-	if (file) {
-		return {
-			kind: 'file',
-			file: {
-				name: file.name,
-				mime_type: file.mime_type,
-				size: file.size,
-				hash: file.hash,
-			},
-		};
-	}
-	const photos: PhotoAttachment[] = meta.map(item => ({
-		name: item.name,
-		mime_type: item.mime_type,
-		size: item.size,
-		hash: item.hash,
-	}));
-	return { kind: 'photos', photos };
-}
 
 /**
  * V1 (Versioned) form of `ChatMessageContent` — matches the serialization in
@@ -134,9 +89,9 @@ export function mediaBundleToAttachment(
 export type MessageContentV1 = {
 	v: '1';
 	message: string;
-	/** Stored/wire form: a flat `MediaBundle` (bytes live in the blob
-	 * store, fetched lazily via `irohblob://`). `mediaBundleToAttachment` turns this
-	 * into the renderable `MediaAttachment`. */
+	/** Stored/wire form: a flat `MediaBundle` (bytes live in the blob store,
+	 * fetched lazily via `irohblob://`). Consumers derive the photos/file
+	 * grouping from this list at render time. */
 	media: MediaBundle | null;
 };
 export type MessageContent = MessageContentV1;
@@ -316,7 +271,7 @@ export interface MessageVersion {
  * history. */
 export interface MessageBody {
 	message: string;
-	media: MediaAttachment | null;
+	media: MediaBundle | null;
 	reactions: Record<DeviceId, string>;
 	editHistory: MessageVersion[];
 }

--- a/ui/src/lib/components/chats/ChatSummary.svelte
+++ b/ui/src/lib/components/chats/ChatSummary.svelte
@@ -6,7 +6,7 @@
 	import {
 		type ChatSummary,
 		type ContactsStore,
-		type MediaAttachment,
+		type MessageBody,
 		hasBody,
 	} from 'dash-chat-stores';
 	import { getContext } from 'svelte';
@@ -39,14 +39,13 @@
 
 	const title = $derived(summary.name || m.waitingForProfile());
 
-	function summarizeMessage(content: {
-		message: string;
-		media: MediaAttachment | null;
-	}): string {
+	function summarizeMessage(content: MessageBody): string {
 		if (content.message) return content.message;
-		if (!content.media) return '';
-		if (content.media.kind === 'file') return content.media.file.name;
-		const n = content.media.photos.length;
+		const media = content.media;
+		if (!media || media.length === 0) return '';
+		const file = media.find(item => item.kind === 'File');
+		if (file) return file.name;
+		const n = media.filter(item => item.kind === 'Photo').length;
 		return n > 1 ? m.photosCount({ count: n }) : m.photo();
 	}
 </script>

--- a/ui/src/lib/components/messages/MessageContent.svelte
+++ b/ui/src/lib/components/messages/MessageContent.svelte
@@ -25,9 +25,13 @@
 
 	const body = $derived(hasBody(message.content) ? message.content : null);
 	const media = $derived(body?.media ?? null);
+	const file = $derived(media?.find(m => m.kind === 'File'));
+	const photos = $derived(
+		file ? [] : (media?.filter(m => m.kind === 'Photo') ?? []),
+	);
 	const hasText = $derived(!!body?.message);
-	const isPhotoOnly = $derived(media?.kind === 'photos' && !hasText);
-	const isFileOnly = $derived(media?.kind === 'file' && !hasText);
+	const isPhotoOnly = $derived(photos.length > 0 && !hasText);
+	const isFileOnly = $derived(!!file && !hasText);
 
 	let metadataWidth = $state(0);
 </script>
@@ -41,13 +45,9 @@
 		{senderName}
 	</div>
 {/if}
-{#if media?.kind === 'photos'}
+{#if photos.length > 0}
 	<div class="media photos">
-		<PhotosAttachment
-			photos={media.photos}
-			{senderName}
-			timestamp={message.timestamp}
-		/>
+		<PhotosAttachment {photos} {senderName} timestamp={message.timestamp} />
 		{#if isPhotoOnly && metadata}
 			<div
 				class="photo-meta pointer-events-none absolute inset-x-0 bottom-0 flex items-center justify-end gap-1 px-2 pt-4 pb-1"
@@ -56,12 +56,9 @@
 			</div>
 		{/if}
 	</div>
-{:else if media?.kind === 'file'}
+{:else if file}
 	<div class="media file">
-		<FileAttachment
-			file={media.file}
-			metadata={isFileOnly ? metadata : undefined}
-		/>
+		<FileAttachment {file} metadata={isFileOnly ? metadata : undefined} />
 	</div>
 {/if}
 {#if hasText || (metadata && !isPhotoOnly && !isFileOnly)}


### PR DESCRIPTION
This is done to be able to accomodate https://github.com/dash-chat/dash-chat/pull/516.

The new voice note attachment type does not fit cleanly with the generic Media struct.