### PR TITLE
Disable message actions in read-only chats

### DIFF
--- a/e2e-tests/helpers/components/messages.ts
+++ b/e2e-tests/helpers/components/messages.ts
@@ -613,6 +613,17 @@ export class Message extends TestHelper {
 		return this.wrapper.$(tid('message-hover-reply'));
 	}
 
+	/** The hover toolbar's add-reaction button. */
+	get hoverReactButton() {
+		return this.wrapper.$(tid('message-hover-react'));
+	}
+
+	/** This message's quick-reaction bar (in the mobile spotlight overlay or
+	 * the desktop hover popover). */
+	get quickReactionBar() {
+		return this.wrapper.$(tid('quick-reaction-bar'));
+	}
+
 	/** Open the actions menu, tap Reply, type `replyText`, and send it. */
 	async reply(replyText: string): Promise<void> {
 		await this.openActions();

--- a/e2e-tests/specs/block-contact.spec.ts
+++ b/e2e-tests/specs/block-contact.spec.ts
@@ -18,6 +18,8 @@ describe('block contact', () => {
 	});
 
 	it('blocks from chat settings and shows the indicators', async () => {
+		await agent1.directChatPage.composer.sendMessage('Hello Bob');
+
 		await blockAgent(agent1);
 		await agent1.directChatPage.blockedBanner.waitForDisplayed();
 		await agent1.directChatPage.blockedNameIcon.waitForDisplayed();
@@ -28,6 +30,29 @@ describe('block contact', () => {
 		await expect(
 			agent2.directChatPage.messages.systemMessage('contact_blocked'),
 		).not.toBeExisting();
+
+		// The chat turns read-only: no swipe, react, reply, or edit — only the
+		// local actions remain. Copy doubles as the way to close the menu again.
+		const target =
+			await agent1.directChatPage.messages.waitForMessage('Hello Bob');
+		if (agent1.platform !== 'desktop') {
+			const engaged = await agent1.execute(
+				(hash: string) => window.__test.swipeToReply(hash),
+				target.hash,
+			);
+			expect(engaged).toBe(false);
+		} else {
+			await expect(target.hoverReplyButton).not.toBeExisting();
+			await expect(target.hoverReactButton).not.toBeExisting();
+		}
+		await target.openActions();
+		if (agent1.platform !== 'desktop') {
+			await expect(target.quickReactionBar).not.toBeExisting();
+		}
+		await expect(target.replyAction).not.toBeExisting();
+		await expect(target.editAction).not.toBeExisting();
+		await expect(target.copyAction).toBeExisting();
+		await target.copyAction.click();
 
 		await agent1.directChatPage.back.click();
 		await agent1.homePage.ready();
@@ -51,6 +76,14 @@ describe('block contact', () => {
 		await expect(
 			agent1.directChatPage.messages.systemMessage('contact_blocked'),
 		).toBeExisting();
+
+		// Unblocking makes the chat writable again, so the actions return.
+		const target =
+			await agent1.directChatPage.messages.waitForMessage('Hello Bob');
+		await target.openActions();
+		await expect(target.replyAction).toBeExisting();
+		await expect(target.editAction).toBeExisting();
+		await target.copyAction.click();
 	});
 
 	it('blocks from the new-message contact menu', async () => {

--- a/e2e-tests/specs/groups/leave-group.spec.ts
+++ b/e2e-tests/specs/groups/leave-group.spec.ts
@@ -29,6 +29,7 @@ describe('Leaving group', () => {
 		await createGroup(agent1, 'Solo Group', null);
 
 		await agent1.groupChatPage.ready();
+		await agent1.groupChatPage.composer.sendMessage('Hello group');
 		await agent1.groupChatPage.infoLink.click();
 		await agent1.groupInfoPage.ready();
 
@@ -66,6 +67,41 @@ describe('Leaving group', () => {
 
 		await agent1.groupInfoPage.back.click();
 		await agent1.groupChatPage.ready();
+		await agent1.groupChatPage.back.click();
+		await agent1.homePage.ready();
+	});
+
+	it('no longer offers reply, edit, or reactions after leaving', async function () {
+		await agent1.homePage.chatListItem('Solo Group').click();
+		await agent1.groupChatPage.ready();
+
+		const target =
+			await agent1.groupChatPage.messages.waitForMessage('Hello group');
+
+		// SwipeToReply only renders on mobile; the hover toolbar only on desktop.
+		if (agent1.platform !== 'desktop') {
+			const engaged = await agent1.execute(
+				(hash: string) => window.__test.swipeToReply(hash),
+				target.hash,
+			);
+			expect(engaged).toBe(false);
+		} else {
+			await expect(target.hoverReplyButton).not.toBeExisting();
+			await expect(target.hoverReactButton).not.toBeExisting();
+		}
+
+		// The actions menu keeps only the local actions — no reply or edit, and
+		// the mobile spotlight carries no reaction bar. Copy doubles as the way
+		// to close the menu again.
+		await target.openActions();
+		if (agent1.platform !== 'desktop') {
+			await expect(target.quickReactionBar).not.toBeExisting();
+		}
+		await expect(target.replyAction).not.toBeExisting();
+		await expect(target.editAction).not.toBeExisting();
+		await expect(target.copyAction).toBeExisting();
+		await target.copyAction.click();
+
 		await agent1.groupChatPage.back.click();
 		await agent1.homePage.ready();
 	});

--- a/packages/stores/src/chats/messages-store.ts
+++ b/packages/stores/src/chats/messages-store.ts
@@ -1,4 +1,4 @@
-import { reactive } from 'signalium';
+import { ReactivePromise, reactive } from 'signalium';
 
 import { ContactsStore } from '../contacts/contacts-store';
 import { LogsStore } from '../p2panda/logs-store';
@@ -59,6 +59,7 @@ export class MessagesStore {
 		protected tombstoneStore: TombstoneStore,
 		public chatId: ChatId,
 		public client: IMessagesClient,
+		public readOnly: () => ReactivePromise<boolean>,
 	) {}
 
 	messages = reactive(async () => {

--- a/packages/stores/src/direct-chats/direct-chat-store.ts
+++ b/packages/stores/src/direct-chats/direct-chat-store.ts
@@ -36,6 +36,7 @@ export class DirectChatStore {
 			tombstoneStore,
 			chatId,
 			messagesClient,
+			reactive(async () => false),
 		);
 	}
 

--- a/packages/stores/src/direct-chats/direct-chat-store.ts
+++ b/packages/stores/src/direct-chats/direct-chat-store.ts
@@ -36,7 +36,7 @@ export class DirectChatStore {
 			tombstoneStore,
 			chatId,
 			messagesClient,
-			reactive(async () => false),
+			reactive(async () => await this.isBlocked()),
 		);
 	}
 

--- a/packages/stores/src/group-chats/group-chat-store.ts
+++ b/packages/stores/src/group-chats/group-chat-store.ts
@@ -53,6 +53,7 @@ export class GroupChatStore {
 			tombstoneStore,
 			chatId,
 			messagesClient,
+			reactive(async () => !(await this.me()).member),
 		);
 		this.logsStore.logsClient.onNewOperation((topicId, op) => {
 			if (topicId === this.chatId && op.header.auth) {

--- a/ui/src/lib/components/SpotlightOverlay.svelte
+++ b/ui/src/lib/components/SpotlightOverlay.svelte
@@ -15,8 +15,9 @@
 		/** Hide the anchored popovers while keeping the backdrop as the single,
 		 * steady dim (e.g. while a sheet covers the overlay). */
 		contentHidden?: boolean;
-		/** Rendered in a pill-shaped popover above the target. */
-		above: Snippet;
+		/** Rendered in a pill-shaped popover above the target; omit to show no
+		 * popover there. */
+		above?: Snippet;
 		/** Rendered in a popover below the target. */
 		below: Snippet;
 	}
@@ -144,8 +145,8 @@
 		const base = target.getBoundingClientRect();
 		baseRect = base;
 		bump = untrack(() =>
-			aboveEl && belowEl
-				? ensembleBump(base, aboveEl.offsetHeight, belowEl.offsetHeight)
+			belowEl
+				? ensembleBump(base, aboveEl?.offsetHeight ?? 0, belowEl.offsetHeight)
 				: 0,
 		);
 		// Konsta popovers only re-read their anchors on window resize; nudge
@@ -216,16 +217,18 @@
 	></div>
 {/if}
 
-<Popover
-	opened={panelsShown && aboveAnchor !== undefined}
-	target={aboveAnchor}
-	backdrop={false}
-	class="!z-[36] !w-auto !rounded-full !origin-bottom [&>div]:!translate-y-0 {panelDelay}"
->
-	<div bind:this={aboveEl}>
-		{@render above()}
-	</div>
-</Popover>
+{#if above}
+	<Popover
+		opened={panelsShown && aboveAnchor !== undefined}
+		target={aboveAnchor}
+		backdrop={false}
+		class="!z-[36] !w-auto !rounded-full !origin-bottom [&>div]:!translate-y-0 {panelDelay}"
+	>
+		<div bind:this={aboveEl}>
+			{@render above()}
+		</div>
+	</Popover>
+{/if}
 
 <Popover
 	opened={panelsShown && belowAnchor !== undefined}

--- a/ui/src/lib/components/messages/MessageActionsMenu.svelte
+++ b/ui/src/lib/components/messages/MessageActionsMenu.svelte
@@ -7,7 +7,9 @@
 		mdiReply,
 	} from '@mdi/js';
 	import { List } from 'konsta/svelte';
-	import type { DeviceId, Message } from 'dash-chat-stores';
+	import { getContext } from 'svelte';
+	import type { DeviceId, Message, MessagesStore } from 'dash-chat-stores';
+	import { useReactivePromise } from '$lib/stores/use-signal';
 	import { canEditMessage } from './message-helpers';
 	import ListAction from '$lib/components/navigation/ListAction.svelte';
 	import DeleteMessageDialog from './DeleteMessageDialog.svelte';
@@ -38,28 +40,33 @@
 		testid = 'message-actions-menu',
 	}: Props = $props();
 
+	const store: MessagesStore = getContext('messages-store');
+	const readOnly = useReactivePromise(store.readOnly);
+
 	const canEdit = $derived(canEditMessage(message, myDeviceId));
 
 	let confirmingDelete = $state(false);
 </script>
 
 <List nested data-testid={testid}>
-	{#if canEdit}
-		<ListAction
-			title={m.edit()}
-			icon={mdiPencilOutline}
-			onClick={() => onEdit?.()}
-			data-testid="message-action-edit"
-		/>
-	{/if}
-	{#if onReply}
-		<ListAction
-			title={m.reply()}
-			icon={mdiReply}
-			onClick={onReply}
-			data-testid="message-action-reply"
-		/>
-	{/if}
+	{#await $readOnly then readOnly}
+		{#if canEdit && !readOnly}
+			<ListAction
+				title={m.edit()}
+				icon={mdiPencilOutline}
+				onClick={() => onEdit?.()}
+				data-testid="message-action-edit"
+			/>
+		{/if}
+		{#if onReply && !readOnly}
+			<ListAction
+				title={m.reply()}
+				icon={mdiReply}
+				onClick={onReply}
+				data-testid="message-action-reply"
+			/>
+		{/if}
+	{/await}
 	<ListAction
 		title={m.menuCopy()}
 		icon={mdiContentCopy}

--- a/ui/src/lib/components/messages/MessageActionsMenu.svelte
+++ b/ui/src/lib/components/messages/MessageActionsMenu.svelte
@@ -50,21 +50,23 @@
 
 <List nested data-testid={testid}>
 	{#await $readOnly then readOnly}
-		{#if canEdit && !readOnly}
-			<ListAction
-				title={m.edit()}
-				icon={mdiPencilOutline}
-				onClick={() => onEdit?.()}
-				data-testid="message-action-edit"
-			/>
-		{/if}
-		{#if onReply && !readOnly}
-			<ListAction
-				title={m.reply()}
-				icon={mdiReply}
-				onClick={onReply}
-				data-testid="message-action-reply"
-			/>
+		{#if !readOnly}
+			{#if canEdit}
+				<ListAction
+					title={m.edit()}
+					icon={mdiPencilOutline}
+					onClick={() => onEdit?.()}
+					data-testid="message-action-edit"
+				/>
+			{/if}
+			{#if onReply}
+				<ListAction
+					title={m.reply()}
+					icon={mdiReply}
+					onClick={onReply}
+					data-testid="message-action-reply"
+				/>
+			{/if}
 		{/if}
 	{/await}
 	<ListAction

--- a/ui/src/lib/components/messages/MessageActionsOverlay.svelte
+++ b/ui/src/lib/components/messages/MessageActionsOverlay.svelte
@@ -7,6 +7,7 @@
 		type MessagesStore,
 		hasBody,
 	} from 'dash-chat-stores';
+	import { useReactivePromise } from '$lib/stores/use-signal';
 	import SpotlightOverlay from '$lib/components/SpotlightOverlay.svelte';
 	import QuickReactionBar from './QuickReactionBar.svelte';
 	import MessageActionsMenu from './MessageActionsMenu.svelte';
@@ -35,6 +36,7 @@
 	}: Props = $props();
 
 	const store: MessagesStore = getContext('messages-store');
+	const readOnly = useReactivePromise(store.readOnly);
 
 	let expanded = $state(false);
 
@@ -70,25 +72,34 @@
 	}
 </script>
 
-<SpotlightOverlay {opened} {target} onClose={close} contentHidden={expanded}>
-	{#snippet above()}
-		<QuickReactionBar
-			{message}
-			onReact={react}
-			onExpand={() => (expanded = true)}
-		/>
-	{/snippet}
-	{#snippet below()}
-		<MessageActionsMenu
-			{message}
-			{myDeviceId}
-			onEdit={edit}
-			onReply={onReply ? reply : undefined}
-			onCopy={copy}
-			onDelete={close}
-		/>
-	{/snippet}
-</SpotlightOverlay>
+{#snippet reactionBar()}
+	<QuickReactionBar
+		{message}
+		onReact={react}
+		onExpand={() => (expanded = true)}
+	/>
+{/snippet}
+
+{#await $readOnly then readOnly}
+	<SpotlightOverlay
+		{opened}
+		{target}
+		onClose={close}
+		contentHidden={expanded}
+		above={readOnly ? undefined : reactionBar}
+	>
+		{#snippet below()}
+			<MessageActionsMenu
+				{message}
+				{myDeviceId}
+				onEdit={edit}
+				onReply={onReply ? reply : undefined}
+				onCopy={copy}
+				onDelete={close}
+			/>
+		{/snippet}
+	</SpotlightOverlay>
+{/await}
 
 {#if opened}
 	<ExpandedReactionsSheet {message} opened={expanded} onReact={react} />

--- a/ui/src/lib/components/messages/MessageHoverToolbar.svelte
+++ b/ui/src/lib/components/messages/MessageHoverToolbar.svelte
@@ -15,6 +15,7 @@
 		type MessagesStore,
 		hasBody,
 	} from 'dash-chat-stores';
+	import { useReactivePromise } from '$lib/stores/use-signal';
 	import IconButton from '$lib/components/IconButton.svelte';
 	import QuickReactionBar from './QuickReactionBar.svelte';
 	import MessageActionsMenu from './MessageActionsMenu.svelte';
@@ -41,6 +42,7 @@
 	}: Props = $props();
 
 	const store: MessagesStore = getContext('messages-store');
+	const readOnly = useReactivePromise(store.readOnly);
 
 	let open = $state<'reactions' | 'menu' | null>(null);
 
@@ -115,27 +117,32 @@
 		class="flex items-center gap-0.5 {reverse ? 'flex-row-reverse' : ''}"
 		data-testid="message-hover-toolbar"
 	>
-		<span bind:this={reactEl}>
-			<IconButton
-				onClick={() => (open = 'reactions')}
-				label={m.addReaction()}
-				testid="message-hover-react"
-				class="!h-9 !w-9"
-			>
-				<wa-icon class="text-xl" src={wrapPathInSvg(mdiHeartPlusOutline)}
-				></wa-icon>
-			</IconButton>
-		</span>
-		{#if onReply}
-			<IconButton
-				onClick={reply}
-				label={m.reply()}
-				testid="message-hover-reply"
-				class="!h-9 !w-9"
-			>
-				<wa-icon class="text-xl" src={wrapPathInSvg(mdiReplyOutline)}></wa-icon>
-			</IconButton>
-		{/if}
+		{#await $readOnly then readOnly}
+			{#if !readOnly}
+				<span bind:this={reactEl}>
+					<IconButton
+						onClick={() => (open = 'reactions')}
+						label={m.addReaction()}
+						testid="message-hover-react"
+						class="!h-9 !w-9"
+					>
+						<wa-icon class="text-xl" src={wrapPathInSvg(mdiHeartPlusOutline)}
+						></wa-icon>
+					</IconButton>
+				</span>
+			{/if}
+			{#if onReply && !readOnly}
+				<IconButton
+					onClick={reply}
+					label={m.reply()}
+					testid="message-hover-reply"
+					class="!h-9 !w-9"
+				>
+					<wa-icon class="text-xl" src={wrapPathInSvg(mdiReplyOutline)}
+					></wa-icon>
+				</IconButton>
+			{/if}
+		{/await}
 		<span bind:this={menuEl}>
 			<IconButton
 				onClick={() => (open = 'menu')}

--- a/ui/src/lib/components/messages/ReactionsSheet.svelte
+++ b/ui/src/lib/components/messages/ReactionsSheet.svelte
@@ -6,7 +6,7 @@
 	import { condenseReactions } from '$lib/utils/emojis';
 	import { isWideScreen } from '$lib/stores/screen.svelte';
 	import { useMyAgentId } from '$lib/stores/my-agent-id';
-	import { useReactivePromise } from '$lib/stores/use-signal';
+	import { useReactivePromises } from '$lib/stores/use-signal';
 	import Modal from '$lib/components/Modal.svelte';
 	import SheetHandle from '$lib/components/SheetHandle.svelte';
 	import Avatar from '$lib/components/profiles/Avatar.svelte';
@@ -24,7 +24,10 @@
 	const store: MessagesStore = getContext('messages-store');
 	const myAgentId = useMyAgentId();
 
-	const profiles = useReactivePromise(store.membersProfiles);
+	const listData = useReactivePromises(() => [
+		store.membersProfiles(),
+		store.readOnly(),
+	]);
 
 	const entries = $derived(
 		Object.entries(reactions) as Array<[AgentId, string]>,
@@ -98,11 +101,11 @@
 			{@render emojiTab(reaction.emoji, reaction.count)}
 		{/each}
 	</div>
-	{#await $profiles then profiles}
+	{#await $listData then [profiles, readOnly]}
 		<List class="!my-2">
 			{#each filtered as [agentId, emoji] (agentId)}
 				{@const own = agentId === myAgentId}
-				{@const removable = own && !isWideScreen.value}
+				{@const removable = own && !isWideScreen.value && !readOnly}
 				{@const profile = profiles[agentId]}
 				<ListItem
 					link={removable}

--- a/ui/src/lib/components/messages/SwipeToReply.svelte
+++ b/ui/src/lib/components/messages/SwipeToReply.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import '@awesome.me/webawesome/dist/components/icon/icon.js';
-	import type { Snippet } from 'svelte';
+	import { getContext, type Snippet } from 'svelte';
 	import { mdiReplyOutline } from '@mdi/js';
+	import type { MessagesStore } from 'dash-chat-stores';
+	import { useReactiveValue } from '$lib/stores/use-signal';
 	import { wrapPathInSvg } from '$lib/utils/icon';
 
 	let {
@@ -16,6 +18,12 @@
 		target?: HTMLElement;
 		children: Snippet;
 	} = $props();
+
+	const store: MessagesStore = getContext('messages-store');
+	// Read synchronously rather than via {#await}: the gate sits in a touch
+	// handler, out of reach of markup awaits.
+	const readOnlyChat = useReactiveValue(store.readOnly);
+	const readOnly = $derived($readOnlyChat ?? false);
 
 	// Distances mirror Signal Android's ConversationSwipeAnimationHelper
 	// (TRIGGER_DX = 64dp, icon slide = 10dp).
@@ -65,7 +73,12 @@
 	}
 
 	function onTouchStart(e: TouchEvent) {
-		if (onReply === undefined || target === undefined || e.touches.length !== 1)
+		if (
+			readOnly ||
+			onReply === undefined ||
+			target === undefined ||
+			e.touches.length !== 1
+		)
 			return;
 		startX = e.touches[0].clientX;
 		startY = e.touches[0].clientY;

--- a/ui/src/lib/components/messages/SwipeToReply.svelte
+++ b/ui/src/lib/components/messages/SwipeToReply.svelte
@@ -21,9 +21,11 @@
 
 	const store: MessagesStore = getContext('messages-store');
 	// Read synchronously rather than via {#await}: the gate sits in a touch
-	// handler, out of reach of markup awaits.
+	// handler, out of reach of markup awaits. Default to read-only while the
+	// value is pending so the gesture fails closed, like the {#await}-gated
+	// surfaces.
 	const readOnlyChat = useReactiveValue(store.readOnly);
-	const readOnly = $derived($readOnlyChat ?? false);
+	const readOnly = $derived($readOnlyChat ?? true);
 
 	// Distances mirror Signal Android's ConversationSwipeAnimationHelper
 	// (TRIGGER_DX = 64dp, icon slide = 10dp).

--- a/ui/tests/setup-utils.ts
+++ b/ui/tests/setup-utils.ts
@@ -275,11 +275,12 @@ function collectFilePickers(): FilePickerRequest[] {
 	return filePickerRequests;
 }
 
-/** Drag a message row start-to-end far enough to trigger swipe-to-reply.
- * Synthesized as bare events with a `touches` list: WebKit and Chromium
- * disagree about constructing real `Touch` objects, and the handler only
- * reads coordinates. */
-function swipeToReply(messageHash: string): void {
+/** Drag a message row start-to-end far enough to trigger swipe-to-reply, and
+ * report whether the gesture claimed the drag — observed synchronously through
+ * touchmove's preventDefault. Synthesized as bare events with a `touches`
+ * list: WebKit and Chromium disagree about constructing real `Touch` objects,
+ * and the handler only reads coordinates. */
+function swipeToReply(messageHash: string): boolean {
 	const row = document.querySelector(
 		`[data-message-hash="${messageHash}"] [data-testid="swipe-to-reply"]`,
 	);
@@ -293,12 +294,13 @@ function swipeToReply(messageHash: string): void {
 		Object.defineProperty(event, 'touches', {
 			value: [{ clientX: x, clientY: 100 }],
 		});
-		row.dispatchEvent(event);
+		return row.dispatchEvent(event);
 	};
 	send('touchstart', startX);
 	send('touchmove', startX + sign * 20);
-	send('touchmove', startX + sign * 100);
+	const claimed = !send('touchmove', startX + sign * 100);
 	send('touchend', startX + sign * 100);
+	return claimed;
 }
 
 export const testUtils = {


### PR DESCRIPTION
## Summary

After leaving a group you could still swipe-to-reply, react, and edit messages — actions that publish operations into a chat you can no longer write to. This PR introduces a read-only notion for chats at the store layer and disables those actions across every surface.

- **`MessagesStore.readOnly`**: a required, public `() => ReactivePromise<boolean>` constructor dependency. `GroupChatStore` wires it to `!me().member`; `DirectChatStore` passes a constant `false`.
- Components read it from the `messages-store` context (no prop drilling):
  - `SwipeToReply` — the gesture goes inert (`useReactiveValue`, since the gate sits in a touch handler).
  - `MessageActionsMenu` — Reply and Edit items are hidden; Copy and Delete (local actions) remain.
  - `MessageHoverToolbar` — the React and Reply buttons are hidden; the ⋯ menu remains.
  - `MessageActionsOverlay` — the long-press spotlight no longer shows the quick-reaction bar (`SpotlightOverlay.above` is now optional, and the ensemble bump handles the missing bar).
  - `ReactionsSheet` — tap-to-remove your own reaction is disabled; reaction chips stay visible and the who-reacted sheet stays browsable.

Note: enforcement is UI-level; rejecting non-member ops in the backend is separate work.