### PR TITLE
Fix report-contact e2e hook leaving Alice on the add-contact page

### DIFF
--- a/e2e-tests/specs/report-contact.spec.ts
+++ b/e2e-tests/specs/report-contact.spec.ts
@@ -26,10 +26,15 @@ describe('report contact', () => {
 		// One-way add, so Alice lands on a chat showing Bob's contact request.
 		await navigateToAddContact(agent1);
 		const aliceLink = await agent1.addContactPage.getAddContactLink();
+		await agent1.addContactPage.back.click();
+		await agent1.newMessagePage.back.click();
+		await agent1.homePage.ready();
+
 		await navigateToAddContact(agent2);
 		await agent2.addContactPage.enterAddContactLink(aliceLink);
 		await agent2.directChatPage.ready();
 
+		await agent1.homePage.chatList.waitForExist();
 		await agent1.homePage.openChat('Bob Test');
 		await agent1.directChatPage.acceptButton.waitForExist();
 	});


### PR DESCRIPTION
Fixes the `report-contact` spec failure on #502's e2e run ([job log](https://github.com/dash-chat/dash-chat/actions/runs/31511959183/job/93847731358)).

## The failure

```
report contact "before all" hook for report contact
Can't call $ on element with selector "[data-testid="all-chats-list"]" because element wasn't found
    at HomePage.openChat (e2e-tests/helpers/pages/home-page.ts:60)
    at Context.<anonymous> (e2e-tests/specs/report-contact.spec.ts:33)
```

The hook walked agent1 to the add-contact page to read her link and never navigated back. Only agent2 enters a link, so only agent2 auto-navigates to the direct chat — agent1 was still sitting on her QR page when `openChat` ran, where `all-chats-list` does not exist. The 33s runtime is the `waitForExist` timeout. The uploaded failure screenshot confirms agent1 is on "Add contact" at the point of failure.

## The change

Back agent1 out to the home page (`add-contact-back` → `new-message-back` → `homePage.ready()`, the same idiom `long-name-truncation` and `add-contact-deep-link` already use) once her link has been read, then wait for the chat list to render before opening Bob's pending request. Alice's home shows the empty state until Bob's request arrives, so the wait is on `all-chats-list` itself rather than on the chained row — a chained lookup would fail against the empty state instead of polling.

## Verification

Typechecked and Prettier-clean. The e2e suite itself was not run here: it needs the built Tauri binary, and `pnpm install` cannot complete in this environment (the private `tauri-plugin-system-theme` git dependency 403s), so CI on this PR is the real check.

## Not fixed here

`qr-upload.spec.ts` also fails on that run, but it fails identically on `develop` ([run 31499351518](https://github.com/dash-chat/dash-chat/actions/runs/31499351518), the base commit of #502), so it is not from the reporting branch. Cause, for whoever picks it up: an unhandled promise rejection in the webview (`[unhandledrejection] … kv={}`, logged right before the click) makes the global handler in `ui/src/lib/utils/logs.ts:110-113` raise an `unexpected` toast. That variant never auto-dismisses (`ToastManager.svelte:27` only sets the TTL for other variants) and keeps pointer events (`ToastManager.svelte:55` applies `pointer-events: none` only when the variant is not `unexpected`), so it parks across the bottom of the screen and swallows the click on the new-message FAB — `element click intercepted`. It reproduces on both the original attempt and the retry, in both runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_012CbuaVqPMZ63yLVtJyEkm8)_