### PR TITLE
Fix reply quote text extraction for WebKit rendering

### DIFF
--- a/e2e-tests/helpers/components/messages.ts
+++ b/e2e-tests/helpers/components/messages.ts
@@ -530,10 +530,18 @@ export class Message extends TestHelper {
 		await this.composer.send();
 	}
 
-	/** Trimmed text of this message's reply quote, or null when it has none. */
+	/** Trimmed text of this message's reply quote, or null when it has none.
+	 * Read from the DOM rather than with `getText()`: the quote is a clipped
+	 * `<button>`, whose text WebKit's rendered-text algorithm leaves out. */
 	async replyQuoteText(): Promise<string | null> {
-		if (!(await this.replyQuote.isExisting())) return null;
-		return (await this.replyQuote.getText()).trim();
+		const text = await this.agent.execute(
+			(wrapperSel: string, quoteSel: string) =>
+				document.querySelector(wrapperSel)?.querySelector(quoteSel)
+					?.textContent ?? null,
+			this.wrapperSelector,
+			tid('reply-quote'),
+		);
+		return text === null ? null : text.trim();
 	}
 
 	/** Wait until this message renders a reply quote containing `quotedText`. */

--- a/e2e-tests/specs/report-contact.spec.ts
+++ b/e2e-tests/specs/report-contact.spec.ts
@@ -70,7 +70,7 @@ describe('report contact', () => {
 		await agent1.homePage.newMessageButton.click();
 		await agent1.newMessagePage.ready();
 
-		await agent1.newMessagePage.openContactMenu('Bob Test');
+		await agent1.newMessagePage.openContactMenu('Bob');
 		await agent1.newMessagePage.contactActionsMenu.report.click();
 		await agent1.newMessagePage.contactActionsMenu.reportConfirm.waitForClickable();
 		await agent1.newMessagePage.contactActionsMenu.reportConfirm.click();


### PR DESCRIPTION
## Summary
Fixed reply quote text extraction in e2e tests to work correctly with WebKit's text rendering algorithm, which omits text from clipped button elements.

## Changes
- **Message helper (`replyQuoteText`)**: Changed from using WebDriver's `getText()` method to directly reading `textContent` from the DOM via `execute()`. This works around a WebKit limitation where rendered-text algorithms skip text in clipped `<button>` elements.
  - Added explanatory comment documenting the WebKit rendering issue
  - Simplified null-coalescing logic in the return statement

- **Report contact spec**: Updated test to use shortened contact name `'Bob'` instead of `'Bob Test'` for consistency with actual test data

## Implementation Details
The reply quote is rendered as a clipped `<button>` element. WebKit's text rendering algorithm excludes such elements from `getText()` results, causing test failures. By querying `textContent` directly via JavaScript execution, we bypass the rendering algorithm and reliably extract the quote text.

https://claude.ai/code/session_01Vc8Gu7eet28fJF23FAFhvq