### PR TITLE
Match Signal's composer reply-banner greys in the iOS theme

### DIFF
--- a/ui/src/lib/components/messages/QuoteFrame.svelte
+++ b/ui/src/lib/components/messages/QuoteFrame.svelte
@@ -15,9 +15,10 @@
 </script>
 
 <span
-	class="quote-frame {mine
-		? 'quote-frame-mine'
-		: 'quote-frame-others'} {composer ? 'quote-frame-composer' : ''}"
+	class="quote-frame"
+	class:quote-frame-mine={mine}
+	class:quote-frame-others={!mine}
+	class:quote-frame-composer={composer}
 >
 	<span class="quote-frame-bar"></span>
 	{@render children()}

--- a/ui/src/lib/components/messages/QuoteFrame.svelte
+++ b/ui/src/lib/components/messages/QuoteFrame.svelte
@@ -3,15 +3,22 @@
 
 	let {
 		mine = false,
+		composer = false,
 		children,
 	}: {
 		/** Whether the frame sits inside my own (brand-colored) bubble. */
 		mine?: boolean;
+		/** Whether the frame sits in the composer's reply banner rather than a bubble. */
+		composer?: boolean;
 		children: Snippet;
 	} = $props();
 </script>
 
-<span class="quote-frame {mine ? 'quote-frame-mine' : 'quote-frame-others'}">
+<span
+	class="quote-frame {mine
+		? 'quote-frame-mine'
+		: 'quote-frame-others'} {composer ? 'quote-frame-composer' : ''}"
+>
 	<span class="quote-frame-bar"></span>
 	{@render children()}
 </span>
@@ -49,5 +56,19 @@
 	}
 	:global(.dark) .quote-frame-others {
 		background-color: rgba(255, 255, 255, 0.16);
+	}
+
+	/* The iOS theme copies Signal's composer reply-banner greys. */
+	:global(.k-ios) .quote-frame-composer {
+		background-color: #dfdfe1;
+	}
+	:global(.k-ios) .quote-frame-composer .quote-frame-bar {
+		background-color: #c1c1c3;
+	}
+	:global(.dark .k-ios) .quote-frame-composer {
+		background-color: #454547;
+	}
+	:global(.dark .k-ios) .quote-frame-composer .quote-frame-bar {
+		background-color: #5f5e63;
 	}
 </style>

--- a/ui/src/lib/components/messages/composer/ReplyBanner.svelte
+++ b/ui/src/lib/components/messages/composer/ReplyBanner.svelte
@@ -42,7 +42,7 @@
 	data-testid="composer-reply-banner"
 	transition:slide={{ duration: 200 }}
 >
-	<QuoteFrame>
+	<QuoteFrame composer>
 		<span class="row min-w-0 flex-1 items-center gap-2 ps-2 py-1.5">
 			<span class="column min-w-0 flex-1">
 				<span class="truncate font-semibold">


### PR DESCRIPTION
## Summary

In the iOS theme, the reply banner in the composer now uses Signal's grey quote colors instead of the white overlay (which was nearly invisible on the light glass composer). The Material theme and the in-bubble reply quotes are unchanged.

Colors are sampled pixel-exact from Signal iOS screenshots:

| Mode | Quote background | Bar |
|---|---|---|
| Light | `#DFDFE1` | `#C1C1C3` |
| Dark | `#454547` | `#5F5E63` |

- `QuoteFrame` gains a `composer` prop that adds a `quote-frame-composer` class with `.k-ios`-scoped overrides.
- `ReplyBanner` passes `composer`.

## Verification

- Ran the app and checked the reply banner in iOS light/dark: computed styles match the sampled Signal values exactly, and the contrast against the glass composer mirrors Signal's.
- Confirmed Material (light/dark) still renders the original white-overlay styling, and in-bubble quotes are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113KjvmUpSb8LPqZ5ANGZfK