### PR TITLE
Notification use OS setting on mobile

### DIFF
--- a/src-tauri/src/notifications/mod.rs
+++ b/src-tauri/src/notifications/mod.rs
@@ -34,15 +34,23 @@ pub(crate) async fn show_sync_notification(
     app_handle: &AppHandle,
     notification: &dashchat_node::OpNotification,
 ) {
-    if !are_notifications_enabled(app_handle) {
+    let op_hash = notification.header.hash();
+    log::debug!("[notification] show_sync_notification for op {op_hash}");
+
+    let settings_enabled = crate::settings::load_settings(app_handle).notifications_enabled;
+    let os_permission = app_handle.notification().permission_state();
+    if !settings_enabled || !matches!(os_permission, Ok(PermissionState::Granted)) {
+        log::debug!("[notification] skipping op {op_hash}: notifications disabled (settings_enabled={settings_enabled}, os_permission={os_permission:?})");
         return;
     }
 
     let Some(app_node_manager) = app_handle.try_state::<AppNodeManager>() else {
+        log::debug!("[notification] skipping op {op_hash}: AppNodeManager state unavailable");
         return;
     };
 
     let Ok(node) = app_node_manager.get().await else {
+        log::debug!("[notification] skipping op {op_hash}: node not ready");
         return;
     };
     let data = build_notification_data(
@@ -53,25 +61,34 @@ pub(crate) async fn show_sync_notification(
     )
     .await;
 
-    let Some(data) = data else { return };
+    let Some(data) = data else {
+        log::debug!(
+            "[notification] skipping op {op_hash}: no user-facing notification for this op"
+        );
+        return;
+    };
 
     match app_node_manager
         .notified_operations_store()
-        .record_notified_operation(notification.header.hash())
+        .record_notified_operation(op_hash)
         .await
     {
         Ok(false) => {
-            log::debug!("Skipping sync notification: op already notified");
+            log::debug!("[notification] skipping op {op_hash}: already notified");
             return;
         }
         Ok(true) => {}
         Err(err) => {
-            log::error!("Failed to record notified operation: {err:?} — proceeding anyway");
+            log::error!("[notification] failed to record notified op {op_hash}: {err:?} — proceeding anyway");
         }
     }
 
-    if let Err(err) = show_notification_from_data(app_handle, data) {
-        log::error!("Failed to show sync-path notification: {err:?}");
+    log::debug!("[notification] sending op {op_hash} to system");
+    match show_notification_from_data(app_handle, data) {
+        Ok(()) => log::debug!("[notification] sent op {op_hash} to system"),
+        Err(err) => log::error!(
+            "[notification] failed to show sync-path notification for op {op_hash}: {err:?}"
+        ),
     }
 }
 
@@ -123,7 +140,7 @@ pub async fn build_notification_data(
     let id = match stable_notification_id(header.hash().as_bytes()) {
         Ok(id) => id,
         Err(err) => {
-            log::error!("Failed to derive stable notification id: {err:?}");
+            log::error!("[notification] failed to derive stable notification id: {err:?}");
             return None;
         }
     };
@@ -171,7 +188,9 @@ async fn chat_message_notification(
     let sender_agent_id = match node.lookup_contact(sender_device_id).await {
         Ok(agent_id) => agent_id,
         Err(err) => {
-            log::error!("Failed to lookup contact for sender {sender_device_id:?}: {err:?}");
+            log::error!(
+                "[notification] failed to lookup contact for sender {sender_device_id:?}: {err:?}"
+            );
             None
         }
     };

--- a/src-tauri/src/notifications/mod.rs
+++ b/src-tauri/src/notifications/mod.rs
@@ -15,15 +15,23 @@ use tauri_plugin_notification::{NotificationData, NotificationExt, PermissionSta
 
 use crate::node::AppNodeManager;
 
-/// Returns `true` iff the user has both enabled notifications in app settings
-/// and granted OS-level permission. On desktop the permission state is always
-/// `Granted` so this collapses to the settings check.
+/// Returns `true` iff notifications should be shown. The OS-level permission is
+/// always required; on desktop the app-level toggle must additionally be on. On
+/// mobile the app-level toggle doesn't exist, so the OS permission is the single
+/// source of truth.
 pub(crate) fn are_notifications_enabled(handle: &AppHandle) -> bool {
-    crate::settings::load_settings(handle).notifications_enabled
-        && matches!(
-            handle.notification().permission_state(),
-            Ok(PermissionState::Granted)
-        )
+    let os_granted = matches!(
+        handle.notification().permission_state(),
+        Ok(PermissionState::Granted)
+    );
+    #[cfg(desktop)]
+    {
+        os_granted && crate::settings::load_settings(handle).notifications_enabled
+    }
+    #[cfg(mobile)]
+    {
+        os_granted
+    }
 }
 
 /// Show a system notification for an operation that arrived through the
@@ -37,10 +45,8 @@ pub(crate) async fn show_sync_notification(
     let op_hash = notification.header.hash();
     log::debug!("[notification] show_sync_notification for op {op_hash}");
 
-    let settings_enabled = crate::settings::load_settings(app_handle).notifications_enabled;
-    let os_permission = app_handle.notification().permission_state();
-    if !settings_enabled || !matches!(os_permission, Ok(PermissionState::Granted)) {
-        log::debug!("[notification] skipping op {op_hash}: notifications disabled (settings_enabled={settings_enabled}, os_permission={os_permission:?})");
+    if !are_notifications_enabled(app_handle) {
+        log::debug!("[notification] skipping op {op_hash}: notifications disabled (app toggle off or OS permission not granted)");
         return;
     }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -26,11 +26,11 @@ impl Default for Settings {
     }
 }
 
-// On desktop the OS-level permission is always granted, so default the
-// app-level toggle to ON. On mobile the user has to grant permission
-// through the OS dialog, which we tie to flipping the toggle ON.
+// The app-level toggle only exists on desktop; on mobile the OS-level
+// permission is the single source of truth, so default the flag to ON there
+// too and skip the app-level check when deciding to notify.
 const fn default_notifications_enabled() -> bool {
-    cfg!(desktop)
+    true
 }
 
 pub(crate) fn load_settings<R: Runtime>(handle: &AppHandle<R>) -> Settings {

--- a/ui/src/lib/components/layout/SettingsPanel.svelte
+++ b/ui/src/lib/components/layout/SettingsPanel.svelte
@@ -25,7 +25,7 @@
 	} from 'konsta/svelte';
 	import TitleTruncatedListItem from '$lib/components/TitleTruncatedListItem.svelte';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
-	import { isIos } from '$lib/utils/environment';
+	import { isIos, isMobile } from '$lib/utils/environment';
 	import type { Action } from 'svelte/action';
 	import Avatar from '../profiles/Avatar.svelte';
 
@@ -136,19 +136,21 @@
 					></wa-icon>
 				{/snippet}
 			</ListItem>
-			<ListItem
-				link
-				class={isActive('/settings/notifications') ? 'active' : ''}
-				linkProps={{ href: '/settings/notifications' }}
-				data-testid="settings-notifications-link"
-				title={m.notifications()}
-				chevron={false}
-			>
-				{#snippet media()}
-					<wa-icon src={wrapPathInSvg(mdiBellOutline)} style="font-size: 28px"
-					></wa-icon>
-				{/snippet}
-			</ListItem>
+			{#if !isMobile}
+				<ListItem
+					link
+					class={isActive('/settings/notifications') ? 'active' : ''}
+					linkProps={{ href: '/settings/notifications' }}
+					data-testid="settings-notifications-link"
+					title={m.notifications()}
+					chevron={false}
+				>
+					{#snippet media()}
+						<wa-icon src={wrapPathInSvg(mdiBellOutline)} style="font-size: 28px"
+						></wa-icon>
+					{/snippet}
+				</ListItem>
+			{/if}
 		</List>
 
 		{#if !isIos}

--- a/ui/src/routes/settings/notifications/+page.svelte
+++ b/ui/src/routes/settings/notifications/+page.svelte
@@ -2,6 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { m } from '$lib/paraglide/messages.js';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
+	import { isMobile } from '$lib/utils/environment';
 	import { useReactivePromise } from '$lib/stores/use-signal';
 	import {
 		BlockTitle,
@@ -75,21 +76,23 @@
 	</Navbar>
 
 	<div class="column" style="flex: 1">
-		<div class="column center-in-desktop">
-			<BlockTitle>{m.messages()}</BlockTitle>
-			<List strongIos inset={isWideScreen.value || theme === 'ios'}>
-				<ListItem title={m.notifications()} data-testid="notifications-toggle">
-					{#snippet after()}
-						{#await $notificationsEnabled then enabled}
-							<Toggle
-								checked={enabled}
-								disabled={toggling}
-								onChange={() => (enabled ? disable() : enable())}
-							/>
-						{/await}
-					{/snippet}
-				</ListItem>
-			</List>
-		</div>
+		{#if !isMobile}
+			<div class="column center-in-desktop">
+				<BlockTitle>{m.messages()}</BlockTitle>
+				<List strongIos inset={isWideScreen.value || theme === 'ios'}>
+					<ListItem title={m.notifications()} data-testid="notifications-toggle">
+						{#snippet after()}
+							{#await $notificationsEnabled then enabled}
+								<Toggle
+									checked={enabled}
+									disabled={toggling}
+									onChange={() => (enabled ? disable() : enable())}
+								/>
+							{/await}
+						{/snippet}
+					</ListItem>
+				</List>
+			</div>
+		{/if}
 	</div>
 </Page>


### PR DESCRIPTION
On mobile ensure that:

- In-app notification setting defaults to true
- Attempts to send notifications don't even check the in-app setting, only use OS setting
- The notification setting in the app doesn't display

Also, add better trace statements, containing the "[notification]" string for easier grepping.