### PR TITLE
Fix the local-hub-discovery e2e failures on switch-mdns-stack

### DIFF
--- a/crates/mailbox-local-server/src/main.rs
+++ b/crates/mailbox-local-server/src/main.rs
@@ -40,7 +40,8 @@ async fn main() -> anyhow::Result<()> {
             .public()
     };
 
-    // Held until the process exits; its `Drop` retires the announcement.
+    // Held until the process exits, when its `Drop` stops the announcement.
+    // Nothing goes on the wire to say so — browsers notice once it ages out.
     let _announcement = mailbox_local_server::spawn_local_hub_announcement(endpoint_id, args.port)?;
 
     let signal = tokio::signal::ctrl_c().map(|f| f.expect("failed to listen for event"));

--- a/e2e-tests/helpers/fuzz/checks.ts
+++ b/e2e-tests/helpers/fuzz/checks.ts
@@ -27,6 +27,14 @@ import type {
  *  user reads the app as slow or broken. */
 export const DISCOVERY_MS = 2_000;
 
+/** What a hub that stopped gets before it has to be off the chip. Longer than
+ *  [`DISCOVERY_MS`] because nothing goes on the wire when a hub goes away —
+ *  swarm-discovery neither sends a goodbye nor reads one — so a phone only
+ *  notices once the hub ages out of its swarm: 3τ of silence (2.1s at the
+ *  interactive cadence, for up to two hubs) checked on a ~0.86s sweep, then the
+ *  app's own unregister. 4s clears that worst case with margin. */
+export const DEPARTURE_MS = 4_000;
+
 /** Open `chat` on `sa` and check it against the model before returning. */
 export async function openChat(
 	sa: StressAgent,
@@ -123,8 +131,8 @@ export async function expectHubs(
 		// settling after a restart or resume, be hidden — both mean no local
 		// hub, which is all this asserts.
 		await chip.waitForNotLocal(
-			DISCOVERY_MS,
-			`${sa.name}: the chip still showed a hub ${DISCOVERY_MS / 1_000}s after ${after}`,
+			DEPARTURE_MS,
+			`${sa.name}: the chip still showed a hub ${DEPARTURE_MS / 1_000}s after ${after}`,
 		);
 		return;
 	}

--- a/e2e-tests/setup/local-hub.ts
+++ b/e2e-tests/setup/local-hub.ts
@@ -100,10 +100,11 @@ function signalHub(hub: LocalHub, signal: NodeJS.Signals): void {
 }
 
 /**
- * Stop a hub and wait for it to exit. SIGINT by default: the hub only sends
- * its mDNS goodbye on a graceful shutdown, and without one every phone on the
- * LAN keeps its records cached until they age out. SIGKILL is for a spec that
- * wants exactly that: a hub that vanished without a word.
+ * Stop a hub and wait for it to exit. SIGINT by default, so the hub gets to run
+ * its shutdown; SIGKILL is for a spec that wants it to vanish mid-flight. Either
+ * way nothing goes out on the wire to retire the announcement — a phone only
+ * notices once the hub ages out of its swarm — so the two look alike to
+ * discovery.
  */
 export function stopLocalHub(
 	hub: LocalHub,

--- a/e2e-tests/specs/local-hub-discovery.spec.ts
+++ b/e2e-tests/specs/local-hub-discovery.spec.ts
@@ -14,7 +14,7 @@
  * real access points.
  */
 import { createGroup } from '../helpers/flows/exchange-contacts-and-create-group';
-import { DISCOVERY_MS } from '../helpers/fuzz/checks';
+import { DEPARTURE_MS, DISCOVERY_MS } from '../helpers/fuzz/checks';
 import { MDNS_RECORD_TTL_S } from '../helpers/fuzz/moves/network';
 import { UI_TIMEOUT } from '../helpers/timeouts';
 import { joinWifi, leaveWifi, wifiDevice } from '../setup/host-wifi';
@@ -61,8 +61,8 @@ describe('Local hub discovery', function () {
 
 	async function expectNoHub(after: string): Promise<void> {
 		await chip().waitForNotLocal(
-			DISCOVERY_MS,
-			`the chip still showed the hub ${DISCOVERY_MS / 1_000}s after ${after}`,
+			DEPARTURE_MS,
+			`the chip still showed the hub ${DEPARTURE_MS / 1_000}s after ${after}`,
 		);
 	}
 

--- a/ui/src/lib/components/connection/ConnectionStatusIndicator.svelte
+++ b/ui/src/lib/components/connection/ConnectionStatusIndicator.svelte
@@ -4,7 +4,7 @@
 	import { getContext, type Snippet } from 'svelte';
 	import { renderingResumedAt } from '$lib/stores/rendering-resumed.svelte';
 	import { wrapPathInSvg } from '$lib/utils/icon';
-	import { shouldShowDisconnectedChip } from './connection-chip';
+	import { connectionChipStatus } from './connection-chip';
 	import { mdiEmoticonPoop } from '@mdi/js';
 	import { Chip, Dialog, DialogButton } from 'konsta/svelte';
 	import { m } from '$lib/paraglide/messages.js';
@@ -26,15 +26,15 @@
 
 {#await $connectionStatus then connectionStatus}
 	{@const localCount = connectionStatus.connectedLocalMailboxCount}
-	{@const isLocal = localCount > 0}
-	{@const showChip = shouldShowDisconnectedChip(
+	{@const status = connectionChipStatus(
 		connectionStatus,
 		renderingResumedAt.value,
 	)}
-	{#if showChip}
+	{@const isLocal = status === 'local'}
+	{#if status !== null}
 		<Chip
 			data-testid="connection-status"
-			data-status={isLocal ? 'local' : 'disconnected'}
+			data-status={status}
 			class="p-1 cursor-pointer"
 			colors={{
 				fillBgIos: 'bg-black/10 dark:bg-brand-primary',

--- a/ui/src/lib/components/connection/connection-chip.ts
+++ b/ui/src/lib/components/connection/connection-chip.ts
@@ -7,26 +7,34 @@ import { withinWindow } from '$lib/utils/time';
  * measurement at all and the user would be told nothing, forever. */
 const SETTLING_MS = 10_000;
 
-interface CloudConnection {
+interface Connection {
 	connectedToCloudMailboxServer: boolean;
 	/** When the cloud mailbox last failed a poll, or null if it never has. */
 	cloudLastFailureAtMs: number | null;
+	connectedLocalMailboxCount: number;
 }
 
-/** Whether to accuse the connection of being down.
+export type ConnectionChipStatus = 'local' | 'disconnected';
+
+/** What the chip reads, or null to leave it off screen.
  *
- * Freshness gates the accusation but not the reassurance: a failure recorded
- * before `resumedAt` happened while the app was away and says nothing about the
- * connection now, whereas erring towards "fine" on a stale success costs the
- * user nothing. Reactive through `withinWindow`, so the settling deadline
- * re-renders the caller when it expires. */
-export function shouldShowDisconnectedChip(
-	connection: CloudConnection,
+ * The chip only has something to say while the cloud is out of reach: that a
+ * local hub is standing in, or that nothing is. A connected hub is a fact and
+ * shows at once. Accusing the connection of being down is gated on freshness:
+ * a failure recorded before `resumedAt` happened while the app was away and
+ * says nothing about the connection now, whereas erring towards "fine" on a
+ * stale success costs the user nothing. Reactive through `withinWindow`, so
+ * the settling deadline re-renders the caller when it expires. */
+export function connectionChipStatus(
+	connection: Connection,
 	resumedAt: number,
-): boolean {
-	if (connection.connectedToCloudMailboxServer) return false;
+): ConnectionChipStatus | null {
+	if (connection.connectedToCloudMailboxServer) return null;
+	if (connection.connectedLocalMailboxCount > 0) return 'local';
 	const failedSinceResume =
 		connection.cloudLastFailureAtMs !== null &&
 		connection.cloudLastFailureAtMs > resumedAt;
-	return failedSinceResume || !withinWindow(resumedAt, SETTLING_MS);
+	return failedSinceResume || !withinWindow(resumedAt, SETTLING_MS)
+		? 'disconnected'
+		: null;
 }


### PR DESCRIPTION
Stacked on #559. Every E2E run on that branch fails `specs/local-hub-discovery.spec.ts` the same way, deterministically (3 tests, all 4 attempts). Two independent causes, one commit each.

## Root cause 1 — a stopped hub is only noticed at age-out

swarm-discovery 0.6.3 has no wire representation for a departure: `DropGuard::drop` just aborts the actor, `remove_all()` makes the announcer fall silent, and the receiver reads neither a goodbye nor a record TTL. So a stopped hub only leaves the browser's view once it ages out: `3τ` of silence (2.1s at the interactive cadence for ≤2 hubs) checked on a ~0.86s sweep, then the app's own unregister. The shared 2s `DISCOVERY_MS` sits below that floor, so `expectNoHub` failed on every run for:

- `drops the hub when it stops and shows it again when it starts`
- `shows the hub again after each of several restarts`

(`drops a hub that was killed without its goodbye` passed only because the previous test aborted before restarting the hub, so its stop was a no-op and its assertion trivially true.)

**Fix:** split the budget. A hub *appearing* keeps 2s — the first query goes out at ~0.7s. A hub *going away* gets its own `DEPARTURE_MS = 4_000`, clearing the age-out worst case (~3.5s) with margin. The stress fuzz runs at most two hubs (`MAX_HUBS = 2`), so one constant serves both it and the spec. Two comments that still described an mDNS goodbye the hub cannot send are corrected.

## Root cause 2 — the chip hid a found hub after a restart

`ConnectionStatusIndicator` rendered nothing until the app had proven the cloud unreachable — a fresh poll failure or the 10s settling window in `shouldShowDisconnectedChip` running out — and `isLocal` was computed *inside* that gate. After `stopApp()`/`startApp()` (a full relaunch on desktop) the 2s window sat entirely inside the settling period, so `shows a hub that started while the app was closed` read a hidden chip for its whole budget regardless of how fast the hub was found.

**Fix:** `connectionChipStatus()` decides the reading in one place: `null` while the cloud is reachable (unchanged — `offline-transition-ux` pins that the chip hides when the cloud returns), `'local'` as soon as a hub is connected, `'disconnected'` only once that verdict is fresh or has settled (the gate, now on the accusation only). A connected hub is a fact, not an accusation; `resume-connection-status` already tolerates `'local'` on return.

One behaviour change worth knowing: on resume with a hub present and stale cloud state, the chip reads `local` until the first successful cloud poll hides it.

## Verified

- `cargo fmt --check`, `cargo check` on the touched crates
- `svelte-check`: 0 errors in the two UI files; `tsc --noEmit` on `e2e-tests`: 0 errors; prettier clean
- fuzz model tests: 17 pass

Not run locally: the E2E suite itself — that's what this PR's CI is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWhLiL1PkrFpG22b2eXJyp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWhLiL1PkrFpG22b2eXJyp)_