### PR TITLE
Delayed search flash

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -297,23 +297,30 @@ li.plain span {
 }
 
 .search-flash {
-	animation: search-flash-anim 1.5s ease-out;
+	--flash-brightness: 1.5;
+	animation: search-flash-anim 1s ease-out;
+}
+
+/* brightness() is multiplicative, so the dark incoming bubble needs a much
+   larger factor than the bright outgoing one to shift by as many levels. */
+:where(.dark) .search-flash.incoming-message {
+	--flash-brightness: 3.0;
 }
 
 @keyframes search-flash-anim {
 	0% {
 		filter: brightness(1);
 	}
-	15% {
-		filter: brightness(1.4);
+	20% {
+		filter: brightness(var(--flash-brightness));
 	}
-	30% {
+	40% {
 		filter: brightness(1);
 	}
-	45% {
-		filter: brightness(1.4);
-	}
 	70% {
+		filter: brightness(var(--flash-brightness));
+	}
+	100% {
 		filter: brightness(1);
 	}
 }

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -297,7 +297,7 @@ li.plain span {
 }
 
 .search-flash {
-	animation: search-flash-anim 0.8s ease-out;
+	animation: search-flash-anim 1.5s ease-out;
 }
 
 @keyframes search-flash-anim {

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -298,7 +298,7 @@ li.plain span {
 
 .search-flash {
 	--flash-brightness: 1.5;
-	animation: search-flash-anim 1s ease-out;
+	animation: search-flash-anim 1.5s ease-out;
 }
 
 /* brightness() is multiplicative, so the dark incoming bubble needs a much

--- a/ui/src/lib/components/messages/message-helpers.ts
+++ b/ui/src/lib/components/messages/message-helpers.ts
@@ -64,3 +64,68 @@ export function highlightMatch(text: string, query: string): string {
 		'<mark class="search-highlight">$1</mark>',
 	);
 }
+
+const SCROLL_MOVE_EPSILON_PX = 0.5;
+const SCROLL_START_GRACE_MS = 100;
+const SCROLL_SETTLED_FRAMES = 3;
+const SCROLL_SETTLE_TIMEOUT_MS = 1500;
+
+/** Run `callback` once `el` has stopped moving under a smooth scroll, or right
+ * away if it never starts moving (target already in view, or the container is
+ * already at its scroll limit). Tracks the element's viewport position rather
+ * than a container's scrollTop so it doesn't need to know which ancestor
+ * scrolls. */
+function afterScrollSettles(el: Element, callback: () => void): void {
+	const start = performance.now();
+	let lastTop = el.getBoundingClientRect().top;
+	let moved = false;
+	let stableFrames = 0;
+
+	const tick = () => {
+		const top = el.getBoundingClientRect().top;
+		if (Math.abs(top - lastTop) > SCROLL_MOVE_EPSILON_PX) {
+			lastTop = top;
+			moved = true;
+			stableFrames = 0;
+		} else if (moved) {
+			stableFrames++;
+		}
+
+		const elapsed = performance.now() - start;
+		const settled = moved
+			? stableFrames >= SCROLL_SETTLED_FRAMES
+			: elapsed > SCROLL_START_GRACE_MS;
+		if (settled || elapsed > SCROLL_SETTLE_TIMEOUT_MS) {
+			callback();
+			return;
+		}
+		requestAnimationFrame(tick);
+	};
+	requestAnimationFrame(tick);
+}
+
+let pendingFlash = 0;
+
+/** Scroll `root` to the message with `hash` and flash its bubble once the
+ * scroll has landed. Used by both chat search and reply-quote navigation. */
+export function scrollToMessage(
+	root: HTMLElement | undefined,
+	hash: string,
+): void {
+	const el = root?.querySelector(`[data-message-hash="${hash}"]`);
+	if (!el) return;
+	el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+	root
+		?.querySelectorAll('.search-flash')
+		.forEach(e => e.classList.remove('search-flash'));
+
+	// Flashing on click would waste the animation on a long scroll: it can be
+	// over before the target comes into view.
+	const flash = ++pendingFlash;
+	afterScrollSettles(el, () => {
+		if (flash !== pendingFlash) return;
+		const card = el.closest('.message') ?? el.querySelector('.message') ?? el;
+		void (card as HTMLElement).offsetWidth;
+		card.classList.add('search-flash');
+	});
+}

--- a/ui/src/lib/components/messages/message-helpers.ts
+++ b/ui/src/lib/components/messages/message-helpers.ts
@@ -130,6 +130,8 @@ export function scrollToMessage(
 		void (card as HTMLElement).offsetWidth;
 		card.classList.add('search-flash');
 	});
+}
+
 /** Escaped HTML for a message body: http(s) urls become anchors, and search
  * matches are highlighted within each run. */
 export function messageTextHtml(text: string, query: string): string {

--- a/ui/src/routes/direct-chats/[agentId]/+page.svelte
+++ b/ui/src/routes/direct-chats/[agentId]/+page.svelte
@@ -55,7 +55,10 @@
 	import MessageFromOthers from '$lib/components/messages/MessageFromOthers.svelte';
 	import ReportMessage from '$lib/components/messages/ReportMessage.svelte';
 	import SystemMessage from '$lib/components/messages/SystemMessage.svelte';
-	import { messagePosition } from '$lib/components/messages/message-helpers';
+	import {
+		messagePosition,
+		scrollToMessage,
+	} from '$lib/components/messages/message-helpers';
 	import ConnectionStatusIndicator from '$lib/components/connection/ConnectionStatusIndicator.svelte';
 	import Divider from '$lib/components/Divider.svelte';
 	import SearchNavBar from '$lib/components/direct-chats/bottom-bar/SearchNavBar.svelte';
@@ -203,19 +206,11 @@
 	});
 
 	function scrollToMatch() {
-		if (!matchingHashes.length) return;
-		const hash = matchingHashes[currentMatchIndex];
-		const el = parentDivEl?.querySelector(`[data-message-hash="${hash}"]`);
-		if (!el) return;
-		el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-		// Remove flash from any previously flashing message
-		parentDivEl
-			?.querySelectorAll('.search-flash')
-			.forEach(e => e.classList.remove('search-flash'));
-		// Flash the current match's message card
-		const card = el.closest('.message') ?? el.querySelector('.message') ?? el;
-		void (card as HTMLElement).offsetWidth;
-		card.classList.add('search-flash');
+		if (matchingHashes.length === 0) return;
+		scrollToMessage(
+			parentDivEl ?? undefined,
+			matchingHashes[currentMatchIndex],
+		);
 	}
 
 	function goToPreviousMatch() {


### PR DESCRIPTION
In Replies, when scrolling up a long way to an older message, the flash can be over by the time the scroll completes. This delays the flash until the scroll has settled. Also adjusts the brightness and duration of the flash to match Signal better.